### PR TITLE
fix(urltest): probe policy members with bounded concurrency

### DIFF
--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -59,7 +59,6 @@ trojan = [
     "zero-transport/tls",
     "dep:ring",
     "dep:trojan",
-    "trojan/runtime",
     "dep:tokio-rustls",
 ]
 vmess = [
@@ -78,6 +77,7 @@ dns = ["zero-dns/udp"]
 
 [dependencies]
 async-trait = "0.1"
+futures-util = "0.3"
 regex = "1"
 quinn = { version = "0.11", default-features = false, features = ["rustls-ring"], optional = true }
 ring = { version = "0.17", optional = true }
@@ -107,7 +107,6 @@ zero-transport = { path = "../transport" }
 
 [dev-dependencies]
 tempfile.workspace = true
-futures-util = "0.3"
 rcgen = "0.14"
 rustls = { workspace = true }
 serde_json.workspace = true

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -59,6 +59,7 @@ trojan = [
     "zero-transport/tls",
     "dep:ring",
     "dep:trojan",
+    "trojan/runtime",
     "dep:tokio-rustls",
 ]
 vmess = [

--- a/crates/proxy/src/groups/urltest.rs
+++ b/crates/proxy/src/groups/urltest.rs
@@ -125,13 +125,8 @@ impl UrlTestRuntime {
         let mut schedule = interval(Duration::from_secs(interval_seconds));
         schedule.set_missed_tick_behavior(MissedTickBehavior::Skip);
         schedule.tick().await;
-        self.refresh_urltest_group_guarded(
-            group_id,
-            &probe,
-            "startup",
-            probe_running.as_ref(),
-        )
-        .await;
+        self.refresh_urltest_group_guarded(group_id, &probe, "startup", probe_running.as_ref())
+            .await;
         schedule.reset();
 
         loop {

--- a/crates/proxy/src/groups/urltest.rs
+++ b/crates/proxy/src/groups/urltest.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use futures_util::stream::{self, StreamExt};
 use tokio::sync::{watch, Notify};
 use tokio::time::{interval, timeout, MissedTickBehavior};
 use tracing::{debug, info, warn};
@@ -15,6 +16,8 @@ use zero_engine::{
 };
 
 use super::super::logging::log_urltest_group_target_changed;
+
+const MAX_CONCURRENT_URLTEST_PROBES: usize = 8;
 
 #[derive(Clone)]
 pub(crate) struct UrlTestRuntime {
@@ -69,6 +72,7 @@ impl UrlTestRuntime {
             group_tag = %group_tag,
             url = probe.url.as_str(),
             interval_seconds,
+            max_concurrent_probes = MAX_CONCURRENT_URLTEST_PROBES,
             "urltest group started"
         );
 
@@ -130,64 +134,89 @@ impl UrlTestRuntime {
         let mut best: Option<ProbeSuccess> = None;
         let started_at_unix_ms = unix_timestamp_ms();
         let started_at = Instant::now();
-        let mut member_states = Vec::with_capacity(urltest.members().len());
 
-        for member_id in urltest.members() {
-            let member = self
-                .target_tag(*member_id)
-                .unwrap_or_else(|| "<unknown>".to_owned());
-            let effective_chains = self.resolve_target_chains(*member_id);
-            let Some((candidate, _plan)) = self.resolve_target_id(*member_id) else {
-                member_states.push(UrlTestMemberState {
-                    member_id: *member_id,
-                    healthy: false,
-                    latency_ms: None,
-                    last_checked_unix_ms: Some(started_at_unix_ms),
-                    last_error: Some("failed to resolve probe target".to_owned()),
-                    effective_chains,
-                });
-                continue;
-            };
-
-            match self.probe_outbound(candidate, probe).await {
-                Ok(latency_ms) => {
-                    if best
-                        .as_ref()
-                        .map(|current| latency_ms < current.latency_ms)
-                        .unwrap_or(true)
-                    {
-                        best = Some(ProbeSuccess {
-                            outbound_id: *member_id,
-                            latency_ms,
-                        });
-                    }
-
-                    member_states.push(UrlTestMemberState {
-                        member_id: *member_id,
-                        healthy: true,
-                        latency_ms: Some(latency_ms),
-                        last_checked_unix_ms: Some(started_at_unix_ms),
-                        last_error: None,
-                        effective_chains,
-                    });
-                }
-                Err(error) => {
-                    debug!(
-                        group_tag = group_tag,
-                        outbound_tag = member,
-                        error = %error,
-                        "urltest probe failed"
+        // Each member retains its own five-second timeout, but independent
+        // outbound checks no longer run serially. Bounded concurrency keeps a
+        // large urltest group from taking N * timeout seconds without opening
+        // an unbounded burst of sockets.
+        let mut probe_results = stream::iter(urltest.members().iter().copied().enumerate())
+            .map(|(index, member_id)| async move {
+                let member = self
+                    .target_tag(member_id)
+                    .unwrap_or_else(|| "<unknown>".to_owned());
+                let effective_chains = self.resolve_target_chains(member_id);
+                let Some((candidate, _plan)) = self.resolve_target_id(member_id) else {
+                    return (
+                        index,
+                        UrlTestMemberState {
+                            member_id,
+                            healthy: false,
+                            latency_ms: None,
+                            last_checked_unix_ms: Some(started_at_unix_ms),
+                            last_error: Some("failed to resolve probe target".to_owned()),
+                            effective_chains,
+                        },
+                        None,
                     );
-                    member_states.push(UrlTestMemberState {
-                        member_id: *member_id,
-                        healthy: false,
-                        latency_ms: None,
-                        last_checked_unix_ms: Some(started_at_unix_ms),
-                        last_error: Some(error.to_string()),
-                        effective_chains,
-                    });
+                };
+
+                match self.probe_outbound(candidate, probe).await {
+                    Ok(latency_ms) => (
+                        index,
+                        UrlTestMemberState {
+                            member_id,
+                            healthy: true,
+                            latency_ms: Some(latency_ms),
+                            last_checked_unix_ms: Some(started_at_unix_ms),
+                            last_error: None,
+                            effective_chains,
+                        },
+                        Some(ProbeSuccess {
+                            outbound_id: member_id,
+                            latency_ms,
+                        }),
+                    ),
+                    Err(error) => {
+                        debug!(
+                            group_tag = group_tag,
+                            outbound_tag = member,
+                            error = %error,
+                            "urltest probe failed"
+                        );
+                        (
+                            index,
+                            UrlTestMemberState {
+                                member_id,
+                                healthy: false,
+                                latency_ms: None,
+                                last_checked_unix_ms: Some(started_at_unix_ms),
+                                last_error: Some(error.to_string()),
+                                effective_chains,
+                            },
+                            None,
+                        )
+                    }
+                }
+            })
+            .buffer_unordered(MAX_CONCURRENT_URLTEST_PROBES)
+            .collect::<Vec<_>>()
+            .await;
+
+        // Preserve configured member order in snapshots and events even though
+        // the probes complete out of order.
+        probe_results.sort_by_key(|(index, _, _)| *index);
+        let mut member_states = Vec::with_capacity(probe_results.len());
+        for (_, member_state, success) in probe_results {
+            if let Some(success) = success {
+                if best
+                    .as_ref()
+                    .map(|current| success.latency_ms < current.latency_ms)
+                    .unwrap_or(true)
+                {
+                    best = Some(success);
                 }
             }
+            member_states.push(member_state);
         }
 
         let previous = self.urltest_selected_target(group_id);

--- a/crates/proxy/src/groups/urltest.rs
+++ b/crates/proxy/src/groups/urltest.rs
@@ -1,8 +1,11 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+use futures_util::future::{BoxFuture, FutureExt, Shared};
 use futures_util::stream::{self, StreamExt};
-use tokio::sync::{watch, Notify};
+use tokio::sync::{watch, Notify, Semaphore};
 use tokio::time::{interval, timeout, MissedTickBehavior};
 use tracing::{debug, info, warn};
 use zero_core::{Address, Network, ProtocolType, Session};
@@ -19,14 +22,43 @@ use super::super::logging::log_urltest_group_target_changed;
 
 const MAX_CONCURRENT_URLTEST_PROBES: usize = 8;
 
+type SharedProbeFuture = Shared<BoxFuture<'static, Result<u64, String>>>;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ProbeKey {
+    config_identity: usize,
+    target_tag: String,
+    url: String,
+}
+
+fn global_probe_limiter() -> Arc<Semaphore> {
+    static LIMITER: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    LIMITER
+        .get_or_init(|| Arc::new(Semaphore::new(MAX_CONCURRENT_URLTEST_PROBES)))
+        .clone()
+}
+
+fn global_shared_probes() -> Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>> {
+    static PROBES: OnceLock<Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>> = OnceLock::new();
+    PROBES
+        .get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+        .clone()
+}
+
 #[derive(Clone)]
 pub(crate) struct UrlTestRuntime {
     services: TcpRuntimeServices,
+    probe_limiter: Arc<Semaphore>,
+    shared_probes: Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>,
 }
 
 impl UrlTestRuntime {
     pub(crate) fn new(services: TcpRuntimeServices) -> Self {
-        Self { services }
+        Self {
+            services,
+            probe_limiter: global_probe_limiter(),
+            shared_probes: global_shared_probes(),
+        }
     }
 
     pub(crate) fn group_ids(&self) -> Vec<TargetId> {
@@ -35,6 +67,10 @@ impl UrlTestRuntime {
 
     pub(crate) fn clear_probe_triggers(&self) {
         self.services.engine().probe_trigger_registry().clear();
+        self.shared_probes
+            .lock()
+            .expect("shared urltest probe lock poisoned")
+            .clear();
     }
 
     pub(crate) async fn run_urltest_group(
@@ -59,9 +95,18 @@ impl UrlTestRuntime {
         })?;
 
         let probe_notify = Arc::new(Notify::new());
+        let probe_running = Arc::new(AtomicBool::new(false));
         let trigger = ProbeTrigger::new({
             let notify = Arc::clone(&probe_notify);
-            move || notify.notify_one()
+            let running = Arc::clone(&probe_running);
+            move || {
+                // A completion already in progress is a fresh authoritative
+                // result for a concurrent manual click. Do not enqueue another
+                // full cycle behind it and probe every member twice.
+                if !running.load(Ordering::Acquire) {
+                    notify.notify_one();
+                }
+            }
         });
         self.services
             .engine()
@@ -73,14 +118,21 @@ impl UrlTestRuntime {
             url = probe.url.as_str(),
             interval_seconds,
             max_concurrent_probes = MAX_CONCURRENT_URLTEST_PROBES,
+            concurrency_scope = "process",
             "urltest group started"
         );
 
         let mut schedule = interval(Duration::from_secs(interval_seconds));
         schedule.set_missed_tick_behavior(MissedTickBehavior::Skip);
         schedule.tick().await;
-        self.refresh_urltest_group(group_id, &probe, "startup")
-            .await;
+        self.refresh_urltest_group_guarded(
+            group_id,
+            &probe,
+            "startup",
+            probe_running.as_ref(),
+        )
+        .await;
+        schedule.reset();
 
         loop {
             tokio::select! {
@@ -93,10 +145,22 @@ impl UrlTestRuntime {
                 }
                 _ = probe_notify.notified() => {
                     debug!(group_tag = %group_tag, "urltest probe triggered by api");
-                    self.refresh_urltest_group(group_id, &probe, "manual").await;
+                    self.refresh_urltest_group_guarded(
+                        group_id,
+                        &probe,
+                        "manual",
+                        probe_running.as_ref(),
+                    ).await;
+                    schedule.reset();
                 }
                 _ = schedule.tick() => {
-                    self.refresh_urltest_group(group_id, &probe, "scheduled").await;
+                    self.refresh_urltest_group_guarded(
+                        group_id,
+                        &probe,
+                        "scheduled",
+                        probe_running.as_ref(),
+                    ).await;
+                    schedule.reset();
                 }
             }
         }
@@ -107,6 +171,20 @@ impl UrlTestRuntime {
             .remove(&group_tag);
         info!(group_tag = %group_tag, "urltest group stopped");
         Ok(())
+    }
+
+    async fn refresh_urltest_group_guarded(
+        &self,
+        group_id: TargetId,
+        probe: &UrlTestProbe,
+        trigger: &'static str,
+        running: &AtomicBool,
+    ) {
+        if running.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.refresh_urltest_group(group_id, probe, trigger).await;
+        running.store(false, Ordering::Release);
     }
 
     async fn refresh_urltest_group(
@@ -135,32 +213,18 @@ impl UrlTestRuntime {
         let started_at_unix_ms = unix_timestamp_ms();
         let started_at = Instant::now();
 
-        // Each member retains its own five-second timeout, but independent
-        // outbound checks no longer run serially. Bounded concurrency keeps a
-        // large urltest group from taking N * timeout seconds without opening
-        // an unbounded burst of sockets.
+        // Each group can prepare up to eight member futures, while every
+        // UrlTestRuntime instance shares one process-wide semaphore. Multiple
+        // urltest groups and diagnostics.probe_outbound therefore cannot
+        // multiply the real socket concurrency beyond the global limit.
         let mut probe_results = stream::iter(urltest.members().iter().copied().enumerate())
             .map(|(index, member_id)| async move {
                 let member = self
                     .target_tag(member_id)
                     .unwrap_or_else(|| "<unknown>".to_owned());
                 let effective_chains = self.resolve_target_chains(member_id);
-                let Some((candidate, _plan)) = self.resolve_target_id(member_id) else {
-                    return (
-                        index,
-                        UrlTestMemberState {
-                            member_id,
-                            healthy: false,
-                            latency_ms: None,
-                            last_checked_unix_ms: Some(started_at_unix_ms),
-                            last_error: Some("failed to resolve probe target".to_owned()),
-                            effective_chains,
-                        },
-                        None,
-                    );
-                };
 
-                match self.probe_outbound(candidate, probe).await {
+                match self.probe_target_shared(member_id, probe).await {
                     Ok(latency_ms) => (
                         index,
                         UrlTestMemberState {
@@ -190,7 +254,7 @@ impl UrlTestRuntime {
                                 healthy: false,
                                 latency_ms: None,
                                 last_checked_unix_ms: Some(started_at_unix_ms),
-                                last_error: Some(error.to_string()),
+                                last_error: Some(error),
                                 effective_chains,
                             },
                             None,
@@ -321,12 +385,64 @@ impl UrlTestRuntime {
                 tag: target_tag.to_owned(),
             });
         };
-        let Some((candidate, _plan)) = self.resolve_target_id(target_id) else {
-            return Err(EngineError::SelectorGroupNotFound {
-                tag: target_tag.to_owned(),
-            });
+        self.probe_target_shared(target_id, &probe)
+            .await
+            .map_err(|message| EngineError::Io(std::io::Error::other(message)))
+    }
+
+    async fn probe_target_shared(
+        &self,
+        target_id: TargetId,
+        probe: &UrlTestProbe,
+    ) -> Result<u64, String> {
+        let target_tag = self
+            .target_tag(target_id)
+            .ok_or_else(|| "failed to resolve probe target".to_owned())?;
+        let config = self.services.engine().config();
+        let key = ProbeKey {
+            config_identity: Arc::as_ptr(&config) as usize,
+            target_tag,
+            url: probe.url.clone(),
         };
-        self.probe_outbound(candidate, &probe).await
+
+        let shared = {
+            let mut probes = self
+                .shared_probes
+                .lock()
+                .expect("shared urltest probe lock poisoned");
+            if let Some(existing) = probes.get(&key) {
+                existing.clone()
+            } else {
+                let runtime = self.clone();
+                let probe = probe.clone();
+                let future = async move {
+                    let _permit = runtime
+                        .probe_limiter
+                        .clone()
+                        .acquire_owned()
+                        .await
+                        .map_err(|_| "urltest probe limiter closed".to_owned())?;
+                    let Some((candidate, _plan)) = runtime.resolve_target_id(target_id) else {
+                        return Err("failed to resolve probe target".to_owned());
+                    };
+                    runtime
+                        .probe_outbound(candidate, &probe)
+                        .await
+                        .map_err(normalize_probe_error)
+                }
+                .boxed()
+                .shared();
+                probes.insert(key.clone(), future.clone());
+                future
+            }
+        };
+
+        let result = shared.await;
+        self.shared_probes
+            .lock()
+            .expect("shared urltest probe lock poisoned")
+            .remove(&key);
+        result
     }
 
     async fn probe_outbound(
@@ -422,6 +538,14 @@ impl UrlTestRuntime {
     }
 }
 
+fn normalize_probe_error(error: EngineError) -> String {
+    let message = error.to_string();
+    message
+        .strip_prefix("io error: ")
+        .unwrap_or(message.as_str())
+        .to_owned()
+}
+
 fn unix_timestamp_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -436,6 +560,7 @@ struct ProbeSuccess {
     latency_ms: u64,
 }
 
+#[derive(Clone)]
 struct UrlTestProbe {
     url: String,
     host: String,


### PR DESCRIPTION
## What changed

- run independent URLTest member probes concurrently instead of strictly serially
- enforce one process-wide limit of eight real URLTest/outbound probe sockets across all URLTest groups
- include `diagnostics.probe_outbound` in the same process-wide concurrency budget
- coalesce overlapping probes for the same runtime configuration, target tag, and test URL
- suppress duplicate manual full-cycle triggers while the same URLTest group is already probing
- reset the scheduled interval after startup, manual, and scheduled cycles
- preserve configured member order in runtime state and `policy.probe.completed` events
- retain deterministic fastest-member selection, including configuration-order tie behavior

## Updated develop integration

This branch has been rebuilt on the current `develop` runtime model.

- URLTest group planning and target resolution use the immutable `EngineRuntimeSnapshot` held by `TcpRuntimeServices`
- configuration reconciliation aborts and joins the previous URLTest generation before clearing triggers and shared in-flight state
- a newly reconciled generation therefore cannot reuse old-generation URLTest tasks or committed member state
- the final pull-request diff is limited to `crates/proxy/Cargo.toml` and `crates/proxy/src/groups/urltest.rs`

## Root cause

The previous implementation awaited every member in sequence, so one group could take approximately `member_count × 5s`. Separate URLTest groups and direct diagnostic probes could also multiply the number of simultaneous sockets, while overlapping requests for the same target repeated DNS resolution and connection work.

## Expected effect

For a group containing 44 nodes, up to eight real probes run concurrently across the process. Requests that overlap for the same runtime configuration, target, and URL share one in-flight operation. Each group still commits its own ordered member state and emits its own completion event.

## Compatibility

The command and event contracts are unchanged. `policy.probe.completed` continues to contain all members in configuration order and is emitted after the group state is committed.

## Validation

- Version Contract: passed
- formatting and workspace Clippy: passed
- all-feature workspace check and tests: passed
- architecture boundary tests: passed
- Linux musl build and static-link verification: passed
- optional-surface matrix: passed
- representative proxy-feature matrix: passed
