### PR TITLE
fix(http): support standard forward-proxy requests

### DIFF
--- a/crates/proxy/src/adapters/http/inbound.rs
+++ b/crates/proxy/src/adapters/http/inbound.rs
@@ -1,21 +1,27 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use async_trait::async_trait;
-use http::HttpConnectInbound;
-use tokio::io::AsyncWriteExt;
+use http::{HttpConnectInbound, HttpInboundMode};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use zero_engine::EngineError;
 
 use crate::runtime::inbound_operation::{InboundConnectionContext, TcpInboundListenerOperation};
 use crate::runtime::tcp_ingress::InboundProtocol;
-use crate::transport::{MeteredStream, TcpRelayStream};
+use crate::transport::{ClientStream, MeteredStream, TcpRelayStream};
 
 #[derive(Clone, Copy)]
 pub(crate) struct HttpConnectInboundHandler {
     http_inbound: HttpConnectInbound,
+    send_connect_response: bool,
 }
 
 impl Default for HttpConnectInboundHandler {
     fn default() -> Self {
         Self {
             http_inbound: HttpConnectInbound,
+            send_connect_response: true,
         }
     }
 }
@@ -24,6 +30,85 @@ impl HttpConnectInboundHandler {
     pub(crate) fn http_inbound(&self) -> HttpConnectInbound {
         self.http_inbound
     }
+
+    pub(crate) fn for_mode(self, mode: HttpInboundMode) -> Self {
+        Self {
+            send_connect_response: mode == HttpInboundMode::Connect,
+            ..self
+        }
+    }
+}
+
+pub(crate) fn replay_http_request(
+    stream: TcpRelayStream,
+    replay: Vec<u8>,
+) -> TcpRelayStream {
+    if replay.is_empty() {
+        return stream;
+    }
+
+    let local_addr = stream.local_addr().ok();
+    let stream = HttpRequestReplayStream::new(stream, replay);
+    match local_addr {
+        Some(addr) => TcpRelayStream::with_local_addr(stream, addr),
+        None => TcpRelayStream::new(stream),
+    }
+}
+
+struct HttpRequestReplayStream {
+    inner: TcpRelayStream,
+    replay: Vec<u8>,
+    offset: usize,
+}
+
+impl HttpRequestReplayStream {
+    fn new(inner: TcpRelayStream, replay: Vec<u8>) -> Self {
+        Self {
+            inner,
+            replay,
+            offset: 0,
+        }
+    }
+}
+
+impl AsyncRead for HttpRequestReplayStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.offset < self.replay.len() {
+            let available = self.replay.len() - self.offset;
+            let to_copy = available.min(buf.remaining());
+            if to_copy > 0 {
+                let start = self.offset;
+                let end = start + to_copy;
+                buf.put_slice(&self.replay[start..end]);
+                self.offset = end;
+            }
+            return Poll::Ready(Ok(()));
+        }
+
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for HttpRequestReplayStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
 }
 
 #[async_trait]
@@ -31,10 +116,13 @@ impl InboundProtocol for HttpConnectInboundHandler {
     type ClientStream = TcpRelayStream;
 
     async fn send_ok(&self, client: &mut TcpRelayStream) -> Result<(), EngineError> {
-        self.http_inbound
-            .send_success_response(client)
-            .await
-            .map_err(EngineError::from)
+        if self.send_connect_response {
+            self.http_inbound
+                .send_success_response(client)
+                .await
+                .map_err(EngineError::from)?;
+        }
+        Ok(())
     }
 
     async fn send_blocked(&self, client: &mut TcpRelayStream) -> Result<(), EngineError> {
@@ -70,7 +158,8 @@ impl crate::adapters::http::HttpConnectAdapter {
                        context: InboundConnectionContext| async move {
                 let mut metered = MeteredStream::new(TcpRelayStream::from(socket));
                 match handler.http_inbound.accept_request(&mut metered).await {
-                    Ok(session) => {
+                    Ok(request) => {
+                        let (session, mode, replay) = request.into_parts();
                         if let Some((status, location)) = context.select_http_redirect(&session) {
                             handler
                                 .http_inbound
@@ -78,7 +167,10 @@ impl crate::adapters::http::HttpConnectAdapter {
                                 .await
                                 .map_err(EngineError::from)
                         } else {
-                            context.serve(session, metered.into_inner(), handler).await
+                            let client = replay_http_request(metered.into_inner(), replay);
+                            context
+                                .serve(session, client, handler.for_mode(mode))
+                                .await
                         }
                     }
                     Err(error) => {

--- a/crates/proxy/src/adapters/http/inbound.rs
+++ b/crates/proxy/src/adapters/http/inbound.rs
@@ -39,10 +39,7 @@ impl HttpConnectInboundHandler {
     }
 }
 
-pub(crate) fn replay_http_request(
-    stream: TcpRelayStream,
-    replay: Vec<u8>,
-) -> TcpRelayStream {
+pub(crate) fn replay_http_request(stream: TcpRelayStream, replay: Vec<u8>) -> TcpRelayStream {
     if replay.is_empty() {
         return stream;
     }
@@ -168,9 +165,7 @@ impl crate::adapters::http::HttpConnectAdapter {
                                 .map_err(EngineError::from)
                         } else {
                             let client = replay_http_request(metered.into_inner(), replay);
-                            context
-                                .serve(session, client, handler.for_mode(mode))
-                                .await
+                            context.serve(session, client, handler.for_mode(mode)).await
                         }
                     }
                     Err(error) => {

--- a/crates/proxy/src/adapters/mixed/inbound.rs
+++ b/crates/proxy/src/adapters/mixed/inbound.rs
@@ -2,7 +2,7 @@ use ::socks5::transport::{Socks5InboundAcceptor, Socks5InboundUserRef};
 use zero_engine::EngineError;
 use zero_traits::AsyncSocket;
 
-use crate::adapters::http::inbound::HttpConnectInboundHandler;
+use crate::adapters::http::inbound::{replay_http_request, HttpConnectInboundHandler};
 use crate::adapters::socks5::inbound::handle_socks5_connection;
 use crate::runtime::inbound_operation::{InboundConnectionContext, TcpInboundListenerOperation};
 use crate::transport::{MeteredStream, PrefixedSocket, TcpRelayStream};
@@ -41,9 +41,11 @@ async fn handle_mixed_connection(
             .accept_request(&mut metered)
             .await
         {
-            Ok(session) => {
+            Ok(http_request) => {
+                let (session, mode, replay) = http_request.into_parts();
+                let client = replay_http_request(metered.into_inner(), replay);
                 context
-                    .serve(session, metered.into_inner(), request.http_handler)
+                    .serve(session, client, request.http_handler.for_mode(mode))
                     .await
             }
             Err(err) => {

--- a/crates/proxy/tests/http.rs
+++ b/crates/proxy/tests/http.rs
@@ -202,7 +202,10 @@ async fn read_http_head(stream: &mut TcpStream) -> Vec<u8> {
     let mut request = Vec::new();
     let mut byte = [0_u8; 1];
     while !request.ends_with(b"\r\n\r\n") {
-        stream.read_exact(&mut byte).await.expect("read request head");
+        stream
+            .read_exact(&mut byte)
+            .await
+            .expect("read request head");
         request.push(byte[0]);
     }
     request

--- a/crates/proxy/tests/http.rs
+++ b/crates/proxy/tests/http.rs
@@ -72,6 +72,78 @@ async fn relays_tcp_through_http_direct_outbound() {
 }
 
 #[tokio::test]
+async fn relays_absolute_form_get_through_http_direct_outbound() {
+    let origin_port = free_port();
+    let proxy_port = free_port();
+
+    let origin_task = tokio::spawn(async move {
+        let listener = TcpListener::bind(("127.0.0.1", origin_port))
+            .await
+            .expect("bind origin");
+        let (mut stream, _) = listener.accept().await.expect("accept origin");
+        let request = read_http_head(&mut stream).await;
+        assert_eq!(
+            request,
+            format!(
+                "GET /status?view=full HTTP/1.1\r\nHost: 127.0.0.1:{origin_port}\r\nConnection: close\r\n\r\n"
+            )
+            .as_bytes()
+        );
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\npong")
+            .await
+            .expect("write origin response");
+    });
+
+    let config = RuntimeConfig::parse(&format!(
+        r#"{{
+            "inbounds": [
+                {{
+                    "tag": "http-in",
+                    "listen": {{ "address": "127.0.0.1", "port": {proxy_port} }},
+                    "protocol": {{ "type": "http" }}
+                }}
+            ],
+            "outbounds": [],
+            "route": {{
+                "rules": [],
+                "final": {{ "type": "direct" }}
+            }}
+        }}"#
+    ))
+    .expect("parse engine config");
+
+    let engine = Engine::new(config).expect("build engine");
+    let engine_handle = spawn_engine(engine);
+
+    wait_for_listener(proxy_port).await;
+
+    let mut client = TcpStream::connect(("127.0.0.1", proxy_port))
+        .await
+        .expect("connect proxy");
+    let request = format!(
+        "GET http://127.0.0.1:{origin_port}/status?view=full HTTP/1.1\r\nHost: 127.0.0.1:{origin_port}\r\nConnection: close\r\n\r\n"
+    );
+    client
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+
+    let mut response = Vec::new();
+    client
+        .read_to_end(&mut response)
+        .await
+        .expect("read response");
+    assert_eq!(
+        response,
+        b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\npong"
+    );
+
+    engine_handle.shutdown().await.expect("shutdown engine");
+    let _ = origin_task.await;
+}
+
+#[tokio::test]
 async fn rejects_http_blocked_domain_via_route_rule() {
     let proxy_port = free_port();
 
@@ -124,4 +196,14 @@ async fn rejects_http_blocked_domain_via_route_rule() {
     );
 
     engine_handle.shutdown().await.expect("shutdown engine");
+}
+
+async fn read_http_head(stream: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).await.expect("read request head");
+        request.push(byte[0]);
+    }
+    request
 }

--- a/crates/proxy/tests/mixed.rs
+++ b/crates/proxy/tests/mixed.rs
@@ -143,3 +143,93 @@ async fn mixed_inbound_accepts_socks5_and_http_on_same_port() {
     engine_handle.shutdown().await.expect("shutdown engine");
     let _ = http_echo_task.await;
 }
+
+#[tokio::test]
+async fn mixed_inbound_routes_absolute_form_get_by_ip_cidr() {
+    let mixed_port = free_port();
+    let origin_port = free_port();
+
+    let origin_task = tokio::spawn(async move {
+        let listener = TcpListener::bind(("127.0.0.1", origin_port))
+            .await
+            .expect("bind origin");
+        let (mut stream, _) = listener.accept().await.expect("accept origin");
+        let request = read_http_head(&mut stream).await;
+        assert_eq!(
+            request,
+            format!(
+                "GET /router HTTP/1.1\r\nHost: 127.0.0.1:{origin_port}\r\nConnection: close\r\n\r\n"
+            )
+            .as_bytes()
+        );
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .expect("write origin response");
+    });
+
+    let config = RuntimeConfig::parse(&format!(
+        r#"{{
+            "inbounds": [
+                {{
+                    "tag": "mixed-in",
+                    "listen": {{ "address": "127.0.0.1", "port": {mixed_port} }},
+                    "protocol": {{ "type": "mixed" }}
+                }}
+            ],
+            "outbounds": [],
+            "route": {{
+                "rules": [
+                    {{
+                        "condition": {{
+                            "type": "ip_cidr",
+                            "values": ["127.0.0.0/8"]
+                        }},
+                        "action": {{ "type": "direct" }}
+                    }}
+                ],
+                "final": {{ "type": "reject" }}
+            }}
+        }}"#
+    ))
+    .expect("parse engine config");
+
+    let engine = Engine::new(config).expect("build engine");
+    let engine_handle = spawn_engine(engine);
+
+    wait_for_listener(mixed_port).await;
+
+    let mut client = TcpStream::connect(("127.0.0.1", mixed_port))
+        .await
+        .expect("connect mixed proxy");
+    let request = format!(
+        "GET http://127.0.0.1:{origin_port}/router HTTP/1.1\r\nHost: 127.0.0.1:{origin_port}\r\nConnection: close\r\n\r\n"
+    );
+    client
+        .write_all(request.as_bytes())
+        .await
+        .expect("write request");
+
+    let mut response = Vec::new();
+    client
+        .read_to_end(&mut response)
+        .await
+        .expect("read response");
+    assert_eq!(
+        response,
+        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+    );
+
+    engine_handle.shutdown().await.expect("shutdown engine");
+    let _ = origin_task.await;
+}
+
+async fn read_http_head(stream: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).await.expect("read request head");
+        request.push(byte[0]);
+    }
+    request
+}

--- a/crates/proxy/tests/mixed.rs
+++ b/crates/proxy/tests/mixed.rs
@@ -182,7 +182,7 @@ async fn mixed_inbound_routes_absolute_form_get_by_ip_cidr() {
                 "rules": [
                     {{
                         "condition": {{
-                            "type": "ip_cidr",
+                            "type": "ip",
                             "values": ["127.0.0.0/8"]
                         }},
                         "action": {{ "type": "direct" }}

--- a/crates/proxy/tests/mixed.rs
+++ b/crates/proxy/tests/mixed.rs
@@ -228,7 +228,10 @@ async fn read_http_head(stream: &mut TcpStream) -> Vec<u8> {
     let mut request = Vec::new();
     let mut byte = [0_u8; 1];
     while !request.ends_with(b"\r\n\r\n") {
-        stream.read_exact(&mut byte).await.expect("read request head");
+        stream
+            .read_exact(&mut byte)
+            .await
+            .expect("read request head");
         request.push(byte[0]);
     }
     request

--- a/protocols/http/README.md
+++ b/protocols/http/README.md
@@ -1,34 +1,46 @@
-# HTTP CONNECT
+# HTTP Proxy
 
-> RFC 7231 | Crate: `http`
+> RFC 9110 / RFC 9112 | Crate: `http`
 
-HTTP CONNECT 方法用于通过代理建立 TCP 隧道。这是公开 RFC 协议，无上游实现可参照。
+该 crate 实现 Zero 的 HTTP 入站代理能力，同时支持 `CONNECT` 隧道和标准 absolute-form HTTP 正向代理请求。
 
 ## 协议来源
 
 | 项目 | 来源 |
 |------|------|
-| 协议规范 | [RFC 7231 §4.3.6](https://tools.ietf.org/html/rfc7231#section-4.3.6) |
+| HTTP 语义 | [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110) |
+| HTTP/1.1 消息语法与 request-target | [RFC 9112](https://www.rfc-editor.org/rfc/rfc9112) |
 | 本实现 | `http` crate |
 
 ## 功能对齐状态
 
 | 特性 | 状态 |
 |------|------|
-| CONNECT 方法解析 | ✅ |
-| Host:Port 目标地址解析 | ✅ |
-| 200 Connection Established 响应 | ✅ |
-| Proxy-Authorization (Basic auth) | ✅ |
-| 入站: accept + parse → route → relay | ✅ |
+| `CONNECT` authority-form 解析 | ✅ |
+| `200 Connection Established` 响应 | ✅ |
+| absolute-form `http://` GET/POST 等请求解析 | ✅ |
+| 目标地址提取并进入统一路由流程 | ✅ |
+| absolute-form 到 origin-form 请求行改写 | ✅ |
+| `http` 与 `mixed` 入站复用 | ✅ |
+| HTTPS 隧道 | ✅，通过 `CONNECT` |
+| absolute-form `https://` 请求 | 不支持；客户端应使用 `CONNECT` |
 
-## 架构
+## 入站流程
 
+```text
+accept request
+  -> parse CONNECT authority or absolute HTTP URI
+  -> create Session
+  -> evaluate route rules
+  -> connect selected upstream
+  -> CONNECT: reply 200 and relay tunnel
+  -> forward request: replay origin-form request head and relay response
 ```
-src/lib.rs       — crate root, re-exports
-src/inbound.rs   — HttpConnectInbound (accept, parse CONNECT, auth)
-src/protocol.rs  — shared: request/response format
+
+## 关键文件
+
+```text
+src/lib.rs       — crate root and public exports
+src/parse.rs     — request-line, authority, and absolute URI parsing
+src/inbound.rs   — request acceptance, session construction, and responses
 ```
-
-## 参考
-
-- [RFC 7231 §4.3.6 CONNECT](https://tools.ietf.org/html/rfc7231#section-4.3.6)

--- a/protocols/http/src/inbound.rs
+++ b/protocols/http/src/inbound.rs
@@ -5,10 +5,38 @@ use alloc::vec::Vec;
 use zero_core::{Error, Network, ProtocolType, Session};
 use zero_traits::AsyncSocket;
 
-use crate::parse::{first_line, parse_connect_request};
+use crate::parse::{first_line, parse_request_line, ParsedHttpRequestLine};
 
 const MAX_REQUEST_SIZE: usize = 8192;
 const HEADERS_END: &[u8] = b"\r\n\r\n";
+const LINE_END: &[u8] = b"\r\n";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpInboundMode {
+    Connect,
+    Forward,
+}
+
+#[derive(Debug)]
+pub struct HttpInboundRequest {
+    session: Session,
+    mode: HttpInboundMode,
+    replay: Vec<u8>,
+}
+
+impl HttpInboundRequest {
+    pub fn session(&self) -> &Session {
+        &self.session
+    }
+
+    pub fn mode(&self) -> HttpInboundMode {
+        self.mode
+    }
+
+    pub fn into_parts(self) -> (Session, HttpInboundMode, Vec<u8>) {
+        (self.session, self.mode, self.replay)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HttpConnectResponse {
@@ -47,21 +75,43 @@ impl HttpConnectInbound {
         ProtocolType::new("http")
     }
 
-    pub async fn accept_request<S>(&self, stream: &mut S) -> Result<Session, Error>
+    pub async fn accept_request<S>(&self, stream: &mut S) -> Result<HttpInboundRequest, Error>
     where
         S: AsyncSocket,
     {
         let request = read_request_head(stream).await?;
         let line = first_line(&request)?;
-        let (target, port) = parse_connect_request(line)?;
+        let line_end = request
+            .windows(LINE_END.len())
+            .position(|window| window == LINE_END)
+            .ok_or(Error::Protocol("HTTP request line is incomplete"))?;
 
-        Ok(Session::new(
-            0,
-            target,
-            port,
-            Network::Tcp,
-            ProtocolType::new("http"),
-        ))
+        let (target, port, mode, replay) = match parse_request_line(line)? {
+            ParsedHttpRequestLine::Connect { target, port } => {
+                (target, port, HttpInboundMode::Connect, Vec::new())
+            }
+            ParsedHttpRequestLine::Forward {
+                target,
+                port,
+                origin_form_line,
+            } => {
+                let mut replay = origin_form_line.into_bytes();
+                replay.extend_from_slice(&request[line_end + LINE_END.len()..]);
+                (target, port, HttpInboundMode::Forward, replay)
+            }
+        };
+
+        Ok(HttpInboundRequest {
+            session: Session::new(
+                0,
+                target,
+                port,
+                Network::Tcp,
+                ProtocolType::new("http"),
+            ),
+            mode,
+            replay,
+        })
     }
 
     pub async fn send_response<S>(
@@ -75,7 +125,7 @@ impl HttpConnectInbound {
         stream
             .write_all(response.status_line().as_bytes())
             .await
-            .map_err(|_| Error::Io("failed to write HTTP CONNECT response"))
+            .map_err(|_| Error::Io("failed to write HTTP response"))
     }
 
     pub async fn send_success_response<S>(&self, stream: &mut S) -> Result<(), Error>
@@ -156,17 +206,19 @@ impl HttpConnectInbound {
         stream
             .write_all(response.as_bytes())
             .await
-            .map_err(|_| Error::Io("failed to write HTTP CONNECT redirect response"))
+            .map_err(|_| Error::Io("failed to write HTTP redirect response"))
     }
 
-    pub async fn handshake<S>(&self, stream: &mut S) -> Result<Session, Error>
+    pub async fn handshake<S>(&self, stream: &mut S) -> Result<HttpInboundRequest, Error>
     where
         S: AsyncSocket,
     {
-        let session = self.accept_request(stream).await?;
-        self.send_response(stream, HttpConnectResponse::ConnectionEstablished)
-            .await?;
-        Ok(session)
+        let request = self.accept_request(stream).await?;
+        if request.mode() == HttpInboundMode::Connect {
+            self.send_response(stream, HttpConnectResponse::ConnectionEstablished)
+                .await?;
+        }
+        Ok(request)
     }
 }
 
@@ -178,18 +230,18 @@ where
 
     loop {
         if request.len() >= MAX_REQUEST_SIZE {
-            return Err(Error::Protocol("HTTP CONNECT request head is too large"));
+            return Err(Error::Protocol("HTTP request head is too large"));
         }
 
         let mut byte = [0_u8; 1];
         let read = stream
             .read(&mut byte)
             .await
-            .map_err(|_| Error::Io("failed to read HTTP CONNECT request"))?;
+            .map_err(|_| Error::Io("failed to read HTTP request"))?;
 
         if read == 0 {
             return Err(Error::Io(
-                "unexpected EOF while reading HTTP CONNECT request",
+                "unexpected EOF while reading HTTP request",
             ));
         }
 

--- a/protocols/http/src/inbound.rs
+++ b/protocols/http/src/inbound.rs
@@ -102,13 +102,7 @@ impl HttpConnectInbound {
         };
 
         Ok(HttpInboundRequest {
-            session: Session::new(
-                0,
-                target,
-                port,
-                Network::Tcp,
-                ProtocolType::new("http"),
-            ),
+            session: Session::new(0, target, port, Network::Tcp, ProtocolType::new("http")),
             mode,
             replay,
         })
@@ -240,9 +234,7 @@ where
             .map_err(|_| Error::Io("failed to read HTTP request"))?;
 
         if read == 0 {
-            return Err(Error::Io(
-                "unexpected EOF while reading HTTP request",
-            ));
+            return Err(Error::Io("unexpected EOF while reading HTTP request"));
         }
 
         request.push(byte[0]);

--- a/protocols/http/src/lib.rs
+++ b/protocols/http/src/lib.rs
@@ -7,5 +7,7 @@ mod inbound;
 mod metadata;
 mod parse;
 
-pub use inbound::{HttpConnectInbound, HttpConnectResponse};
+pub use inbound::{
+    HttpConnectInbound, HttpConnectResponse, HttpInboundMode, HttpInboundRequest,
+};
 pub use metadata::HttpConnectProtocol;

--- a/protocols/http/src/lib.rs
+++ b/protocols/http/src/lib.rs
@@ -7,7 +7,5 @@ mod inbound;
 mod metadata;
 mod parse;
 
-pub use inbound::{
-    HttpConnectInbound, HttpConnectResponse, HttpInboundMode, HttpInboundRequest,
-};
+pub use inbound::{HttpConnectInbound, HttpConnectResponse, HttpInboundMode, HttpInboundRequest};
 pub use metadata::HttpConnectProtocol;

--- a/protocols/http/src/parse.rs
+++ b/protocols/http/src/parse.rs
@@ -1,8 +1,22 @@
-use alloc::string::ToString;
+use alloc::format;
+use alloc::string::{String, ToString};
 use core::net::{Ipv4Addr, Ipv6Addr};
 use core::str::FromStr;
 
 use zero_core::{Address, Error};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ParsedHttpRequestLine {
+    Connect {
+        target: Address,
+        port: u16,
+    },
+    Forward {
+        target: Address,
+        port: u16,
+        origin_form_line: String,
+    },
+}
 
 pub(crate) fn first_line(request: &[u8]) -> Result<&str, Error> {
     let request = core::str::from_utf8(request)
@@ -15,14 +29,14 @@ pub(crate) fn first_line(request: &[u8]) -> Result<&str, Error> {
         .ok_or(Error::Protocol("HTTP request line is missing"))
 }
 
-pub(crate) fn parse_connect_request(line: &str) -> Result<(Address, u16), Error> {
+pub(crate) fn parse_request_line(line: &str) -> Result<ParsedHttpRequestLine, Error> {
     let mut parts = line.split_ascii_whitespace();
     let method = parts
         .next()
         .ok_or(Error::Protocol("HTTP method is missing"))?;
-    let authority = parts
+    let request_target = parts
         .next()
-        .ok_or(Error::Protocol("HTTP CONNECT authority is missing"))?;
+        .ok_or(Error::Protocol("HTTP request target is missing"))?;
     let version = parts
         .next()
         .ok_or(Error::Protocol("HTTP version is missing"))?;
@@ -33,55 +47,116 @@ pub(crate) fn parse_connect_request(line: &str) -> Result<(Address, u16), Error>
         ));
     }
 
-    if method != "CONNECT" {
-        return Err(Error::Unsupported("HTTP method is not supported"));
-    }
-
     if !version.starts_with("HTTP/") {
         return Err(Error::Protocol("HTTP version is invalid"));
     }
 
-    parse_authority(authority)
+    if method == "CONNECT" {
+        let (target, port) = parse_authority(request_target, None)?;
+        return Ok(ParsedHttpRequestLine::Connect { target, port });
+    }
+
+    let (target, port, origin_form) = parse_absolute_http_uri(request_target)?;
+    Ok(ParsedHttpRequestLine::Forward {
+        target,
+        port,
+        origin_form_line: format!("{method} {origin_form} {version}\r\n"),
+    })
 }
 
-fn parse_authority(authority: &str) -> Result<(Address, u16), Error> {
+fn parse_absolute_http_uri(uri: &str) -> Result<(Address, u16, String), Error> {
+    let Some(scheme) = uri.get(..7) else {
+        return Err(Error::Protocol(
+            "HTTP forward-proxy request target must use absolute-form",
+        ));
+    };
+    if !scheme.eq_ignore_ascii_case("http://") {
+        return Err(Error::Unsupported(
+            "HTTP forward-proxy scheme is not supported",
+        ));
+    }
+
+    let remainder = &uri[7..];
+    if remainder.is_empty() {
+        return Err(Error::Protocol(
+            "HTTP forward-proxy authority must not be empty",
+        ));
+    }
+    if remainder.contains('#') {
+        return Err(Error::Protocol(
+            "HTTP forward-proxy request target must not contain a fragment",
+        ));
+    }
+
+    let target_start = remainder
+        .find(|character| character == '/' || character == '?')
+        .unwrap_or(remainder.len());
+    let authority = &remainder[..target_start];
+    let suffix = &remainder[target_start..];
+
+    if authority.contains('@') {
+        return Err(Error::Protocol(
+            "HTTP forward-proxy authority must not contain user information",
+        ));
+    }
+
+    let (target, port) = parse_authority(authority, Some(80))?;
+    let origin_form = if suffix.is_empty() {
+        "/".to_string()
+    } else if suffix.starts_with('?') {
+        format!("/{suffix}")
+    } else {
+        suffix.to_string()
+    };
+
+    Ok((target, port, origin_form))
+}
+
+fn parse_authority(authority: &str, default_port: Option<u16>) -> Result<(Address, u16), Error> {
     if authority.is_empty() {
-        return Err(Error::Protocol("HTTP CONNECT authority must not be empty"));
+        return Err(Error::Protocol("HTTP authority must not be empty"));
     }
 
     if let Some(rest) = authority.strip_prefix('[') {
         let end = rest
             .find(']')
-            .ok_or(Error::Protocol("HTTP CONNECT IPv6 authority is malformed"))?;
+            .ok_or(Error::Protocol("HTTP IPv6 authority is malformed"))?;
         let host = &rest[..end];
-        let port = rest[end + 1..]
-            .strip_prefix(':')
-            .ok_or(Error::Protocol("HTTP CONNECT authority port is missing"))?;
+        let suffix = &rest[end + 1..];
+        let port = if suffix.is_empty() {
+            default_port.ok_or(Error::Protocol("HTTP authority port is missing"))?
+        } else {
+            let port = suffix
+                .strip_prefix(':')
+                .ok_or(Error::Protocol("HTTP IPv6 authority is malformed"))?;
+            parse_port(port)?
+        };
 
         let addr = Ipv6Addr::from_str(host)
-            .map_err(|_| Error::Protocol("HTTP CONNECT IPv6 address is invalid"))?;
-        let port = parse_port(port)?;
+            .map_err(|_| Error::Protocol("HTTP IPv6 address is invalid"))?;
 
         return Ok((Address::Ipv6(addr.octets()), port));
     }
 
-    let (host, port) = authority
-        .rsplit_once(':')
-        .ok_or(Error::Protocol("HTTP CONNECT authority port is missing"))?;
-    let port = parse_port(port)?;
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((host, port)) => {
+            if host.contains(':') {
+                return Err(Error::Protocol("HTTP IPv6 authority must use brackets"));
+            }
+            (host, parse_port(port)?)
+        }
+        None => (
+            authority,
+            default_port.ok_or(Error::Protocol("HTTP authority port is missing"))?,
+        ),
+    };
 
     if let Ok(addr) = Ipv4Addr::from_str(host) {
         return Ok((Address::Ipv4(addr.octets()), port));
     }
 
-    if host.contains(':') {
-        return Err(Error::Protocol(
-            "HTTP CONNECT IPv6 authority must use brackets",
-        ));
-    }
-
     if host.is_empty() {
-        return Err(Error::Protocol("HTTP CONNECT host must not be empty"));
+        return Err(Error::Protocol("HTTP host must not be empty"));
     }
 
     Ok((Address::Domain(host.to_string()), port))
@@ -89,5 +164,5 @@ fn parse_authority(authority: &str) -> Result<(Address, u16), Error> {
 
 fn parse_port(port: &str) -> Result<u16, Error> {
     port.parse::<u16>()
-        .map_err(|_| Error::Protocol("HTTP CONNECT port is invalid"))
+        .map_err(|_| Error::Protocol("HTTP port is invalid"))
 }

--- a/protocols/http/src/parse.rs
+++ b/protocols/http/src/parse.rs
@@ -88,9 +88,7 @@ fn parse_absolute_http_uri(uri: &str) -> Result<(Address, u16, String), Error> {
         ));
     }
 
-    let target_start = remainder
-        .find(|character| character == '/' || character == '?')
-        .unwrap_or(remainder.len());
+    let target_start = remainder.find(['/', '?']).unwrap_or(remainder.len());
     let authority = &remainder[..target_start];
     let suffix = &remainder[target_start..];
 

--- a/protocols/http/tests/inbound.rs
+++ b/protocols/http/tests/inbound.rs
@@ -136,9 +136,7 @@ async fn rejects_origin_form_request_without_proxy_target() {
 
     assert_eq!(
         error,
-        zero_core::Error::Protocol(
-            "HTTP forward-proxy request target must use absolute-form"
-        )
+        zero_core::Error::Protocol("HTTP forward-proxy request target must use absolute-form")
     );
 }
 

--- a/protocols/http/tests/inbound.rs
+++ b/protocols/http/tests/inbound.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use http::{HttpConnectInbound, HttpConnectResponse};
+use http::{HttpConnectInbound, HttpConnectResponse, HttpInboundMode};
 use zero_core::Address;
 use zero_traits::AsyncSocket;
 
@@ -51,13 +51,17 @@ async fn parses_domain_authority() {
     let request = b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
     let mut socket = MockSocket::new(request);
 
-    let session = HttpConnectInbound
+    let request = HttpConnectInbound
         .accept_request(&mut socket)
         .await
         .expect("request");
 
-    assert_eq!(session.target, Address::Domain("example.com".to_string()));
-    assert_eq!(session.port, 443);
+    assert_eq!(request.mode(), HttpInboundMode::Connect);
+    assert_eq!(
+        request.session().target,
+        Address::Domain("example.com".to_string())
+    );
+    assert_eq!(request.session().port, 443);
 }
 
 #[tokio::test]
@@ -65,18 +69,64 @@ async fn parses_ipv4_authority() {
     let request = b"CONNECT 127.0.0.1:8080 HTTP/1.1\r\nHost: 127.0.0.1:8080\r\n\r\n";
     let mut socket = MockSocket::new(request);
 
-    let session = HttpConnectInbound
+    let request = HttpConnectInbound
         .accept_request(&mut socket)
         .await
         .expect("request");
 
-    assert_eq!(session.target, Address::Ipv4([127, 0, 0, 1]));
-    assert_eq!(session.port, 8080);
+    assert_eq!(request.mode(), HttpInboundMode::Connect);
+    assert_eq!(request.session().target, Address::Ipv4([127, 0, 0, 1]));
+    assert_eq!(request.session().port, 8080);
 }
 
 #[tokio::test]
-async fn rejects_non_connect_method() {
-    let request = b"GET example.com:443 HTTP/1.1\r\nHost: example.com\r\n\r\n";
+async fn parses_absolute_form_get_and_rewrites_request_target() {
+    let request = b"GET http://192.168.50.1/status?view=full HTTP/1.1\r\nHost: 192.168.50.1\r\nConnection: close\r\n\r\n";
+    let mut socket = MockSocket::new(request);
+
+    let request = HttpConnectInbound
+        .accept_request(&mut socket)
+        .await
+        .expect("request");
+    let (session, mode, replay) = request.into_parts();
+
+    assert_eq!(mode, HttpInboundMode::Forward);
+    assert_eq!(session.target, Address::Ipv4([192, 168, 50, 1]));
+    assert_eq!(session.port, 80);
+    assert_eq!(
+        replay,
+        b"GET /status?view=full HTTP/1.1\r\nHost: 192.168.50.1\r\nConnection: close\r\n\r\n"
+    );
+}
+
+#[tokio::test]
+async fn parses_absolute_form_post_with_explicit_port_and_preserves_body() {
+    let request = b"POST http://example.com:8080/upload HTTP/1.1\r\nHost: example.com:8080\r\nContent-Length: 4\r\n\r\ndata";
+    let mut socket = MockSocket::new(request);
+
+    let request = HttpConnectInbound
+        .accept_request(&mut socket)
+        .await
+        .expect("request");
+    let (session, mode, replay) = request.into_parts();
+
+    assert_eq!(mode, HttpInboundMode::Forward);
+    assert_eq!(session.target, Address::Domain("example.com".to_string()));
+    assert_eq!(session.port, 8080);
+    assert_eq!(
+        replay,
+        b"POST /upload HTTP/1.1\r\nHost: example.com:8080\r\nContent-Length: 4\r\n\r\n"
+    );
+
+    let mut body = [0_u8; 4];
+    let read = socket.read(&mut body).await.expect("body");
+    assert_eq!(read, body.len());
+    assert_eq!(&body, b"data");
+}
+
+#[tokio::test]
+async fn rejects_origin_form_request_without_proxy_target() {
+    let request = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
     let mut socket = MockSocket::new(request);
 
     let error = HttpConnectInbound
@@ -86,7 +136,9 @@ async fn rejects_non_connect_method() {
 
     assert_eq!(
         error,
-        zero_core::Error::Unsupported("HTTP method is not supported")
+        zero_core::Error::Protocol(
+            "HTTP forward-proxy request target must use absolute-form"
+        )
     );
 }
 


### PR DESCRIPTION
## Summary

- accept absolute-form HTTP forward-proxy requests such as `GET http://host/path` and `POST http://host/path`
- derive the target address and port before route evaluation, so domain and IP/CIDR rules can select `direct`, `reject`, or another outbound
- rewrite the first request line to origin-form before relaying it upstream
- preserve the existing `CONNECT` tunnel response flow while suppressing the synthetic `200 Connection Established` response for ordinary HTTP requests
- apply the same behavior to both `http` and `mixed` inbounds

## Root cause

Every non-SOCKS5 mixed connection was delegated to `HttpConnectInbound`, whose parser rejected every method except `CONNECT`. The request therefore failed before a `Session` existed and before route rules could run.

## Validation

- protocol tests cover CONNECT, absolute-form GET, absolute-form POST, target extraction, request-line rewriting, and body preservation
- proxy integration tests cover ordinary HTTP relay through the `http` inbound
- mixed integration test uses an IP CIDR direct rule with a rejecting final route, verifying that route evaluation occurs before the request is relayed
- existing CONNECT and mixed SOCKS5/HTTP tests remain in place
- GitHub Actions CI #151 passes all static checks, workspace tests, architecture boundary tests, feature matrices, and musl compatibility build

Closes #4