### PR TITLE
ci(release): formalize version evolution and automated publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
     paths-ignore:
       - "**.md"
       - "LICENSE"
@@ -10,7 +10,7 @@ on:
       - "examples/**"
       - "proto/**"
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
     paths-ignore:
       - "**.md"
       - "LICENSE"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,139 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: Target release stage
+        required: true
+        type: choice
+        default: rc
+        options:
+          - dev
+          - alpha
+          - beta
+          - rc
+          - stable
+      bump:
+        description: Base version bump when starting a new cycle
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Create release pull request
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Calculate next version
+        id: version
+        shell: bash
+        env:
+          STAGE: ${{ inputs.stage }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          git fetch origin main --tags --force
+          VERSION=$(./scripts/release.sh --next "$STAGE" --bump "$BUMP")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release/v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Next release version: $VERSION"
+
+      - name: Ensure release branch is new
+        shell: bash
+        env:
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Release branch '$BRANCH' already exists"
+            exit 1
+          fi
+
+      - name: Prepare version contract
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          if [ "$STAGE" = "dev" ]; then
+            ./scripts/release.sh "$VERSION" --start-development
+          else
+            ./scripts/release.sh "$VERSION" --seal-only
+          fi
+          ./scripts/release.sh --check
+
+      - name: Commit release contract
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add Cargo.toml release/breaking-changes.md
+          git commit -m "release: prepare v$VERSION"
+          git push --set-upstream origin "$BRANCH"
+
+      - name: Create draft release pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          STAGE: ${{ inputs.stage }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          cat > /tmp/release-pr.md <<EOF
+          ## Summary
+
+          Prepare Zero Core version \`$VERSION\` from the current \`main\` branch.
+
+          ## Release policy
+
+          - Stage: \`$STAGE\`
+          - Requested bump: \`$BUMP\`
+          - Base branch: \`main\`
+          - Tag creation is deferred until this PR is merged and the Publish Release workflow passes.
+
+          ## Validation
+
+          - Version format and forward-only transition checked by \`scripts/release.sh\`
+          - Cargo workspace version and compatibility ledger sealed together
+          - Pull request CI will revalidate the transition from \`main\`
+          EOF
+
+          gh pr create \
+            --draft \
+            --base main \
+            --head "$BRANCH" \
+            --title "release: prepare v$VERSION" \
+            --body-file /tmp/release-pr.md
+
+      - name: Job summary
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          echo "## Release PR prepared" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch: \`$BRANCH\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Base: \`main\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,98 @@
+name: Publish Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Confirm that the merged main version should be tagged
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Verify main and create tag
+    if: inputs.confirm == true
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Read release version
+        id: version
+        shell: bash
+        run: |
+          git fetch origin main --tags --force
+          VERSION=$(awk '
+            /^\[workspace\.package\][[:space:]]*$/ { in_workspace=1; next }
+            in_workspace && /^\[/ { exit }
+            in_workspace && /^version[[:space:]]*=/ {
+              if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            }
+          ' Cargo.toml)
+          test -n "$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version contract and tag
+        shell: bash
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          ./scripts/release.sh --check
+          ./scripts/release.sh --verify-tag "$TAG"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag '$TAG' already exists on origin"
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Format
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace --all-features
+
+      - name: Create annotated tag
+        shell: bash
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "release: $TAG"
+          git push origin "$TAG"
+
+      - name: Job summary
+        shell: bash
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          echo "## Release tag published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: \`$TAG\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Source: \`main\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Quality gate: format, clippy, and all-feature tests" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,24 +9,25 @@ permissions:
 
 jobs:
   guard:
-    name: Verify tag is on main
+    name: Verify release tag and main ancestry
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch authoritative branch and tags
+        run: git fetch origin main --tags --force
+
+      - name: Validate tag policy
+        run: ./scripts/release.sh --verify-tag "$GITHUB_REF_NAME"
+
       - name: Ensure tag points to main
         run: |
-          if ! git branch -r --contains "$GITHUB_REF" origin/main; then
-            echo "::error::Tag ${GITHUB_REF_NAME} is not on main branch"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} is not contained in main"
             exit 1
           fi
-
-      - name: Verify sealed version contract
-        shell: bash
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          ./scripts/release.sh "$VERSION" --check-release
 
   quality:
     name: Verify release quality
@@ -50,7 +51,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 
-      - name: Test connector delivery and workspace contracts
+      - name: Test workspace contracts
         run: cargo test --workspace --all-features
 
   build:
@@ -61,8 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Keep the existing GNU/glibc artifact and publish a separate,
-          # statically linked musl artifact for older Linux distributions.
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             name: linux-x86_64
@@ -71,8 +70,6 @@ jobs:
             target: x86_64-unknown-linux-musl
             name: linux-x86_64-musl
             ext: tar.gz
-          # Build the Intel macOS artifact on the native Intel runner instead
-          # of cross-targeting from the arm64 `macos-latest` image.
           - os: macos-15-intel
             target: x86_64-apple-darwin
             name: darwin-x86_64
@@ -88,8 +85,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -99,10 +94,7 @@ jobs:
 
       - name: Install musl toolchain
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes musl-tools
+        run: sudo apt-get update && sudo apt-get install --yes musl-tools
 
       - name: Configure LLVM linker (macOS)
         if: runner.os == 'macOS'
@@ -119,24 +111,22 @@ jobs:
       - name: Build release
         run: cargo build --features full,status-api,connector --release --target ${{ matrix.target }}
 
-      - name: Verify musl compatibility artifact
+      - name: Verify musl static linkage
         if: matrix.target == 'x86_64-unknown-linux-musl'
         shell: bash
         run: |
           BINARY="target/${{ matrix.target }}/release/zero"
           file "$BINARY"
           if readelf --program-headers "$BINARY" | grep -q 'INTERP'; then
-            echo "::error::The musl compatibility artifact is dynamically linked"
-            readelf --program-headers "$BINARY" | grep 'INTERP' || true
+            echo "::error::The musl artifact is dynamically linked"
             exit 1
           fi
           if readelf --version-info "$BINARY" 2>/dev/null | grep -q 'GLIBC_'; then
-            echo "::error::The musl compatibility artifact still requires glibc"
-            readelf --version-info "$BINARY" | grep 'GLIBC_' || true
+            echo "::error::The musl artifact requires glibc"
             exit 1
           fi
 
-      - name: Package (unix)
+      - name: Package Unix artifact
         if: runner.os != 'Windows'
         shell: bash
         run: |
@@ -145,23 +135,24 @@ jobs:
           tar czf "$ARCHIVE" zero
           sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
 
-      - name: Package (windows)
+      - name: Package Windows artifact
         if: runner.os == 'Windows'
         shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          7z a zero-${{ matrix.name }}.${{ matrix.ext }} zero.exe
-          sha256sum zero-${{ matrix.name }}.${{ matrix.ext }} \
-            > zero-${{ matrix.name }}.${{ matrix.ext }}.sha256
+          ARCHIVE="zero-${{ matrix.name }}.${{ matrix.ext }}"
+          7z a "$ARCHIVE" zero.exe
+          sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: zero-${{ matrix.name }}
           path: target/${{ matrix.target }}/release/zero-*.${{ matrix.ext }}*
+          if-no-files-found: error
 
   release:
-    name: Create Release
+    name: Create GitHub release
     runs-on: ubuntu-22.04
     needs: build
     steps:
@@ -174,122 +165,62 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Flatten artifact tree
-        shell: bash
-        run: |
-          # merge-multiple flattens all files into artifacts/ directly
-          ls -la artifacts/
-
-      - name: Generate changelog
+      - name: Generate release notes
         shell: bash
         env:
           CURRENT_TAG: ${{ github.ref_name }}
         run: |
-          # Find the previous stable tag. Only an exact vX.Y.Z tag is stable;
-          # every suffix or other tag shape is a prerelease.
-          PREV_TAG=$(git tag --sort=-version:refname \
-            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          PREVIOUS_TAG=$(git tag --sort=-version:refname \
+            | grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(dev|alpha|beta|rc)\.[1-9][0-9]*)?$' \
             | grep -vFx "$CURRENT_TAG" \
             | head -n 1 || true)
-          if [ -z "$PREV_TAG" ]; then
-            RANGE="$CURRENT_TAG"
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            RANGE="$PREVIOUS_TAG..$CURRENT_TAG"
           else
-            RANGE="${PREV_TAG}..${CURRENT_TAG}"
+            RANGE="$CURRENT_TAG"
           fi
-          echo "Changelog range: $RANGE"
-
-          # Extract commit log once; exclude merge commits and release commits
-          # (both "release:" and "release vX.Y.Z" forms).
-          COMMITS=$(git log "$RANGE" --no-merges --format="%s" 2>/dev/null | grep -ivE '^release([: ]|$)' || true)
-
-          # ── Helpers ────────────────────────────────────────────────
-
-          # Extract and format commits matching a prefix regex.
-          # $1 = pipe-separated prefixes (e.g. "improve|refactor|perf")
-          # Patterns accept an optional conventional-commit scope, e.g.
-          # "fix(ipc):" / "docs(vless):", not just "fix:".
-          extract() {
-            local result
-            result=$(echo "$COMMITS" | grep -iE "^(${1})(\([^)]*\))?:" 2>/dev/null || true)
-            if [ -n "$result" ]; then
-              echo "$result" | while IFS= read -r raw; do
-                # Strip the prefix label (e.g. "feat: " / "fix(ipc): ")
-                local body="${raw#*: }"
-                echo "- ${body}"
-              done
-            fi
-          }
-
-          # Count commits matching a prefix regex
-          count() {
-            local n
-            n=$(echo "$COMMITS" | grep -ciE "^(${1})(\([^)]*\))?:" 2>/dev/null || true)
-            echo "${n:-0}"
-          }
-
-          # Emit a section if there are commits in the category.
-          # $1 = section title (with emoji), $2 = grep pattern
-          section() {
-            local title="$1" pattern="$2" n body
-            n=$(count "$pattern")
-            if [ "$n" -gt 0 ]; then
-              echo "### ${title} (${n})"
-              echo ""
-              extract "$pattern"
-              echo ""
-            fi
-          }
-
-          # ── Build changelog ────────────────────────────────────────
 
           {
-            echo "## 📦 Assets"
+            echo "## Assets"
             echo ""
             echo "| Platform | Archive |"
-            echo "|----------|---------|"
-            echo "| Linux x86_64 (GNU/glibc) | \`zero-linux-x86_64.tar.gz\`      |"
-            echo "| Linux x86_64 (musl, compatible) | \`zero-linux-x86_64-musl.tar.gz\` |"
-            echo "| macOS x86_64             | \`zero-darwin-x86_64.tar.gz\`     |"
-            echo "| macOS aarch64            | \`zero-darwin-aarch64.tar.gz\`    |"
-            echo "| Windows x86_64           | \`zero-windows-x86_64.zip\`       |"
+            echo "|---|---|"
+            echo '| Linux x86_64 (GNU/glibc) | `zero-linux-x86_64.tar.gz` |'
+            echo '| Linux x86_64 (musl) | `zero-linux-x86_64-musl.tar.gz` |'
+            echo '| macOS x86_64 | `zero-darwin-x86_64.tar.gz` |'
+            echo '| macOS aarch64 | `zero-darwin-aarch64.tar.gz` |'
+            echo '| Windows x86_64 | `zero-windows-x86_64.zip` |'
             echo ""
-            echo "> **Quick download (latest):** \`https://github.com/\${{ github.repository }}/releases/latest/download/zero-{platform}.{ext}\`"
+            echo "## Changes"
             echo ""
-            echo "## 📝 Changes"
+            git log "$RANGE" --no-merges --format='- %s' \
+              | grep -ivE '^- release([: ]|$)' || true
             echo ""
-
-            section "🚀 Added"           "feat"
-            section "🐛 Fixed"           "fix"
-            section "🔨 Improved"        "improve|refactor|perf"
-            section "🔧 Maintenance"     "chore|ci|style|test|revert"
-            section "📖 Documentation"   "docs"
-
             echo "---"
-            echo "🤖 auto-generated by GitHub Actions"
-          } > /tmp/changelog.md
+            echo "Generated from $RANGE by GitHub Actions."
+          } > /tmp/release-notes.md
 
-      - name: Classify release tag
-        id: release_kind
+      - name: Classify release
+        id: kind
         shell: bash
         run: |
-          if [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "draft=true" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
             echo "make_latest=false" >> "$GITHUB_OUTPUT"
-            echo "${GITHUB_REF_NAME} is a stable release candidate; creating a draft pending release sign-off"
           else
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
             echo "draft=false" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
             echo "make_latest=false" >> "$GITHUB_OUTPUT"
-            echo "${GITHUB_REF_NAME} is a prerelease"
           fi
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ github.ref_name }}
-          body_path: /tmp/changelog.md
+          body_path: /tmp/release-notes.md
           files: artifacts/*
-          draft: ${{ steps.release_kind.outputs.draft }}
-          prerelease: ${{ steps.release_kind.outputs.prerelease }}
-          make_latest: ${{ steps.release_kind.outputs.make_latest }}
+          draft: ${{ steps.kind.outputs.draft }}
+          prerelease: ${{ steps.kind.outputs.prerelease }}
+          make_latest: ${{ steps.kind.outputs.make_latest }}

--- a/.github/workflows/version-contract.yml
+++ b/.github/workflows/version-contract.yml
@@ -48,7 +48,7 @@ jobs:
           bash -n scripts/test-release-policy.sh
 
       - name: Release policy tests
-        run: ./scripts/test-release-policy.sh
+        run: bash scripts/test-release-policy.sh
 
       - name: Current version contract
         run: ./scripts/release.sh --check

--- a/.github/workflows/version-contract.yml
+++ b/.github/workflows/version-contract.yml
@@ -2,21 +2,31 @@ name: Version Contract
 
 on:
   push:
-    branches: [develop, main]
+    branches: [main, develop]
     paths:
       - "Cargo.toml"
       - "release/breaking-changes.md"
       - "scripts/release.ps1"
       - "scripts/release.sh"
+      - "scripts/test-release-policy.sh"
+      - "docs/project/release-process.md"
+      - "docs/project/tooling.md"
+      - ".github/workflows/prepare-release.yml"
+      - ".github/workflows/publish-release.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/version-contract.yml"
   pull_request:
-    branches: [develop, main]
+    branches: [main, develop]
     paths:
       - "Cargo.toml"
       - "release/breaking-changes.md"
       - "scripts/release.ps1"
       - "scripts/release.sh"
+      - "scripts/test-release-policy.sh"
+      - "docs/project/release-process.md"
+      - "docs/project/tooling.md"
+      - ".github/workflows/prepare-release.yml"
+      - ".github/workflows/publish-release.yml"
       - ".github/workflows/release.yml"
       - ".github/workflows/version-contract.yml"
 
@@ -24,15 +34,32 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: Validate Cargo and compatibility versions
+  policy:
+    name: Validate release policy
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Bash contract
+      - name: Bash syntax
+        run: |
+          bash -n scripts/release.sh
+          bash -n scripts/test-release-policy.sh
+
+      - name: Release policy tests
+        run: ./scripts/test-release-policy.sh
+
+      - name: Current version contract
         run: ./scripts/release.sh --check
 
-      - name: PowerShell contract
+      - name: Pull request version transition
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/release.sh --check-transition "$BASE_SHA" "$HEAD_SHA"
+
+      - name: PowerShell wrapper contract
         shell: pwsh
         run: ./scripts/release.ps1 -Check

--- a/docs/project/release-process.md
+++ b/docs/project/release-process.md
@@ -1,0 +1,290 @@
+# 版本演化与发布流程
+
+本文定义 Zero Core 仓库的内部版本演化、发布审批、标签创建和制品生成规则。
+
+该流程属于 Core 项目的工程治理规范，不是对外 API、配置或产品使用文档，因此不需要同步到 `zerodenet/docs` 仓库。对外文档只在公开接口、配置、协议能力或用户可见行为发生变化时更新。
+
+## 基本原则
+
+1. `main` 是当前唯一权威发布分支。
+2. 标签是所有版本与质量检查通过后的结果，不是发布检查的起点。
+3. 版本号由发布工具根据当前版本和目标阶段计算，日常发布不手工拼写版本号。
+4. 版本只能向前演进，不能回退基础版本、阶段或阶段编号。
+5. `Cargo.toml`、兼容性台账、Git 标签和 GitHub Release 必须表示同一个版本。
+6. 已推送的公开标签不可移动、覆盖或复用。
+7. 正式版本必须经过同一基础版本的 RC 阶段。
+
+## 当前分支模型
+
+当前 `develop` 落后于 `main`，因此在完成同步前：
+
+- Release PR 必须以 `main` 为基线并合并回 `main`；
+- `develop` 不得作为标签或发布制品的来源；
+- 发布标签必须指向 `main` 已包含的提交；
+- `develop` 后续同步时应以 `main` 为事实来源，不能反向覆盖已经发布的版本状态。
+
+未来如果重新启用稳定的双分支模型，必须先修改本规范、发布脚本和工作流，并在同一个 PR 中完成验证。
+
+## 版本格式
+
+只允许以下形式：
+
+```text
+X.Y.Z-dev.N
+X.Y.Z-alpha.N
+X.Y.Z-beta.N
+X.Y.Z-rc.N
+X.Y.Z
+```
+
+其中：
+
+- `X`、`Y`、`Z` 为没有前导零的非负整数；
+- `N` 为从 `1` 开始、没有前导零的正整数；
+- 正式版本没有后缀；
+- 标签始终在版本前增加 `v`，例如 `v0.0.16-rc.1`。
+
+以下形式无效：
+
+```text
+0.0.16-dev
+0.0.16-rc
+0.0.16-bate.1
+0.0.16-preview.1
+0.0.16-rc.01
+00.0.16
+```
+
+历史上已经存在的非标准标签只作为历史事实保留，不得作为新版本格式继续使用。
+
+## 版本状态机
+
+阶段顺序固定为：
+
+```text
+dev < alpha < beta < rc < stable
+```
+
+允许在不回退的前提下跳过中间预发布阶段，例如：
+
+```text
+0.0.16-dev.3 -> 0.0.16-rc.1
+```
+
+### 同一阶段
+
+同一阶段的编号默认必须连续：
+
+```text
+0.0.16-rc.1 -> 0.0.16-rc.2
+```
+
+以下变化会被拒绝：
+
+```text
+0.0.16-rc.1 -> 0.0.16-rc.3
+0.0.16-dev.2 -> 0.0.16-dev.1
+```
+
+`--allow-gap` 只用于管理员处理明确的历史缺口，不得用于普通发布。
+
+### 切换阶段
+
+进入新阶段时编号必须从 `.1` 开始：
+
+```text
+0.0.16-dev.5 -> 0.0.16-beta.1
+0.0.16-beta.3 -> 0.0.16-rc.1
+```
+
+以下变化会被拒绝：
+
+```text
+0.0.16-dev.5 -> 0.0.16-rc.6
+0.0.16-rc.2 -> 0.0.16-beta.3
+```
+
+### 正式版本
+
+正式版本只能从同一基础版本的 RC 演进：
+
+```text
+0.0.16-rc.2 -> 0.0.16
+```
+
+不能从 `dev`、`alpha` 或 `beta` 直接发布正式版本，也不能在正式版本发布后继续创建同一基础版本的预发布标签。
+
+### 新开发周期
+
+正式版本之后，新基础版本必须增大，并从预发布阶段的 `.1` 开始：
+
+```text
+0.0.15 -> 0.0.16-dev.1
+0.0.15 -> 0.1.0-alpha.1
+0.0.15 -> 1.0.0-rc.1
+```
+
+新基础版本不能直接发布为正式版本。
+
+## 权威文件
+
+发布流程涉及三个不同职责：
+
+| 文件 | 职责 |
+|---|---|
+| `Cargo.toml` | 当前构建身份 |
+| `release/breaking-changes.md` | 已封板版本的兼容性与迁移记录 |
+| `docs/project/release-process.md` | 版本如何演化和发布 |
+
+`release/breaking-changes.md` 不记录工作流操作说明；本文件也不重复每个版本的消费者迁移内容。
+
+## 本地命令
+
+检查当前 Cargo 与兼容性台账：
+
+```bash
+./scripts/release.sh --check
+```
+
+计算下一个版本：
+
+```bash
+./scripts/release.sh --next dev --bump patch
+./scripts/release.sh --next rc
+./scripts/release.sh --next stable
+```
+
+检查两个 Git ref 的版本变化：
+
+```bash
+./scripts/release.sh --check-transition origin/main HEAD
+```
+
+验证标签、Cargo 版本、兼容性台账和 `main` 归属：
+
+```bash
+./scripts/release.sh --verify-tag v0.0.16-rc.1
+```
+
+只预览封板差异：
+
+```bash
+./scripts/release.sh 0.0.16-rc.1 --seal-only --dry-run
+```
+
+Windows 使用 `scripts/release.ps1`。PowerShell 文件只负责参数转发，实际规则统一由 `scripts/release.sh` 执行，避免两套状态机产生差异。
+
+## 标准发布流程
+
+### 1. 准备 Release PR
+
+在 GitHub Actions 中运行 `Prepare Release`：
+
+1. 选择目标阶段：`dev`、`alpha`、`beta`、`rc` 或 `stable`；
+2. 只有开启新基础版本时，`bump` 才决定使用 `patch`、`minor` 或 `major`；
+3. 工作流从当前 `main` 读取版本并计算唯一的下一版本；
+4. 工作流同步修改 `Cargo.toml` 和兼容性台账；
+5. 工作流创建 `release/v<version>` 分支；
+6. 工作流创建目标为 `main` 的 Draft PR。
+
+此时不会创建标签。
+
+### 2. Release PR 校验
+
+Release PR 至少经过：
+
+- 发布脚本语法检查；
+- 版本状态机测试；
+- 当前版本契约检查；
+- PR 基线版本到目标版本的变化检查；
+- PowerShell 包装入口检查；
+- 仓库原有格式、Clippy、测试和构建检查。
+
+版本未变化的普通代码 PR 可以通过版本转换检查；一旦修改版本，就必须满足状态机。
+
+### 3. 合并到 main
+
+Release PR 通过检查后合并到 `main`。
+
+合并只表示版本契约已经准备完成，不表示标签和制品已经发布。
+
+### 4. 创建标签
+
+在 GitHub Actions 中运行 `Publish Release Tag` 并明确确认：
+
+1. 工作流重新从 `main` 读取版本；
+2. 验证版本格式、历史演进、Cargo 与台账一致性；
+3. 验证远端不存在同名标签；
+4. 重新运行格式、Clippy 和全 feature 测试；
+5. 所有检查通过后创建 annotated tag；
+6. 标签推送触发 `Release` 工作流。
+
+标签不能从本地开发分支直接推送作为标准发布方式。
+
+### 5. 构建 GitHub Release
+
+`Release` 工作流再次验证：
+
+- 标签符合严格格式；
+- 标签版本等于 Cargo 版本；
+- 兼容性台账已经封板；
+- 标签提交属于 `main`；
+- 发布质量检查通过。
+
+随后生成 Linux GNU、Linux musl、macOS Intel、macOS Apple Silicon 和 Windows 制品以及 SHA-256 校验文件。
+
+预发布版本创建 GitHub prerelease。正式版本创建 Draft Release，人工检查制品和发布说明后再公开并标记为 latest。
+
+## 兼容性台账规则
+
+- `Unreleased` 始终保留一个矩阵行和一个章节；
+- `dev.N` 版本不进入已发布兼容性台账；
+- `alpha.N`、`beta.N`、`rc.N` 和正式版本在封板时生成对应矩阵行与章节；
+- 没有兼容性变化的版本仍要明确记录 `No compatibility changes`；
+- 同一版本不得重复出现；
+- 台账不能被用来证明一个从未创建标签的版本已经公开发布。
+
+## 发布失败处理
+
+### Release PR 失败
+
+修复 Release PR 分支并重新运行检查。失败的 PR 不创建标签，因此不会污染发布历史。
+
+### 标签发布前质量检查失败
+
+修复代码并重新走 Release PR。不得绕过检查手工创建标签。
+
+### 标签已经创建但制品失败
+
+公开标签不得移动或覆盖。应修复构建流程，并在确认源提交没有变化的前提下重新运行对应 workflow；如果源代码必须变化，则创建下一个合法版本。
+
+### GitHub Release 为 Draft
+
+Draft 可以补充说明或重新上传同一标签对应的制品，但不能改变标签指向。正式发布前必须确认所有平台制品及校验文件完整。
+
+## 紧急修复
+
+紧急修复仍遵守状态机：
+
+1. 从当前 `main` 开启下一个 patch 基础版本；
+2. 至少发布一个 `rc.1`；
+3. 验证后发布正式 patch；
+4. 将修复同步到后续开发线。
+
+紧急程度不是跳过版本审计、RC 或质量门禁的理由。
+
+## 修改本流程
+
+修改版本格式、状态转换、分支来源、标签时机或制品分类时，必须在同一个 PR 中同步检查：
+
+- `scripts/release.sh`；
+- `scripts/release.ps1`；
+- `scripts/test-release-policy.sh`；
+- `.github/workflows/version-contract.yml`；
+- `.github/workflows/prepare-release.yml`；
+- `.github/workflows/publish-release.yml`；
+- `.github/workflows/release.yml`；
+- `docs/project/release-process.md`；
+- `docs/project/tooling.md`。
+
+发布机制属于 Core 仓库内部工程规范，除非同时改变了公开契约，否则不要求更新外部文档仓库。

--- a/docs/project/tooling.md
+++ b/docs/project/tooling.md
@@ -38,63 +38,85 @@ cargo test <test_name>
 
 修改协议行为、配置解析、路由、运行时接线或日志后，应运行完整测试集。
 
-公开文档站由 `zerodenet/docs` 仓库独立构建和部署。本仓库只维护工程资料；
-公开文档变更应提交到该仓库并运行其 `pnpm check:build`。
+公开文档站由 `zerodenet/docs` 仓库独立构建和部署。本仓库只维护工程资料；公开文档变更应提交到该仓库并运行其 `pnpm check:build`。
 
-## 版本契约与封板
+## 版本与发布
 
-开发构建号、待发布兼容性记录和正式发布版本由现有 `scripts/release.ps1` 与 `scripts/release.sh` 管理。不要手工把 `-dev` 版本写进 `breaking-changes.md`，也不要在发布 workflow 中临时覆盖 Cargo 版本。两套脚本提供相同语义，不需要额外安装 Python、Node 或其他版本工具。
+完整的版本格式、状态转换、分支来源、Release PR、标签创建和失败处理规则见[版本演化与发布流程](./release-process.md)。该流程属于 Core 仓库内部工程规范，不需要同步到外部文档仓库。
 
-开发期间，已实现但尚未封板的语义变化登记在 `Unreleased`：
+当前 `main` 是唯一权威发布来源。`develop` 完成与 `main` 的同步前，不得作为标签或发布制品来源。
 
-```powershell
-./scripts/release.ps1 -Check
-```
+发布规则统一实现在 `scripts/release.sh`。`scripts/release.ps1` 只负责将 Windows 参数转发到 Git for Windows Bash，避免维护两套不同的状态机。
 
-Linux/macOS 使用 `./scripts/release.sh --check`。正式版本测试完成后，可先只读预览封板差异：
-
-`Unreleased` 没有兼容性变化时也允许发布。脚本仍会生成对应版本的矩阵行和章节，
-明确记录该版本没有需要消费者迁移的语义变化；空台账不是跳过 Cargo、tag 或版本一致性校验。
-
-```powershell
-./scripts/release.ps1 -Version 0.0.16 -DryRun
-```
-
-实际发布仍通过现有 wrapper 完成。wrapper 会调用版本契约脚本，同时更新 `Cargo.toml` 和兼容性文档，然后提交、打 tag，并按参数决定是否推送：
-
-```powershell
-./scripts/release.ps1 -Version 0.0.16 -NoPush
-```
+检查当前版本契约：
 
 ```bash
-./scripts/release.sh 0.0.16 --no-push
+./scripts/release.sh --check
 ```
 
-发布后开启下一个开发周期时使用：
+计算下一版本：
 
-```powershell
-./scripts/release.ps1 -Version 0.0.17-dev -StartDevelopment
+```bash
+./scripts/release.sh --next dev --bump patch
+./scripts/release.sh --next rc
+./scripts/release.sh --next stable
 ```
 
-Linux/macOS 对应命令为 `./scripts/release.sh 0.0.17-dev --start-development`。
+检查 PR 的版本变化：
+
+```bash
+./scripts/release.sh --check-transition origin/main HEAD
+```
+
+验证标签：
+
+```bash
+./scripts/release.sh --verify-tag v0.0.16-rc.1
+```
+
+预览候选版本封板：
+
+```bash
+./scripts/release.sh 0.0.16-rc.1 --seal-only --dry-run
+```
+
+日常发布不应直接使用本地脚本提交和推送标签。标准入口是：
+
+1. GitHub Actions `Prepare Release` 计算版本并创建目标为 `main` 的 Draft PR；
+2. PR 通过版本契约和仓库质量检查后合并；
+3. GitHub Actions `Publish Release Tag` 从已合并的 `main` 重新验证并创建标签；
+4. 标签触发 `Release` workflow 构建制品和 GitHub Release。
 
 命令语义：
 
 | 命令 | 是否写文件 | 作用 |
-|------|------------|------|
-| `-Check` / `--check` | 否 | 根据 Cargo 当前是 `-dev` 或正式版本，检查文档状态 |
-| `-StartDevelopment` / `--start-development` | 是 | 设置开发构建身份，保留新的 `Unreleased` 区域 |
-| 普通 release 命令 | 是 | 将 `Unreleased` 封板为正式版本、更新 Cargo、提交并打 tag |
-| `-CheckRelease` / `--check-release` | 否 | 校验 Cargo、兼容矩阵和版本章节与 tag 一致 |
+|---|---:|---|
+| `--check` | 否 | 检查 Cargo 与兼容性台账当前状态 |
+| `--next <stage>` | 否 | 根据当前版本计算唯一的下一版本 |
+| `--check-transition <base> <head>` | 否 | 检查两个 Git ref 的版本是否向前演进 |
+| `--verify-tag <tag>` | 否 | 检查标签格式、版本、台账、历史和 `main` 归属 |
+| `--start-development` | 是 | 开启严格的 `X.Y.Z-dev.N` 开发版本 |
+| `--seal-only` | 是 | 更新 Cargo 并将 `Unreleased` 封板到候选或正式版本 |
+| 普通 release 命令 | 是 | 兼容的本地发布入口；标准流程不使用它直接推送标签 |
 
-独立 CI workflow 会在 Cargo、兼容台账、发布脚本或 workflow 变化时分别执行 Bash 和 PowerShell 契约检查；tag release 还会再次执行 `check-release`。
+版本格式只允许：
+
+```text
+X.Y.Z-dev.N
+X.Y.Z-alpha.N
+X.Y.Z-beta.N
+X.Y.Z-rc.N
+X.Y.Z
+```
+
+阶段固定按 `dev < alpha < beta < rc < stable` 向前演进。阶段编号默认连续，新阶段必须从 `.1` 开始，正式版本必须由同一基础版本的 RC 演进。
 
 ## 根 package 的 feature
 
 根 package `zero` 是对外构建入口，它把协议和控制面 feature 转发到内部 crate。
 
 | Feature | 说明 |
-|---------|------|
+|---|---|
 | `default` | 等同于 `full,status-api` |
 | `full` | 启用全部协议能力和 `dns` |
 | `dns` | DNS 子系统 |
@@ -137,6 +159,7 @@ Linux/macOS 对应命令为 `./scripts/release.sh 0.0.17-dev --start-development
 - 协议能力变化时，同步更新协议详情、能力矩阵和限制说明。
 - 控制面请求、响应或事件变化时，在 `zerodenet/docs` 仓库同步更新公开控制面文档和 GUI 指南。
 - 运行时分层变化时，同步更新 `docs/project/`。
+- 版本和发布治理变化时，同步更新 `docs/project/release-process.md`，不需要同步外部文档仓库。
 - `https://docs.zerodenet.org/projects/core/control-plane/` 描述当前外部契约；`control-plane/` 仅保存历史设计背景，不作为实现依据。
 - 文档只描述当前事实，避免使用“从某版本开始”“截至目前”等版本历史措辞。
 - Rust 标识符、配置字段、协议名称和标准术语可以保留英文；普通叙述和章节标题统一使用中文。

--- a/release/breaking-changes.md
+++ b/release/breaking-changes.md
@@ -27,7 +27,6 @@
 |------|--------|----------|
 | `Unreleased` | - | No pending compatibility changes <!-- version-contract:unreleased-row --> |
 | `0.0.15` | - | No pending compatibility changes |
-| `0.0.16` | - | No pending compatibility changes |
 | `0.0.15-rc.4` | - | No pending compatibility changes |
 | `0.0.15-rc.3` | Diagnostics API 消费者、Connector 运维与事件 Sink | `diagnostics.trace_route` 改为执行真实会话路由追踪；Connector 对事实事件施加有界内存与可选 outbox 背压，采样事件改为仅 best-effort 且不持久化；默认重试次数由 3 调整为 10 |
 | `0.0.15-rc.2` | 构建脚本、事件消费者、Webhook 接收端 | 公开 Cargo feature 改用 kebab-case；引擎生成的 `event_id` 增加每次启动唯一的随机 epoch；开发期固定中心 API 被撤销，Connector 收缩为通用 Webhook 事件投递；认证项速率改为 Zero 主体策略聚合 |
@@ -39,10 +38,6 @@
 <!-- Record implemented but unsealed compatibility changes here. -->
 
 ## 0.0.15
-
-<!-- No compatibility changes in this release. -->
-
-## 0.0.16
 
 <!-- No compatibility changes in this release. -->
 
@@ -186,4 +181,4 @@ IPC、HTTP SSE 和 gRPC 的 wire 格式保持 `zero.api.v1` / `zero.event.v1`，
 - GUI/SDK/面板的明确迁移步骤；
 - 对应回归测试位置。
 
-开发期间只在版本矩阵和 `## Unreleased` 下登记，不预判最终发布版本，也不写入 Cargo 的 `-dev` 构建号。完整测试通过后，由 `scripts/release.ps1` 或 `scripts/release.sh` 将矩阵行、章节标题和 workspace 版本一起封板；禁止手工分别修改这些位置。
+开发期间只在版本矩阵和 `## Unreleased` 下登记，不预判最终发布版本，也不写入 Cargo 的 `-dev.N` 构建号。完整测试通过后，由 `Prepare Release` 工作流或 `scripts/release.sh` 将矩阵行、章节标题和 workspace 版本一起封板；禁止手工分别修改这些位置。

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -1,19 +1,13 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Manage the Zero version contract and publish a sealed release.
+    PowerShell wrapper for the canonical Bash release policy.
 
 .DESCRIPTION
-    During development, compatibility changes remain under Unreleased. A
-    normal release moves that entry to the requested version, updates the
-    workspace package version, commits both files, creates an annotated tag,
-    and pushes the branch and tag to every configured remote.
-
-.EXAMPLE
-    ./scripts/release.ps1 -Check
-    ./scripts/release.ps1 -Version 0.0.16 -DryRun
-    ./scripts/release.ps1 -Version 0.0.16 -NoPush
-    ./scripts/release.ps1 -Version 0.0.17-dev -StartDevelopment
+    The release state machine is implemented once in scripts/release.sh.
+    This wrapper preserves the Windows command surface and forwards every
+    operation to Git for Windows Bash, preventing the Bash and PowerShell
+    implementations from drifting apart.
 #>
 
 param(
@@ -26,307 +20,89 @@ param(
     [switch]$Check,
     [switch]$CheckRelease,
     [switch]$StartDevelopment,
-
-    [Parameter(DontShow = $true)]
-    [switch]$SealOnly
+    [switch]$SealOnly,
+    [switch]$AllowGap,
+    [string]$Remote = "origin",
+    [string]$Next,
+    [ValidateSet("patch", "minor", "major")]
+    [string]$Bump = "patch",
+    [string]$CheckTransition,
+    [string]$HeadRef = "HEAD",
+    [string]$VerifyTag
 )
 
 $ErrorActionPreference = "Stop"
-$repoRoot = if ($env:ZERO_REPO_ROOT) { $env:ZERO_REPO_ROOT } else { Join-Path $PSScriptRoot ".." }
-Set-Location $repoRoot
-
-$cargoTomlPath = "Cargo.toml"
-$breakingChangesPath = "release/breaking-changes.md"
-$rowMarker = "<!-- version-contract:unreleased-row -->"
-$emptyRow = "| ``Unreleased`` | - | No pending compatibility changes $rowMarker |"
-$emptyBodyComment = "<!-- Record implemented but unsealed compatibility changes here. -->"
-$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-
-function Read-Utf8([string]$Path) {
-    return [System.IO.File]::ReadAllText((Join-Path (Get-Location) $Path), [System.Text.Encoding]::UTF8)
-}
-
-function Write-Utf8([string]$Path, [string]$Content) {
-    [System.IO.File]::WriteAllText((Join-Path (Get-Location) $Path), $Content, $utf8NoBom)
-}
-
-function Assert-Version([string]$Value, [bool]$Development) {
-    if ($Value -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$') {
-        throw "Invalid version '$Value'; expected X.Y.Z or X.Y.Z-suffix."
-    }
-    $isDevelopment = $Value.EndsWith("-dev", [System.StringComparison]::Ordinal)
-    if ($Development -and -not $isDevelopment) {
-        throw "Development version must end with '-dev'."
-    }
-    if (-not $Development -and $isDevelopment) {
-        throw "Release version must not end with '-dev'."
-    }
-}
-
-function Get-WorkspaceVersion([string]$CargoContent) {
-    $section = [regex]::Match($CargoContent, '(?ms)^\[workspace\.package\]\s*\r?\n(?<body>.*?)(?=^\[|\z)')
-    if (-not $section.Success) {
-        throw "Cargo.toml has no [workspace.package] section."
-    }
-    $match = [regex]::Match($section.Groups['body'].Value, '(?m)^version\s*=\s*"(?<version>[^"]+)"')
-    if (-not $match.Success) {
-        throw "[workspace.package] has no version field."
-    }
-    return $match.Groups['version'].Value
-}
-
-function Set-WorkspaceVersion([string]$CargoContent, [string]$Value) {
-    $pattern = '(?ms)(^\[workspace\.package\]\s*\r?\n.*?^version\s*=\s*")[^"]+(".*?$)'
-    $match = [regex]::Match($CargoContent, $pattern)
-    if (-not $match.Success) {
-        throw "Failed to locate workspace package version."
-    }
-    return $CargoContent.Substring(0, $match.Index) +
-        $match.Groups[1].Value + $Value + $match.Groups[2].Value +
-        $CargoContent.Substring($match.Index + $match.Length)
-}
-
-function Get-UnreleasedRow([string]$BreakingContent) {
-    $pattern = '(?m)^\| `Unreleased` \|[^\r\n]*' + [regex]::Escape($rowMarker) + '[^\r\n]*\r?$'
-    $matches = [regex]::Matches($BreakingContent, $pattern)
-    if ($matches.Count -ne 1) {
-        throw "Compatibility matrix must contain exactly one marked Unreleased row."
-    }
-    return $matches[0].Value.TrimEnd("`r")
-}
-
-function Get-UnreleasedBody([string]$BreakingContent) {
-    $matches = [regex]::Matches($BreakingContent, '(?ms)^## Unreleased\r?\n(?<body>.*?)(?=^## |\z)')
-    if ($matches.Count -ne 1) {
-        throw "Breaking changes must contain exactly one '## Unreleased' section."
-    }
-    return $matches[0].Groups['body'].Value
-}
-
-function Test-SubstantiveBody([string]$Body) {
-    return ([regex]::Replace($Body, '<!--.*?-->', '', 'Singleline')).Trim().Length -gt 0
-}
-
-function Assert-DevelopmentContract([string]$CargoContent, [string]$BreakingContent) {
-    $currentVersion = Get-WorkspaceVersion $CargoContent
-    Assert-Version $currentVersion $true
-    [void](Get-UnreleasedRow $BreakingContent)
-    [void](Get-UnreleasedBody $BreakingContent)
-    if ($BreakingContent.IndexOf($currentVersion, [System.StringComparison]::Ordinal) -ge 0) {
-        throw "Development version '$currentVersion' must not be bound into the compatibility ledger."
-    }
-    return $currentVersion
-}
-
-function Assert-UnsealedContract([string]$CargoContent, [string]$BreakingContent) {
-    $currentVersion = Get-WorkspaceVersion $CargoContent
-    if ($currentVersion.EndsWith("-dev", [System.StringComparison]::Ordinal)) {
-        Assert-Version $currentVersion $true
-        if ($BreakingContent.IndexOf($currentVersion, [System.StringComparison]::Ordinal) -ge 0) {
-            throw "Development version '$currentVersion' must not be bound into the compatibility ledger."
-        }
-    }
-    else {
-        Assert-Version $currentVersion $false
-    }
-    [void](Get-UnreleasedRow $BreakingContent)
-    [void](Get-UnreleasedBody $BreakingContent)
-    return $currentVersion
-}
-
-function Assert-ReleaseContract(
-    [string]$CargoContent,
-    [string]$BreakingContent,
-    [string]$ReleaseVersion
-) {
-    Assert-Version $ReleaseVersion $false
-    $currentVersion = Get-WorkspaceVersion $CargoContent
-    if ($currentVersion -ne $ReleaseVersion) {
-        throw "Cargo workspace version '$currentVersion' does not match release '$ReleaseVersion'."
-    }
-    if ((Get-UnreleasedRow $BreakingContent) -ne $emptyRow) {
-        throw "Release requires an empty Unreleased matrix row."
-    }
-    if (Test-SubstantiveBody (Get-UnreleasedBody $BreakingContent)) {
-        throw "Release requires an empty Unreleased section."
-    }
-    if ($BreakingContent -notmatch ('(?m)^## ' + [regex]::Escape($ReleaseVersion) + '\r?$')) {
-        throw "Breaking changes has no release section for '$ReleaseVersion'."
-    }
-    if ($BreakingContent -notmatch ('(?m)^\| `' + [regex]::Escape($ReleaseVersion) + '` \|')) {
-        throw "Compatibility matrix has no release row for '$ReleaseVersion'."
-    }
-}
-
-function Prepare-ReleaseContract(
-    [string]$CargoContent,
-    [string]$BreakingContent,
-    [string]$ReleaseVersion
-) {
-    [void](Assert-UnsealedContract $CargoContent $BreakingContent)
-    Assert-Version $ReleaseVersion $false
-    if ($BreakingContent -match ('(?m)^## ' + [regex]::Escape($ReleaseVersion) + '\r?$')) {
-        throw "Release '$ReleaseVersion' already exists in breaking changes."
-    }
-
-    $newline = if ($BreakingContent.Contains("`r`n")) { "`r`n" } else { "`n" }
-    $unreleasedBody = Get-UnreleasedBody $BreakingContent
-    $releasedBody = if (Test-SubstantiveBody $unreleasedBody) {
-        $unreleasedBody
-    }
-    else {
-        "$newline<!-- No compatibility changes in this release. -->$newline$newline"
-    }
-    $unreleasedRow = Get-UnreleasedRow $BreakingContent
-    $releasedRow = $unreleasedRow.Replace('`Unreleased`', "``$ReleaseVersion``").Replace($rowMarker, '')
-    $releasedRow = [regex]::Replace($releasedRow, '\s+\|$', ' |')
-    $rowPattern = '(?m)^\| `Unreleased` \|[^\r\n]*' + [regex]::Escape($rowMarker) + '[^\r\n]*\r?$'
-    $rowReplacement = $emptyRow + $newline + $releasedRow
-    $nextBreaking = [regex]::Replace(
-        $BreakingContent,
-        $rowPattern,
-        [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $rowReplacement },
-        1
-    )
-    $headingReplacement = "## Unreleased${newline}${newline}${emptyBodyComment}${newline}${newline}## $ReleaseVersion${newline}${releasedBody}"
-    $nextBreaking = [regex]::Replace(
-        $nextBreaking,
-        '(?ms)^## Unreleased\r?\n.*?(?=^## |\z)',
-        [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $headingReplacement },
-        1
-    )
-    $nextCargo = Set-WorkspaceVersion $CargoContent $ReleaseVersion
-    Assert-ReleaseContract $nextCargo $nextBreaking $ReleaseVersion
-    return @($nextCargo, $nextBreaking)
-}
-
-function Assert-CleanTree {
-    $gitStatus = git status --porcelain
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to inspect Git working tree."
-    }
-    if ($gitStatus) {
-        throw "Working tree is not clean. Commit or stash changes before changing versions."
-    }
-}
-
-if (-not (Test-Path $cargoTomlPath) -or -not (Test-Path $breakingChangesPath)) {
-    throw "Cargo.toml or breaking-changes.md was not found in '$repoRoot'."
-}
-
-$cargoContent = Read-Utf8 $cargoTomlPath
-$breakingContent = Read-Utf8 $breakingChangesPath
-
-if ($Check) {
-    $currentVersion = Get-WorkspaceVersion $cargoContent
-    if ($currentVersion.EndsWith("-dev")) {
-        [void](Assert-DevelopmentContract $cargoContent $breakingContent)
-        Write-Host "Development contract is valid ($currentVersion, Unreleased)." -ForegroundColor Green
-    }
-    elseif ((Get-UnreleasedRow $breakingContent) -ne $emptyRow -or
-        (Test-SubstantiveBody (Get-UnreleasedBody $breakingContent))) {
-        [void](Assert-UnsealedContract $cargoContent $breakingContent)
-        Write-Host "Unsealed release contract is valid ($currentVersion, Unreleased)." -ForegroundColor Green
-    }
-    else {
-        Assert-ReleaseContract $cargoContent $breakingContent $currentVersion
-        Write-Host "Release contract is valid ($currentVersion)." -ForegroundColor Green
-    }
-    exit 0
-}
-
-if ($CheckRelease) {
-    if (-not $Version) { throw "-CheckRelease requires -Version." }
-    Assert-ReleaseContract $cargoContent $breakingContent $Version
-    Write-Host "Release contract is valid ($Version)." -ForegroundColor Green
-    exit 0
-}
-
-if ($StartDevelopment) {
-    if (-not $Version) { throw "-StartDevelopment requires -Version X.Y.Z-dev." }
-    Assert-Version $Version $true
-    $currentVersion = Get-WorkspaceVersion $cargoContent
-    if ($currentVersion.EndsWith("-dev")) {
-        [void](Assert-DevelopmentContract $cargoContent $breakingContent)
-    }
-    elseif ((Get-UnreleasedRow $breakingContent) -ne $emptyRow -or
-        (Test-SubstantiveBody (Get-UnreleasedBody $breakingContent))) {
-        [void](Assert-UnsealedContract $cargoContent $breakingContent)
-    }
-    else {
-        Assert-ReleaseContract $cargoContent $breakingContent $currentVersion
-    }
-    $nextCargo = Set-WorkspaceVersion $cargoContent $Version
-    [void](Assert-DevelopmentContract $nextCargo $breakingContent)
-    if ($DryRun) {
-        Write-Host "[DRY RUN] Cargo version: $currentVersion -> $Version" -ForegroundColor Green
-    }
-    else {
-        Assert-CleanTree
-        Write-Utf8 $cargoTomlPath $nextCargo
-        Write-Host "Development contract opened for $Version." -ForegroundColor Green
-    }
-    exit 0
-}
-
-if (-not $Version) {
-    throw "Version is required for a release (for example: -Version 0.0.16)."
-}
-Assert-Version $Version $false
-$prepared = Prepare-ReleaseContract $cargoContent $breakingContent $Version
-
-if ($SealOnly) {
-    if ($DryRun) {
-        Write-Host "[DRY RUN] Would seal Unreleased and Cargo as $Version." -ForegroundColor Green
-    }
-    else {
-        Write-Utf8 $cargoTomlPath $prepared[0]
-        Write-Utf8 $breakingChangesPath $prepared[1]
-        Write-Host "Release contract sealed for $Version." -ForegroundColor Green
-    }
-    exit 0
-}
-
-Assert-CleanTree
-$tagName = "v$Version"
-$Message = if ($Message) { $Message } else { "release: v$Version" }
-$currentBranch = git rev-parse --abbrev-ref HEAD
-$remotes = (git remote) | ForEach-Object { $_.Trim() } | Where-Object { $_ }
-if (-not $remotes) {
-    throw "No Git remotes are configured."
-}
-
-Write-Host "Current branch: $currentBranch" -ForegroundColor Cyan
-Write-Host "Cargo version: $(Get-WorkspaceVersion $cargoContent) -> $Version" -ForegroundColor Yellow
-Write-Host "Tag: $tagName" -ForegroundColor Yellow
-Write-Host "Remotes: $($remotes -join ', ')" -ForegroundColor Cyan
-
-if ($DryRun) {
-    Write-Host "[DRY RUN] Would seal Cargo and breaking changes, commit, tag $tagName, and push to: $($remotes -join ', ')" -ForegroundColor Green
-    exit 0
-}
-
-$confirm = Read-Host "Proceed with release v$Version? [y/N]"
-if ($confirm -notmatch '^[yY]') {
-    Write-Host "Aborted." -ForegroundColor Red
-    exit 0
-}
-
-Write-Utf8 $cargoTomlPath $prepared[0]
-Write-Utf8 $breakingChangesPath $prepared[1]
-Assert-ReleaseContract (Read-Utf8 $cargoTomlPath) (Read-Utf8 $breakingChangesPath) $Version
-
-git add Cargo.toml release/breaking-changes.md
-git commit -m $Message
-git tag -a $tagName -m $Message
-
-if (-not $NoPush) {
-    foreach ($remote in $remotes) {
-        git push $remote $currentBranch
-        git push $remote $tagName
-        Write-Host "${remote}: pushed ${currentBranch} + ${tagName}" -ForegroundColor Green
-    }
+$repoRoot = if ($env:ZERO_REPO_ROOT) {
+    $env:ZERO_REPO_ROOT
 }
 else {
-    Write-Host "Skipped push (-NoPush). Commit and tag are local only." -ForegroundColor Yellow
+    (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+function Find-Bash {
+    $command = Get-Command bash -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $candidates = @(
+        "$env:ProgramFiles\Git\bin\bash.exe",
+        "$env:ProgramFiles\Git\usr\bin\bash.exe",
+        "${env:ProgramFiles(x86)}\Git\bin\bash.exe"
+    )
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return $candidate
+        }
+    }
+
+    throw "Git Bash was not found. Install Git for Windows or add bash to PATH."
+}
+
+$arguments = [System.Collections.Generic.List[string]]::new()
+
+if ($Check) {
+    $arguments.Add("--check")
+}
+elseif ($CheckTransition) {
+    $arguments.Add("--check-transition")
+    $arguments.Add($CheckTransition)
+    $arguments.Add($HeadRef)
+}
+elseif ($VerifyTag) {
+    $arguments.Add("--verify-tag")
+    $arguments.Add($VerifyTag)
+}
+elseif ($Next) {
+    $arguments.Add("--next")
+    $arguments.Add($Next)
+    $arguments.Add("--bump")
+    $arguments.Add($Bump)
+}
+else {
+    if ($Version) { $arguments.Add($Version) }
+    if ($CheckRelease) { $arguments.Add("--check-release") }
+    if ($StartDevelopment) { $arguments.Add("--start-development") }
+    if ($SealOnly) { $arguments.Add("--seal-only") }
+    if ($DryRun) { $arguments.Add("--dry-run") }
+    if ($NoPush) { $arguments.Add("--no-push") }
+    if ($AllowGap) { $arguments.Add("--allow-gap") }
+    if ($Message) {
+        $arguments.Add("--message")
+        $arguments.Add($Message)
+    }
+    if ($Remote) {
+        $arguments.Add("--remote")
+        $arguments.Add($Remote)
+    }
+}
+
+$bash = Find-Bash
+Push-Location $repoRoot
+try {
+    & $bash "scripts/release.sh" @arguments
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,23 +1,52 @@
 #!/usr/bin/env bash
 #
-# Manage the Zero version contract and publish a sealed release.
+# Manage the Zero version contract and release lifecycle.
 #
-# Usage:
+# Version policy:
+#   X.Y.Z-dev.N -> X.Y.Z-alpha.N -> X.Y.Z-beta.N -> X.Y.Z-rc.N -> X.Y.Z
+#
+# Common commands:
 #   ./scripts/release.sh --check
-#   ./scripts/release.sh 0.0.16 --dry-run
-#   ./scripts/release.sh 0.0.16 --no-push
-#   ./scripts/release.sh 0.0.17-dev --start-development
+#   ./scripts/release.sh --next rc
+#   ./scripts/release.sh --check-transition origin/main HEAD
+#   ./scripts/release.sh --verify-tag v0.0.16-rc.1
+#   ./scripts/release.sh 0.0.16-rc.1 --seal-only
+#   ./scripts/release.sh 0.0.17-dev.1 --start-development
 set -euo pipefail
 
 MODE=release
 DRY_RUN=false
 NO_PUSH=false
 SEAL_ONLY=false
+ALLOW_GAP=false
 MESSAGE=""
 VERSION=""
+BASE_REF=""
+HEAD_REF="HEAD"
+NEXT_STAGE=""
+BUMP="patch"
+REMOTE="origin"
+TAG_NAME=""
 
 usage() {
-    sed -n '2,10p' "$0"
+    cat <<'USAGE'
+Usage:
+  release.sh --check
+  release.sh --next <dev|alpha|beta|rc|stable> [--bump patch|minor|major]
+  release.sh --check-transition <base-ref> [head-ref]
+  release.sh --verify-tag <vX.Y.Z[-stage.N]>
+  release.sh <version> --check-release
+  release.sh <version> --start-development [--dry-run]
+  release.sh <version> --seal-only [--dry-run]
+  release.sh <version> [--dry-run] [--no-push] [--remote origin]
+
+Accepted versions:
+  X.Y.Z-dev.N
+  X.Y.Z-alpha.N
+  X.Y.Z-beta.N
+  X.Y.Z-rc.N
+  X.Y.Z
+USAGE
     exit 1
 }
 
@@ -25,19 +54,53 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --check) MODE=check; shift ;;
         --check-release) MODE=check-release; shift ;;
+        --check-transition)
+            MODE=check-transition
+            [[ $# -ge 2 ]] || usage
+            BASE_REF=$2
+            shift 2
+            if [[ $# -gt 0 && "$1" != -* ]]; then HEAD_REF=$1; shift; fi
+            ;;
+        --verify-tag)
+            MODE=verify-tag
+            [[ $# -ge 2 ]] || usage
+            TAG_NAME=$2
+            shift 2
+            ;;
+        --next)
+            MODE=next
+            [[ $# -ge 2 ]] || usage
+            NEXT_STAGE=$2
+            shift 2
+            ;;
+        --bump)
+            [[ $# -ge 2 ]] || usage
+            BUMP=$2
+            shift 2
+            ;;
         --start-development) MODE=start-development; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         --no-push) NO_PUSH=true; shift ;;
         --seal-only) SEAL_ONLY=true; shift ;;
-        -m) MESSAGE="$2"; shift 2 ;;
+        --allow-gap) ALLOW_GAP=true; shift ;;
+        --remote)
+            [[ $# -ge 2 ]] || usage
+            REMOTE=$2
+            shift 2
+            ;;
+        -m|--message)
+            [[ $# -ge 2 ]] || usage
+            MESSAGE=$2
+            shift 2
+            ;;
         --help|-h) usage ;;
-        -*) echo "Unknown option: $1"; usage ;;
+        -*) echo "Unknown option: $1" >&2; usage ;;
         *)
             if [[ -n "$VERSION" ]]; then
-                echo "Version already set to '$VERSION', unexpected argument: $1"
+                echo "Version already set to '$VERSION', unexpected argument: $1" >&2
                 usage
             fi
-            VERSION="$1"
+            VERSION=$1
             shift
             ;;
     esac
@@ -62,15 +125,123 @@ require_files() {
         fail "Cargo.toml or breaking-changes.md was not found in $(pwd)."
 }
 
-validate_version() {
-    local version=$1 expected=$2
-    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]] || \
-        fail "invalid version '$version'; expected X.Y.Z or X.Y.Z-suffix"
-    if [[ "$expected" == development && "$version" != *-dev ]]; then
-        fail "development version must end with '-dev'"
+V_MAJOR=0
+V_MINOR=0
+V_PATCH=0
+V_STAGE=stable
+V_SEQ=0
+
+parse_version() {
+    local version=$1
+    if [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+        V_MAJOR=${BASH_REMATCH[1]}
+        V_MINOR=${BASH_REMATCH[2]}
+        V_PATCH=${BASH_REMATCH[3]}
+        V_STAGE=stable
+        V_SEQ=0
+        return 0
     fi
-    if [[ "$expected" == release && "$version" == *-dev ]]; then
-        fail "release version must not end with '-dev'"
+    if [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev|alpha|beta|rc)\.([1-9][0-9]*)$ ]]; then
+        V_MAJOR=${BASH_REMATCH[1]}
+        V_MINOR=${BASH_REMATCH[2]}
+        V_PATCH=${BASH_REMATCH[3]}
+        V_STAGE=${BASH_REMATCH[4]}
+        V_SEQ=${BASH_REMATCH[5]}
+        return 0
+    fi
+    return 1
+}
+
+validate_version() {
+    local version=$1 expected=${2:-any}
+    parse_version "$version" || \
+        fail "invalid version '$version'; expected X.Y.Z or X.Y.Z-(dev|alpha|beta|rc).N"
+    case "$expected" in
+        any) ;;
+        development)
+            [[ "$V_STAGE" == dev ]] || fail "development version must use '-dev.N'"
+            ;;
+        release)
+            [[ "$V_STAGE" != dev ]] || fail "release version must not use the dev stage"
+            ;;
+        stable)
+            [[ "$V_STAGE" == stable ]] || fail "stable version must use X.Y.Z without a suffix"
+            ;;
+        *) fail "unknown version expectation '$expected'" ;;
+    esac
+}
+
+stage_rank() {
+    case "$1" in
+        dev) echo 0 ;;
+        alpha) echo 1 ;;
+        beta) echo 2 ;;
+        rc) echo 3 ;;
+        stable) echo 4 ;;
+        *) return 1 ;;
+    esac
+}
+
+version_key() {
+    local version=$1 rank
+    parse_version "$version" || return 1
+    rank=$(stage_rank "$V_STAGE")
+    printf '%010d%010d%010d%02d%010d\n' "$V_MAJOR" "$V_MINOR" "$V_PATCH" "$rank" "$V_SEQ"
+}
+
+compare_versions() {
+    local left=$1 right=$2 left_key right_key
+    left_key=$(version_key "$left") || fail "cannot compare invalid version '$left'"
+    right_key=$(version_key "$right") || fail "cannot compare invalid version '$right'"
+    if [[ "$left_key" < "$right_key" ]]; then echo -1
+    elif [[ "$left_key" > "$right_key" ]]; then echo 1
+    else echo 0
+    fi
+}
+
+same_base() {
+    local left=$1 right=$2 lm lmi lp rm rmi rp
+    parse_version "$left" || return 1
+    lm=$V_MAJOR; lmi=$V_MINOR; lp=$V_PATCH
+    parse_version "$right" || return 1
+    rm=$V_MAJOR; rmi=$V_MINOR; rp=$V_PATCH
+    [[ "$lm" == "$rm" && "$lmi" == "$rmi" && "$lp" == "$rp" ]]
+}
+
+assert_transition() {
+    local from=$1 to=$2 cmp from_stage from_seq from_rank to_stage to_seq to_rank
+    validate_version "$from" any
+    from_stage=$V_STAGE; from_seq=$V_SEQ; from_rank=$(stage_rank "$V_STAGE")
+    validate_version "$to" any
+    to_stage=$V_STAGE; to_seq=$V_SEQ; to_rank=$(stage_rank "$V_STAGE")
+
+    cmp=$(compare_versions "$from" "$to")
+    [[ "$cmp" -lt 0 ]] || fail "version must move forward: $from -> $to"
+
+    if same_base "$from" "$to"; then
+        [[ "$from_stage" != stable ]] || fail "stable version '$from' is immutable"
+        [[ "$to_rank" -ge "$from_rank" ]] || \
+            fail "release stage must not move backward: $from -> $to"
+
+        if [[ "$to_stage" == "$from_stage" ]]; then
+            [[ "$to_stage" != stable ]] || fail "stable version '$to' already exists"
+            if [[ "$ALLOW_GAP" == true ]]; then
+                [[ "$to_seq" -gt "$from_seq" ]] || fail "stage number must increase: $from -> $to"
+            else
+                [[ "$to_seq" -eq $((from_seq + 1)) ]] || \
+                    fail "stage number must be consecutive: expected $((from_seq + 1)), got $to_seq"
+            fi
+        elif [[ "$to_stage" == stable ]]; then
+            [[ "$from_stage" == rc ]] || fail "stable release requires a prior rc version"
+        else
+            [[ "$to_seq" -eq 1 ]] || \
+                fail "a new release stage must start at .1: $from -> $to"
+        fi
+    else
+        [[ "$to_stage" != stable ]] || \
+            fail "a new base version must enter through a prerelease stage before stable"
+        [[ "$to_seq" -eq 1 ]] || \
+            fail "a new base version must start its stage at .1: $from -> $to"
     fi
 }
 
@@ -86,6 +257,50 @@ workspace_version() {
             }
         }
     ' "$path"
+}
+
+workspace_version_at_ref() {
+    local ref=$1 content
+    content=$(git show "${ref}:Cargo.toml" 2>/dev/null) || fail "cannot read Cargo.toml at '$ref'"
+    printf '%s\n' "$content" | awk '
+        /^\[workspace\.package\][[:space:]]*$/ { in_workspace=1; next }
+        in_workspace && /^\[/ { exit }
+        in_workspace && /^version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+            }
+        }
+    '
+}
+
+strict_tag_versions() {
+    git tag --list 'v*' 2>/dev/null | while IFS= read -r tag; do
+        local_version=${tag#v}
+        if parse_version "$local_version"; then
+            printf '%s\n' "$local_version"
+        fi
+    done
+}
+
+latest_strict_version() {
+    local exclude=${1:-} latest="" candidate
+    while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        [[ "$candidate" != "$exclude" ]] || continue
+        if [[ -z "$latest" || "$(compare_versions "$candidate" "$latest")" -gt 0 ]]; then
+            latest=$candidate
+        fi
+    done < <(strict_tag_versions)
+    printf '%s\n' "$latest"
+}
+
+assert_history_transition() {
+    local target=$1 latest
+    latest=$(latest_strict_version "$target")
+    if [[ -n "$latest" && "$latest" != "$target" ]]; then
+        assert_transition "$latest" "$target"
+    fi
 }
 
 unreleased_row() {
@@ -125,8 +340,7 @@ assert_common_contract() {
 }
 
 assert_development_contract() {
-    local cargo=${1:-$CARGO_TOML} breaking=${2:-$BREAKING_CHANGES}
-    local current
+    local cargo=${1:-$CARGO_TOML} breaking=${2:-$BREAKING_CHANGES} current
     current=$(workspace_version "$cargo")
     [[ -n "$current" ]] || fail "workspace package version was not found"
     validate_version "$current" development
@@ -138,25 +352,19 @@ assert_development_contract() {
 }
 
 assert_unsealed_contract() {
-    local cargo=${1:-$CARGO_TOML} breaking=${2:-$BREAKING_CHANGES}
-    local current
+    local cargo=${1:-$CARGO_TOML} breaking=${2:-$BREAKING_CHANGES} current
     current=$(workspace_version "$cargo")
     [[ -n "$current" ]] || fail "workspace package version was not found"
-    if [[ "$current" == *-dev ]]; then
-        validate_version "$current" development
-        if grep -Fq "$current" "$breaking"; then
-            fail "development version '$current' must not be bound into the compatibility ledger"
-        fi
-    else
-        validate_version "$current" release
+    validate_version "$current" any
+    if [[ "$V_STAGE" == dev ]] && grep -Fq "$current" "$breaking"; then
+        fail "development version '$current' must not be bound into the compatibility ledger"
     fi
     assert_common_contract "$breaking"
     echo "$current"
 }
 
 assert_release_contract() {
-    local cargo=$1 breaking=$2 release_version=$3
-    local current row
+    local cargo=$1 breaking=$2 release_version=$3 current row
     validate_version "$release_version" release
     current=$(workspace_version "$cargo")
     [[ "$current" == "$release_version" ]] || \
@@ -229,17 +437,18 @@ render_release_docs() {
 }
 
 prepare_release_contract() {
-    local release_version=$1 dry_run=$2
-    local current cargo_tmp docs_tmp has_changes
+    local release_version=$1 dry_run=$2 current cargo_tmp docs_tmp has_changes
     current=$(assert_unsealed_contract "$CARGO_TOML" "$BREAKING_CHANGES")
     validate_version "$release_version" release
+    assert_history_transition "$release_version"
+    if [[ "$current" != "$release_version" ]]; then
+        assert_transition "$current" "$release_version"
+    fi
     if grep -Eq "^## ${release_version//./\\.}\r?$" "$BREAKING_CHANGES"; then
         fail "release '$release_version' already exists in breaking changes"
     fi
     has_changes=false
-    if unreleased_body "$BREAKING_CHANGES" | body_is_substantive; then
-        has_changes=true
-    fi
+    if unreleased_body "$BREAKING_CHANGES" | body_is_substantive; then has_changes=true; fi
     cargo_tmp=$(mktemp "${CARGO_TOML}.version.XXXXXX")
     docs_tmp=$(mktemp "${BREAKING_CHANGES}.version.XXXXXX")
     trap 'rm -f "${cargo_tmp:-}" "${docs_tmp:-}"' RETURN
@@ -262,14 +471,10 @@ start_development() {
     local version=$1 dry_run=$2 current cargo_tmp
     validate_version "$version" development
     current=$(workspace_version "$CARGO_TOML")
-    if [[ "$current" == *-dev ]]; then
-        assert_development_contract "$CARGO_TOML" "$BREAKING_CHANGES" >/dev/null
-    elif [[ "$(unreleased_row "$BREAKING_CHANGES")" != "$EMPTY_ROW" ]] || \
-        unreleased_body "$BREAKING_CHANGES" | body_is_substantive; then
-        assert_unsealed_contract "$CARGO_TOML" "$BREAKING_CHANGES" >/dev/null
-    else
-        assert_release_contract "$CARGO_TOML" "$BREAKING_CHANGES" "$current"
-    fi
+    validate_version "$current" any
+    assert_common_contract "$BREAKING_CHANGES"
+    assert_history_transition "$version"
+    if [[ "$current" != "$version" ]]; then assert_transition "$current" "$version"; fi
     cargo_tmp=$(mktemp "${CARGO_TOML}.version.XXXXXX")
     trap 'rm -f "${cargo_tmp:-}"' RETURN
     render_cargo_version "$CARGO_TOML" "$cargo_tmp" "$version"
@@ -283,9 +488,71 @@ start_development() {
     echo "Development contract prepared: $current -> $version"
 }
 
+bump_base() {
+    local version=$1 bump=$2
+    parse_version "$version" || fail "cannot bump invalid version '$version'"
+    case "$bump" in
+        patch) printf '%d.%d.%d\n' "$V_MAJOR" "$V_MINOR" $((V_PATCH + 1)) ;;
+        minor) printf '%d.%d.0\n' "$V_MAJOR" $((V_MINOR + 1)) ;;
+        major) printf '%d.0.0\n' $((V_MAJOR + 1)) ;;
+        *) fail "invalid bump '$bump'; expected patch, minor, or major" ;;
+    esac
+}
+
+next_version() {
+    local stage=$1 bump=$2 current current_stage current_seq current_base target_base current_rank target_rank
+    case "$stage" in dev|alpha|beta|rc|stable) ;; *) fail "invalid stage '$stage'" ;; esac
+    current=$(workspace_version "$CARGO_TOML")
+    validate_version "$current" any
+    current_stage=$V_STAGE; current_seq=$V_SEQ
+    current_base="$V_MAJOR.$V_MINOR.$V_PATCH"
+    current_rank=$(stage_rank "$current_stage")
+    target_rank=$(stage_rank "$stage")
+
+    if [[ "$current_stage" == stable ]]; then
+        [[ "$stage" != stable ]] || fail "cannot calculate a new stable version without a prerelease cycle"
+        target_base=$(bump_base "$current" "$bump")
+        printf '%s-%s.1\n' "$target_base" "$stage"
+        return
+    fi
+
+    [[ "$target_rank" -ge "$current_rank" ]] || \
+        fail "release stage must not move backward: $current_stage -> $stage"
+    if [[ "$stage" == "$current_stage" ]]; then
+        printf '%s-%s.%d\n' "$current_base" "$stage" $((current_seq + 1))
+    elif [[ "$stage" == stable ]]; then
+        [[ "$current_stage" == rc ]] || fail "stable release requires a prior rc version"
+        printf '%s\n' "$current_base"
+    else
+        printf '%s-%s.1\n' "$current_base" "$stage"
+    fi
+}
+
 assert_clean_tree() {
     [[ -z "$(git status --porcelain)" ]] || \
         fail "working tree is not clean; commit or stash changes before changing versions"
+}
+
+verify_tag() {
+    local tag=$1 version current branch
+    [[ "$tag" == v* ]] || fail "release tag must start with 'v'"
+    version=${tag#v}
+    validate_version "$version" any
+    current=$(workspace_version "$CARGO_TOML")
+    [[ "$current" == "$version" ]] || fail "tag '$tag' does not match Cargo version '$current'"
+    assert_history_transition "$version"
+    if [[ "$V_STAGE" == dev ]]; then
+        assert_development_contract "$CARGO_TOML" "$BREAKING_CHANGES" >/dev/null
+    else
+        assert_release_contract "$CARGO_TOML" "$BREAKING_CHANGES" "$version"
+    fi
+    if git rev-parse --verify HEAD >/dev/null 2>&1; then
+        branch=$(git branch -r --contains HEAD 2>/dev/null | sed 's/^[ *]*//' || true)
+        if [[ -n "$branch" && "$branch" != *"origin/main"* ]]; then
+            fail "release tags must point to a commit contained in origin/main"
+        fi
+    fi
+    echo "Release tag is valid ($tag)."
 }
 
 require_files
@@ -293,7 +560,8 @@ require_files
 case "$MODE" in
     check)
         current=$(workspace_version "$CARGO_TOML")
-        if [[ "$current" == *-dev ]]; then
+        validate_version "$current" any
+        if [[ "$V_STAGE" == dev ]]; then
             assert_development_contract "$CARGO_TOML" "$BREAKING_CHANGES" >/dev/null
             echo "Development contract is valid ($current, Unreleased)."
         elif [[ "$(unreleased_row "$BREAKING_CHANGES")" != "$EMPTY_ROW" ]] || \
@@ -309,11 +577,35 @@ case "$MODE" in
     check-release)
         [[ -n "$VERSION" ]] || fail "--check-release requires a version"
         assert_release_contract "$CARGO_TOML" "$BREAKING_CHANGES" "$VERSION"
+        assert_history_transition "$VERSION"
         echo "Release contract is valid ($VERSION)."
         exit 0
         ;;
+    check-transition)
+        [[ -n "$BASE_REF" ]] || fail "--check-transition requires a base ref"
+        from=$(workspace_version_at_ref "$BASE_REF")
+        to=$(workspace_version_at_ref "$HEAD_REF")
+        [[ -n "$from" && -n "$to" ]] || fail "workspace version was not found in one of the refs"
+        if [[ "$from" == "$to" ]]; then
+            echo "Version is unchanged ($to)."
+        else
+            assert_transition "$from" "$to"
+            echo "Version transition is valid ($from -> $to)."
+        fi
+        exit 0
+        ;;
+    verify-tag)
+        [[ -n "$TAG_NAME" ]] || fail "--verify-tag requires a tag"
+        verify_tag "$TAG_NAME"
+        exit 0
+        ;;
+    next)
+        [[ -n "$NEXT_STAGE" ]] || fail "--next requires a stage"
+        next_version "$NEXT_STAGE" "$BUMP"
+        exit 0
+        ;;
     start-development)
-        [[ -n "$VERSION" ]] || fail "--start-development requires X.Y.Z-dev"
+        [[ -n "$VERSION" ]] || fail "--start-development requires X.Y.Z-dev.N"
         if [[ "$DRY_RUN" != true ]]; then assert_clean_tree; fi
         start_development "$VERSION" "$DRY_RUN"
         exit 0
@@ -329,8 +621,8 @@ if [[ "$SEAL_ONLY" == true ]]; then
 fi
 
 assert_clean_tree
-mapfile -t REMOTES < <(git remote)
-[[ ${#REMOTES[@]} -gt 0 ]] || fail "no Git remotes are configured"
+[[ -n "$(git remote get-url "$REMOTE" 2>/dev/null || true)" ]] || \
+    fail "Git remote '$REMOTE' is not configured"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_VERSION=$(workspace_version "$CARGO_TOML")
 TAG_NAME="v${VERSION}"
@@ -339,19 +631,16 @@ MESSAGE="${MESSAGE:-release: v${VERSION}}"
 echo "Current branch: $CURRENT_BRANCH"
 echo "Cargo version: $CURRENT_VERSION -> $VERSION"
 echo "Tag: $TAG_NAME"
-echo "Remotes: ${REMOTES[*]}"
+echo "Remote: $REMOTE"
 
 if [[ "$DRY_RUN" == true ]]; then
     prepare_release_contract "$VERSION" true
-    echo "[DRY RUN] Would commit, tag $TAG_NAME, and push to: ${REMOTES[*]}"
+    echo "[DRY RUN] Would commit, tag $TAG_NAME, and push to $REMOTE"
     exit 0
 fi
 
 read -r -p "Proceed with release v${VERSION}? [y/N] " CONFIRM
-if [[ ! "$CONFIRM" =~ ^[yY] ]]; then
-    echo "Aborted."
-    exit 0
-fi
+if [[ ! "$CONFIRM" =~ ^[yY] ]]; then echo "Aborted."; exit 0; fi
 
 prepare_release_contract "$VERSION" false
 git add Cargo.toml release/breaking-changes.md
@@ -359,11 +648,9 @@ git commit -m "$MESSAGE"
 git tag -a "$TAG_NAME" -m "$MESSAGE"
 
 if [[ "$NO_PUSH" != true ]]; then
-    for remote in "${REMOTES[@]}"; do
-        git push "$remote" "$CURRENT_BRANCH"
-        git push "$remote" "$TAG_NAME"
-        echo "${remote}: pushed ${CURRENT_BRANCH} + ${TAG_NAME}"
-    done
+    git push "$REMOTE" "$CURRENT_BRANCH"
+    git push "$REMOTE" "$TAG_NAME"
+    echo "$REMOTE: pushed $CURRENT_BRANCH + $TAG_NAME"
 else
     echo "Skipped push (--no-push). Commit and tag are local only."
 fi

--- a/scripts/test-release-policy.sh
+++ b/scripts/test-release-policy.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_UNDER_TEST=${1:-scripts/release.sh}
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+mkdir -p "$ROOT/release"
+
+cat > "$ROOT/Cargo.toml" <<'TOML'
+[workspace]
+members = []
+
+[workspace.package]
+version = "0.0.15"
+TOML
+
+cat > "$ROOT/release/breaking-changes.md" <<'DOC'
+# Compatibility ledger
+
+| Version | Area | Migration |
+|---|---|---|
+| `Unreleased` | - | No pending compatibility changes <!-- version-contract:unreleased-row --> |
+| `0.0.15` | - | No pending compatibility changes |
+
+## Unreleased
+
+<!-- Record implemented but unsealed compatibility changes here. -->
+
+## 0.0.15
+
+<!-- No compatibility changes in this release. -->
+DOC
+
+run_release() {
+    ZERO_REPO_ROOT="$ROOT" bash "$SCRIPT_UNDER_TEST" "$@"
+}
+
+expect_fail() {
+    if run_release "$@" >/tmp/zero-release-policy.out 2>&1; then
+        echo "Expected failure: $*" >&2
+        cat /tmp/zero-release-policy.out >&2
+        exit 1
+    fi
+}
+
+cd "$ROOT"
+git init -q
+git config user.name "Release Policy Test"
+git config user.email "release-policy@example.invalid"
+git add Cargo.toml release/breaking-changes.md
+git commit -qm "initial"
+git tag -a v0.0.15 -m v0.0.15
+
+[[ "$(run_release --next dev)" == "0.0.16-dev.1" ]]
+[[ "$(run_release --next rc)" == "0.0.16-rc.1" ]]
+expect_fail 0.0.15 --seal-only
+expect_fail 0.0.16-rc.2 --seal-only
+
+run_release 0.0.16-rc.1 --seal-only
+git add Cargo.toml release/breaking-changes.md
+git commit -qm "release: v0.0.16-rc.1"
+git tag -a v0.0.16-rc.1 -m v0.0.16-rc.1
+
+[[ "$(run_release --next rc)" == "0.0.16-rc.2" ]]
+[[ "$(run_release --next stable)" == "0.0.16" ]]
+expect_fail 0.0.16-beta.1 --seal-only
+expect_fail 0.0.16-rc.3 --seal-only
+
+run_release 0.0.16-rc.2 --seal-only
+git add Cargo.toml release/breaking-changes.md
+git commit -qm "release: v0.0.16-rc.2"
+git tag -a v0.0.16-rc.2 -m v0.0.16-rc.2
+run_release 0.0.16 --seal-only
+run_release --check
+
+expect_fail 0.0.16-rc.3 --seal-only
+expect_fail 0.0.15 --seal-only
+
+echo "Release policy tests passed."

--- a/scripts/test-release-policy.sh
+++ b/scripts/test-release-policy.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_UNDER_TEST=${1:-scripts/release.sh}
+SCRIPT_UNDER_TEST="$(cd "$(dirname "$SCRIPT_UNDER_TEST")" && pwd)/$(basename "$SCRIPT_UNDER_TEST")"
 ROOT=$(mktemp -d)
 trap 'rm -rf "$ROOT"' EXIT
 mkdir -p "$ROOT/release"


### PR DESCRIPTION
## Summary

Establish a forward-only release state machine and an automated release workflow using the current `main` branch as the authoritative source.

## What changed

- enforce strict versions: `dev.N`, `alpha.N`, `beta.N`, `rc.N`, and stable
- reject base-version rollback, stage rollback, duplicate numbering, and RC gaps
- calculate the next version from the current Cargo version
- validate version changes between pull request base and head refs
- make the PowerShell entry a wrapper around the canonical Bash implementation
- add release-policy tests using isolated temporary Git repositories
- add `Prepare Release` to create versioned Draft PRs targeting `main`
- add `Publish Release Tag` to run the final quality gate before creating an annotated tag
- harden tag-triggered artifact publishing and require tags to belong to `main`
- extend the repository CI to pull requests and pushes targeting `main`
- remove the unpublished `0.0.16` compatibility-ledger placeholder so the version can be sealed normally in the future
- document the internal release process under `docs/project/release-process.md`

## Branch policy

`main` is treated as the only authoritative release source while `develop` remains behind. This PR does not require changes in the external `zerodenet/docs` repository.

## Validation

### Version Contract — passed

- Bash syntax and isolated release-policy tests
- current Cargo and compatibility-ledger contract
- pull request base-to-head version transition
- PowerShell wrapper forwarding

### CI — passed

- format and Clippy
- all-feature workspace check and tests
- architecture boundary tests
- Linux musl build and static-link verification
- optional surface matrix
- representative proxy feature matrix

The release-policy tests cover:

- `0.0.15 -> 0.0.16-rc.1 -> 0.0.16-rc.2 -> 0.0.16`
- version rollback rejection
- stage rollback rejection
- skipped RC number rejection
- stable release requiring a prior RC
