### PR TITLE
fix(quic): resolve outbound server domains

### DIFF
--- a/crates/transport/src/quic.rs
+++ b/crates/transport/src/quic.rs
@@ -1,10 +1,10 @@
-// QUIC transport 鈥?quic.rs
+// QUIC transport — quic.rs
 //
 // UDP-based transport with TLS 1.3 encryption built-in via QUIC.
 // Uses quinn (Rust QUIC implementation).
 
 use std::io;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -29,11 +29,12 @@ impl QuicStream {
     }
 }
 
-// 鈹€鈹€ client (outbound) connect 鈹€鈹€
+// ── client (outbound) connect ──
 
 pub async fn connect_quic(
-    server_name: &str,
+    server: &str,
     port: u16,
+    server_name: &str,
     _insecure: bool,
     alpn_protocols: &[Vec<u8>],
 ) -> Result<QuicStream, RuntimeError> {
@@ -54,31 +55,7 @@ pub async fn connect_quic(
     transport.max_idle_timeout(Some(std::time::Duration::from_secs(30).try_into().unwrap()));
     client_cfg.transport_config(Arc::new(transport));
 
-    let bind_addr = "0.0.0.0:0"
-        .parse::<std::net::SocketAddr>()
-        .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic bind addr: {e}"))))?;
-
-    let socket = std::net::UdpSocket::bind(bind_addr)
-        .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic bind socket: {e}"))))?;
-    let mut endpoint = quinn::Endpoint::new(
-        quinn::EndpointConfig::default(),
-        None,
-        socket,
-        Arc::new(quinn::TokioRuntime),
-    )
-    .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic endpoint: {e}"))))?;
-
-    endpoint.set_default_client_config(client_cfg);
-
-    let server_addr = format!("{server_name}:{port}")
-        .parse::<std::net::SocketAddr>()
-        .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic addr parse: {e}"))))?;
-
-    let conn = endpoint
-        .connect(server_addr, server_name)
-        .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic connect: {e}"))))?
-        .await
-        .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic connection: {e}"))))?;
+    let conn = connect_quic_endpoint(server, port, server_name, client_cfg).await?;
 
     let (send, recv) = conn
         .open_bi()
@@ -88,7 +65,95 @@ pub async fn connect_quic(
     Ok(QuicStream::new(send, recv))
 }
 
-// 鈹€鈹€ server (inbound) accept 鈹€鈹€
+async fn connect_quic_endpoint(
+    server: &str,
+    port: u16,
+    server_name: &str,
+    client_config: quinn::ClientConfig,
+) -> Result<quinn::Connection, RuntimeError> {
+    let server_addrs = resolve_server_addresses(server, port).await?;
+    let mut last_error = None;
+
+    for server_addr in server_addrs {
+        let bind_addr = wildcard_bind_addr(server_addr);
+        let socket = match std::net::UdpSocket::bind(bind_addr) {
+            Ok(socket) => socket,
+            Err(error) => {
+                last_error = Some(format!("bind {bind_addr} for {server_addr}: {error}"));
+                continue;
+            }
+        };
+        let mut endpoint = match quinn::Endpoint::new(
+            quinn::EndpointConfig::default(),
+            None,
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        ) {
+            Ok(endpoint) => endpoint,
+            Err(error) => {
+                last_error = Some(format!("create endpoint for {server_addr}: {error}"));
+                continue;
+            }
+        };
+        endpoint.set_default_client_config(client_config.clone());
+
+        let connecting = match endpoint.connect(server_addr, server_name) {
+            Ok(connecting) => connecting,
+            Err(error) => {
+                last_error = Some(format!("connect {server_addr}: {error}"));
+                continue;
+            }
+        };
+        match connecting.await {
+            Ok(connection) => return Ok(connection),
+            Err(error) => {
+                last_error = Some(format!("connect {server_addr}: {error}"));
+            }
+        }
+    }
+
+    Err(RuntimeError::Io(io::Error::other(format!(
+        "quic connection to {server}:{port} failed: {}",
+        last_error.unwrap_or_else(|| "no resolved address was connectable".to_owned())
+    ))))
+}
+
+async fn resolve_server_addresses(
+    server: &str,
+    port: u16,
+) -> Result<Vec<SocketAddr>, RuntimeError> {
+    let mut addresses = Vec::new();
+    let resolved = tokio::net::lookup_host((server, port))
+        .await
+        .map_err(|error| {
+            RuntimeError::Io(io::Error::other(format!(
+                "quic resolve {server}:{port}: {error}"
+            )))
+        })?;
+
+    for address in resolved {
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+    }
+
+    if addresses.is_empty() {
+        return Err(RuntimeError::Io(io::Error::other(format!(
+            "quic resolve {server}:{port}: no addresses returned"
+        ))));
+    }
+
+    Ok(addresses)
+}
+
+fn wildcard_bind_addr(server_addr: SocketAddr) -> SocketAddr {
+    match server_addr {
+        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+    }
+}
+
+// ── server (inbound) accept ──
 
 pub struct QuicInbound {
     endpoint: quinn::Endpoint,
@@ -193,7 +258,7 @@ impl QuicInbound {
     }
 }
 
-// 鈹€鈹€ SkipServerVerification for QUIC client 鈹€鈹€
+// ── SkipServerVerification for QUIC client ──
 
 #[derive(Debug)]
 struct SkipServerVerification;
@@ -243,7 +308,7 @@ impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
     }
 }
 
-// 鈹€鈹€ AsyncRead / AsyncWrite / AsyncSocket / ClientStream 鈹€鈹€
+// ── AsyncRead / AsyncWrite / AsyncSocket / ClientStream ──
 
 impl AsyncRead for QuicStream {
     fn poll_read(
@@ -268,7 +333,7 @@ impl AsyncWrite for QuicStream {
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.send)
-            .poll_flush(cx)
+            .poll_flush(cx, buf)
             .map_err(io::Error::other)
     }
 
@@ -316,4 +381,24 @@ fn resolve_path(base_dir: Option<&Path>, path: &str) -> PathBuf {
     base_dir
         .map(|base_dir| base_dir.join(&path))
         .unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wildcard_bind_addr;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn uses_ipv4_wildcard_for_ipv4_server() {
+        let server: SocketAddr = "192.0.2.1:443".parse().unwrap();
+
+        assert_eq!(wildcard_bind_addr(server), "0.0.0.0:0".parse().unwrap());
+    }
+
+    #[test]
+    fn uses_ipv6_wildcard_for_ipv6_server() {
+        let server: SocketAddr = "[2001:db8::1]:443".parse().unwrap();
+
+        assert_eq!(wildcard_bind_addr(server), "[::]:0".parse().unwrap());
+    }
 }

--- a/crates/transport/src/quic.rs
+++ b/crates/transport/src/quic.rs
@@ -333,7 +333,7 @@ impl AsyncWrite for QuicStream {
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.send)
-            .poll_flush(cx, buf)
+            .poll_flush(cx)
             .map_err(io::Error::other)
     }
 

--- a/protocols/hysteria2/src/transport/connection.rs
+++ b/protocols/hysteria2/src/transport/connection.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 use zero_transport::RuntimeError;
@@ -51,29 +52,88 @@ pub async fn open_quic_connection(
     transport.datagram_receive_buffer_size(options.datagram_receive_buffer_size);
     client_config.transport_config(Arc::new(transport));
 
-    let bind_addr: std::net::SocketAddr = "0.0.0.0:0"
-        .parse()
-        .map_err(|error| RuntimeError::Io(io::Error::other(format!("quic bind addr: {error}"))))?;
-    let socket = std::net::UdpSocket::bind(bind_addr).map_err(|error| {
-        RuntimeError::Io(io::Error::other(format!("quic bind socket: {error}")))
-    })?;
-    let mut endpoint = quinn::Endpoint::new(
-        quinn::EndpointConfig::default(),
-        None,
-        socket,
-        Arc::new(quinn::TokioRuntime),
-    )
-    .map_err(|error| RuntimeError::Io(io::Error::other(format!("quic endpoint: {error}"))))?;
-    endpoint.set_default_client_config(client_config);
+    let server_addrs = resolve_server_addresses(options.server, options.port).await?;
+    let mut last_error = None;
 
-    let server_addr = format!("{}:{}", options.server, options.port)
-        .parse::<std::net::SocketAddr>()
-        .map_err(|error| RuntimeError::Io(io::Error::other(format!("quic addr: {error}"))))?;
-    endpoint
-        .connect(server_addr, options.server)
-        .map_err(|error| RuntimeError::Io(io::Error::other(format!("quic connect: {error}"))))?
+    for server_addr in server_addrs {
+        let bind_addr = wildcard_bind_addr(server_addr);
+        let socket = match std::net::UdpSocket::bind(bind_addr) {
+            Ok(socket) => socket,
+            Err(error) => {
+                last_error = Some(format!("bind {bind_addr} for {server_addr}: {error}"));
+                continue;
+            }
+        };
+        let mut endpoint = match quinn::Endpoint::new(
+            quinn::EndpointConfig::default(),
+            None,
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        ) {
+            Ok(endpoint) => endpoint,
+            Err(error) => {
+                last_error = Some(format!("create endpoint for {server_addr}: {error}"));
+                continue;
+            }
+        };
+        endpoint.set_default_client_config(client_config.clone());
+
+        let connecting = match endpoint.connect(server_addr, options.server) {
+            Ok(connecting) => connecting,
+            Err(error) => {
+                last_error = Some(format!("connect {server_addr}: {error}"));
+                continue;
+            }
+        };
+        match connecting.await {
+            Ok(connection) => return Ok(connection),
+            Err(error) => {
+                last_error = Some(format!("connect {server_addr}: {error}"));
+            }
+        }
+    }
+
+    Err(RuntimeError::Io(io::Error::other(format!(
+        "quic connection to {}:{} failed: {}",
+        options.server,
+        options.port,
+        last_error.unwrap_or_else(|| "no resolved address was connectable".to_owned())
+    ))))
+}
+
+async fn resolve_server_addresses(
+    server: &str,
+    port: u16,
+) -> Result<Vec<SocketAddr>, RuntimeError> {
+    let mut addresses = Vec::new();
+    let resolved = tokio::net::lookup_host((server, port))
         .await
-        .map_err(|error| RuntimeError::Io(io::Error::other(format!("quic connection: {error}"))))
+        .map_err(|error| {
+            RuntimeError::Io(io::Error::other(format!(
+                "quic resolve {server}:{port}: {error}"
+            )))
+        })?;
+
+    for address in resolved {
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+    }
+
+    if addresses.is_empty() {
+        return Err(RuntimeError::Io(io::Error::other(format!(
+            "quic resolve {server}:{port}: no addresses returned"
+        ))));
+    }
+
+    Ok(addresses)
+}
+
+fn wildcard_bind_addr(server_addr: SocketAddr) -> SocketAddr {
+    match server_addr {
+        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+    }
 }
 
 pub fn negotiated_alpn(connection: &quinn::Connection) -> Option<Vec<u8>> {
@@ -123,5 +183,25 @@ impl rustls::client::danger::ServerCertVerifier for SkipVerify {
             rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
             rustls::SignatureScheme::ED25519,
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wildcard_bind_addr;
+    use std::net::SocketAddr;
+
+    #[test]
+    fn uses_ipv4_wildcard_for_ipv4_server() {
+        let server: SocketAddr = "192.0.2.1:443".parse().unwrap();
+
+        assert_eq!(wildcard_bind_addr(server), "0.0.0.0:0".parse().unwrap());
+    }
+
+    #[test]
+    fn uses_ipv6_wildcard_for_ipv6_server() {
+        let server: SocketAddr = "[2001:db8::1]:443".parse().unwrap();
+
+        assert_eq!(wildcard_bind_addr(server), "[::]:0".parse().unwrap());
     }
 }

--- a/protocols/vless/src/transport/outbound/direct.rs
+++ b/protocols/vless/src/transport/outbound/direct.rs
@@ -20,7 +20,14 @@ pub(super) async fn open_vless_quic_transport(
     let server_name = quic_config.server_name.as_deref().unwrap_or(server);
     let alpn_protocols = quic_config.alpn_protocols();
     Ok(TcpRelayStream::new(
-        quic::connect_quic(server_name, port, quic_config.insecure, &alpn_protocols).await?,
+        quic::connect_quic(
+            server,
+            port,
+            server_name,
+            quic_config.insecure,
+            &alpn_protocols,
+        )
+        .await?,
     ))
 }
 
@@ -82,7 +89,7 @@ pub(super) async fn build_vless_outbound_transport(
     // XHTTP is handled first because it is mutually exclusive with other transports.
     if let Some(cfg) = split_http_config {
         let mode = split_http::XhttpMode::parse(&cfg.mode);
-        // stream-one (and `auto`): a single bidirectional connection 閳?one TCP/TLS
+        // stream-one (and `auto`): a single bidirectional connection — one TCP/TLS
         // socket carries both the chunked upload and the chunked download.
         if mode.is_single_connection() {
             let carrier: TcpRelayStream = match tls_config {


### PR DESCRIPTION
## Summary

- resolve Hysteria2 and VLESS QUIC server hostnames before opening UDP endpoints
- keep network destination (`server`) separate from TLS SNI (`server_name`)
- bind an IPv4 or IPv6 wildcard UDP socket according to each resolved address
- try all unique resolved addresses before returning a connection error
- add regression coverage for IPv4/IPv6 wildcard bind selection

## Root cause

Both QUIC outbound paths constructed a host and port and parsed them directly as `SocketAddr`. That only accepts numeric IP addresses, so valid domain-based nodes failed before DNS resolution with errors such as `quic addr: invalid socket address syntax`.

VLESS QUIC also used its optional `server_name` as both the network destination and TLS SNI. A custom SNI could therefore replace the configured server address instead of only affecting certificate negotiation.

## Impact

- Hysteria2 nodes configured with domain names can establish QUIC connections and participate in latency probes.
- VLESS QUIC nodes configured with domain names can connect normally.
- VLESS QUIC custom SNI no longer changes the DNS destination.
- Dual-stack domains can fall back across resolved IPv4 and IPv6 addresses.

## Validation

- added IPv4 and IPv6 wildcard bind-selection tests in both QUIC connection paths
- verified the branch diff against `develop`
- GitHub Actions runs formatting, clippy, feature checks, workspace tests, and compatibility builds