### PR TITLE
fix: isolate outbound diagnostics from URLTest policy

### DIFF
--- a/crates/proxy/src/groups/mod.rs
+++ b/crates/proxy/src/groups/mod.rs
@@ -1,5 +1,3 @@
 mod urltest;
 
-/// Re-exported so `ProxyHandle` can fall back to it for
-/// `diagnostics.probe_outbound` when the caller omits `url`.
 pub(crate) use urltest::UrlTestRuntime;

--- a/crates/proxy/src/groups/urltest.rs
+++ b/crates/proxy/src/groups/urltest.rs
@@ -1,35 +1,18 @@
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use futures_util::future::{BoxFuture, FutureExt, Shared};
-use futures_util::stream::{self, StreamExt};
-use tokio::sync::{watch, Notify, Semaphore};
-use tokio::time::{interval, timeout, MissedTickBehavior};
-use tracing::{debug, info, warn};
-use zero_core::{Address, Network, ProtocolType, Session};
-use zero_traits::AsyncSocket;
+use tokio::sync::{watch, Notify};
+use tokio::time::{interval, MissedTickBehavior};
+use tracing::{debug, info};
 
 use crate::protocol_registry::TcpRuntimeServices;
-use crate::transport::extract_tcp_stream;
-use zero_engine::{
-    EngineError, PolicyProbeCompletedPayload, PolicyProbeMember, ProbeTrigger, ProbeTriggerAck,
-    ResolvedOutbound, TargetId, UrlTestMemberState,
+use crate::runtime::outbound_probe::{
+    OutboundProbeRequest, OutboundProbeRuntime, MAX_CONCURRENT_OUTBOUND_PROBES,
 };
+use zero_engine::{EngineError, ProbeTrigger, ProbeTriggerAck, TargetId};
 
-use super::super::logging::log_urltest_group_target_changed;
-
-const MAX_CONCURRENT_URLTEST_PROBES: usize = 8;
-
-type SharedProbeFuture = Shared<BoxFuture<'static, Result<u64, String>>>;
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct ProbeKey {
-    config_identity: usize,
-    target_tag: String,
-    url: String,
-}
+mod refresh;
 
 #[derive(Default)]
 struct ProbeOperationState {
@@ -66,33 +49,18 @@ fn generated_operation_id() -> String {
     )
 }
 
-fn global_probe_limiter() -> Arc<Semaphore> {
-    static LIMITER: OnceLock<Arc<Semaphore>> = OnceLock::new();
-    LIMITER
-        .get_or_init(|| Arc::new(Semaphore::new(MAX_CONCURRENT_URLTEST_PROBES)))
-        .clone()
-}
-
-fn global_shared_probes() -> Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>> {
-    static PROBES: OnceLock<Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>> = OnceLock::new();
-    PROBES
-        .get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
-        .clone()
-}
-
 #[derive(Clone)]
 pub(crate) struct UrlTestRuntime {
     services: TcpRuntimeServices,
-    probe_limiter: Arc<Semaphore>,
-    shared_probes: Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>,
+    outbound_probe: OutboundProbeRuntime,
 }
 
 impl UrlTestRuntime {
     pub(crate) fn new(services: TcpRuntimeServices) -> Self {
+        let outbound_probe = OutboundProbeRuntime::new(services.clone());
         Self {
             services,
-            probe_limiter: global_probe_limiter(),
-            shared_probes: global_shared_probes(),
+            outbound_probe,
         }
     }
 
@@ -102,10 +70,7 @@ impl UrlTestRuntime {
 
     pub(crate) fn clear_probe_triggers(&self) {
         self.services.engine().probe_trigger_registry().clear();
-        self.shared_probes
-            .lock()
-            .expect("shared urltest probe lock poisoned")
-            .clear();
+        self.outbound_probe.clear_shared();
     }
 
     pub(crate) async fn run_urltest_group(
@@ -122,10 +87,10 @@ impl UrlTestRuntime {
         };
         let group_tag = group.tag().to_owned();
         let interval_seconds = urltest.interval().as_secs();
-        let probe = UrlTestProbe::parse(urltest.url()).map_err(|message| {
+        let probe = OutboundProbeRequest::parse(urltest.url()).map_err(|error| {
             EngineError::InvalidUrlTestGroup {
                 tag: group_tag.clone(),
-                message,
+                message: error.message().to_owned(),
             }
         })?;
 
@@ -154,7 +119,7 @@ impl UrlTestRuntime {
             group_tag = %group_tag,
             url = probe.url.as_str(),
             interval_seconds,
-            max_concurrent_probes = MAX_CONCURRENT_URLTEST_PROBES,
+            max_concurrent_probes = MAX_CONCURRENT_OUTBOUND_PROBES,
             concurrency_scope = "process",
             "urltest group started"
         );
@@ -222,7 +187,7 @@ impl UrlTestRuntime {
     async fn run_probe_operation(
         &self,
         group_id: TargetId,
-        probe: &UrlTestProbe,
+        probe: &OutboundProbeRequest,
         trigger: &'static str,
         operation_id: String,
         operations: &Mutex<ProbeOperationState>,
@@ -242,408 +207,6 @@ impl UrlTestRuntime {
             state.current = None;
         }
     }
-
-    async fn refresh_urltest_group(
-        &self,
-        group_id: TargetId,
-        probe: &UrlTestProbe,
-        trigger: &'static str,
-        operation_id: &str,
-    ) {
-        let runtime_snapshot = self.services.snapshot();
-        let config_revision = runtime_snapshot.config_revision();
-        let plan = runtime_snapshot.plan();
-        let Some(group) = plan.target(group_id) else {
-            debug!(
-                group_id = group_id.index(),
-                trigger, "urltest group disappeared during config reload"
-            );
-            return;
-        };
-        let Some(urltest) = group.as_urltest() else {
-            debug!(
-                group_id = group_id.index(),
-                trigger, "urltest group changed during config reload"
-            );
-            return;
-        };
-        let group_tag = group.tag();
-        let started_at_unix_ms = unix_timestamp_ms();
-        let started_at = Instant::now();
-
-        // Each group can prepare up to eight member futures, while every
-        // UrlTestRuntime instance shares one process-wide semaphore. Multiple
-        // urltest groups and diagnostics.probe_outbound therefore cannot
-        // multiply the real socket concurrency beyond the global limit.
-        let mut probe_results = stream::iter(urltest.members().iter().copied().enumerate())
-            .map(|(index, member_id)| async move {
-                let member = self
-                    .target_tag(member_id)
-                    .unwrap_or_else(|| "<unknown>".to_owned());
-                let effective_chains = self.resolve_target_chains(member_id);
-
-                match self.probe_target_shared(member_id, probe).await {
-                    Ok(latency_ms) => (
-                        index,
-                        UrlTestMemberState {
-                            member_id,
-                            healthy: true,
-                            latency_ms: Some(latency_ms),
-                            last_checked_unix_ms: Some(started_at_unix_ms),
-                            last_error: None,
-                            effective_chains,
-                        },
-                        Some((member_id, latency_ms)),
-                    ),
-                    Err(error) => {
-                        debug!(
-                            group_tag = group_tag,
-                            outbound_tag = member,
-                            error = %error,
-                            "urltest probe failed"
-                        );
-                        (
-                            index,
-                            UrlTestMemberState {
-                                member_id,
-                                healthy: false,
-                                latency_ms: None,
-                                last_checked_unix_ms: Some(started_at_unix_ms),
-                                last_error: Some(error),
-                                effective_chains,
-                            },
-                            None,
-                        )
-                    }
-                }
-            })
-            .buffer_unordered(MAX_CONCURRENT_URLTEST_PROBES)
-            .collect::<Vec<_>>()
-            .await;
-
-        // Preserve configured member order in snapshots and events even though
-        // the probes complete out of order.
-        probe_results.sort_by_key(|(index, _, _)| *index);
-        let mut member_states = Vec::with_capacity(probe_results.len());
-        let mut successful_members = Vec::with_capacity(probe_results.len());
-        for (_, member_state, success) in probe_results {
-            if let Some(success) = success {
-                successful_members.push(success);
-            }
-            member_states.push(member_state);
-        }
-
-        let previous = self.urltest_selected_target(group_id);
-        let selection = urltest.select(previous, &successful_members);
-        let selected = selection.selected;
-        let selected_tag = self
-            .target_tag(selected)
-            .unwrap_or_else(|| "<unknown>".to_owned());
-        let previous_tag = previous.and_then(|target| self.target_tag(target));
-
-        let latency_ms = successful_members
-            .iter()
-            .find(|(member_id, _)| *member_id == selected)
-            .map(|(_, latency_ms)| *latency_ms);
-
-        let probe_members: Vec<PolicyProbeMember> = member_states
-            .iter()
-            .map(|state| {
-                let tag = self
-                    .target_tag(state.member_id)
-                    .unwrap_or_else(|| "<unknown>".to_owned());
-                PolicyProbeMember {
-                    target_tag: tag,
-                    healthy: state.healthy,
-                    latency_ms: state.latency_ms,
-                    error_code: state.last_error.as_deref().map(probe_error_code),
-                    error: state.last_error.clone(),
-                }
-            })
-            .collect();
-
-        let healthy_members = member_states.iter().filter(|member| member.healthy).count();
-        let total_members = member_states.len();
-        self.update_urltest_state(
-            group_id,
-            selected,
-            latency_ms,
-            member_states,
-            selection.clone(),
-        );
-
-        let completed_at_unix_ms = unix_timestamp_ms();
-        let duration_ms = started_at.elapsed().as_millis() as u64;
-        let terminal_status = match healthy_members {
-            count if count == total_members => "succeeded",
-            0 => "failed",
-            _ => "partial_failure",
-        };
-        let event_payload = PolicyProbeCompletedPayload {
-            operation_id: operation_id.to_owned(),
-            core_instance_id: self.services.engine().core_instance_id().to_owned(),
-            config_revision,
-            policy_tag: group_tag.to_owned(),
-            trigger: trigger.to_owned(),
-            url: probe.url.clone(),
-            started_at_unix_ms,
-            completed_at_unix_ms,
-            duration_ms,
-            terminal_status: terminal_status.to_owned(),
-            selected: Some(selected_tag.clone()),
-            selection: Some(zero_api::UrlTestSelectionSnapshot {
-                previous_selected: selection
-                    .previous
-                    .and_then(|target| self.target_tag(target)),
-                selected: selected_tag.clone(),
-                best_candidate: selection.best.and_then(|target| self.target_tag(target)),
-                current_latency_ms: selection.current_latency_ms,
-                best_latency_ms: selection.best_latency_ms,
-                tolerance_ms: selection.tolerance_ms,
-                switched: selection.switched,
-                reason: selection.reason.as_str().to_owned(),
-            }),
-            members: probe_members,
-        };
-
-        info!(
-            event_type = "policy.probe.completed",
-            group_kind = "url_test",
-            group_tag,
-            trigger,
-            url = probe.url.as_str(),
-            started_at_unix_ms,
-            completed_at_unix_ms,
-            duration_ms,
-            operation_id,
-            config_revision,
-            terminal_status,
-            selection_reason = selection.reason.as_str(),
-            tolerance_ms = selection.tolerance_ms,
-            switched = selection.switched,
-            selected = %selected_tag,
-            healthy_members,
-            total_members,
-            members = ?event_payload.members,
-            "urltest probe completed"
-        );
-
-        self.services
-            .engine()
-            .push_policy_probe_completed(group_tag, event_payload);
-
-        log_urltest_group_target_changed(
-            group_tag,
-            previous_tag.as_deref(),
-            &selected_tag,
-            latency_ms,
-        );
-
-        if selection.best.is_none() {
-            warn!(
-                group_tag = group_tag,
-                selected = selected_tag,
-                "urltest probe found no healthy outbound; keeping current selection"
-            );
-        }
-    }
-
-    pub(crate) async fn probe_outbound_single(
-        &self,
-        target_tag: &str,
-        url: &str,
-    ) -> Result<u64, EngineError> {
-        let probe =
-            UrlTestProbe::parse(url).map_err(|message| EngineError::InvalidUrlTestGroup {
-                tag: target_tag.to_owned(),
-                message,
-            })?;
-        let plan = self.services.snapshot().plan();
-        let Some(target_id) = plan.target_id(target_tag) else {
-            return Err(EngineError::SelectorGroupNotFound {
-                tag: target_tag.to_owned(),
-            });
-        };
-        self.probe_target_shared(target_id, &probe)
-            .await
-            .map_err(|message| EngineError::Io(std::io::Error::other(message)))
-    }
-
-    async fn probe_target_shared(
-        &self,
-        target_id: TargetId,
-        probe: &UrlTestProbe,
-    ) -> Result<u64, String> {
-        let target_tag = self
-            .target_tag(target_id)
-            .ok_or_else(|| "failed to resolve probe target".to_owned())?;
-        let config = self.services.engine().config();
-        let key = ProbeKey {
-            config_identity: Arc::as_ptr(&config) as usize,
-            target_tag,
-            url: probe.url.clone(),
-        };
-
-        let shared = {
-            let mut probes = self
-                .shared_probes
-                .lock()
-                .expect("shared urltest probe lock poisoned");
-            if let Some(existing) = probes.get(&key) {
-                existing.clone()
-            } else {
-                let runtime = self.clone();
-                let probe = probe.clone();
-                let future = async move {
-                    let _permit = runtime
-                        .probe_limiter
-                        .clone()
-                        .acquire_owned()
-                        .await
-                        .map_err(|_| "urltest probe limiter closed".to_owned())?;
-                    let Some((candidate, _plan)) = runtime.resolve_target_id(target_id) else {
-                        return Err("failed to resolve probe target".to_owned());
-                    };
-                    runtime
-                        .probe_outbound(candidate, &probe)
-                        .await
-                        .map_err(normalize_probe_error)
-                }
-                .boxed()
-                .shared();
-                probes.insert(key.clone(), future.clone());
-                future
-            }
-        };
-
-        let result = shared.await;
-        self.shared_probes
-            .lock()
-            .expect("shared urltest probe lock poisoned")
-            .remove(&key);
-        result
-    }
-
-    async fn probe_outbound(
-        &self,
-        candidate: ResolvedOutbound<'static>,
-        probe: &UrlTestProbe,
-    ) -> Result<u64, EngineError> {
-        match candidate {
-            ResolvedOutbound::Relay { .. } => Err(EngineError::Io(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                "relay chain cannot be used as a urltest member",
-            ))),
-            resolved => self.probe_resolved_outbound(resolved, probe).await,
-        }
-    }
-
-    async fn probe_resolved_outbound(
-        &self,
-        resolved: ResolvedOutbound<'static>,
-        probe: &UrlTestProbe,
-    ) -> Result<u64, EngineError> {
-        const URLTEST_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
-
-        timeout(URLTEST_PROBE_TIMEOUT, async {
-            let started_at = Instant::now();
-            let probe_session = Session::new(
-                0,
-                Address::Domain(probe.host.clone()),
-                probe.port,
-                Network::Tcp,
-                ProtocolType::UNKNOWN,
-            );
-
-            let outbound = crate::runtime::tcp_dispatch::dispatch_tcp_outbound(
-                self.services.clone(),
-                &probe_session,
-                resolved,
-            )
-            .await
-            .map_err(|failure| failure.error)?;
-            let result = extract_tcp_stream(outbound)?;
-            let mut socket = result.upstream;
-
-            socket
-                .write_all(probe.request.as_bytes())
-                .await
-                .map_err(EngineError::from)?;
-
-            let mut buf = [0_u8; 1];
-            let read = socket.read(&mut buf).await.map_err(EngineError::from)?;
-            if read == 0 {
-                return Err(std::io::Error::other(
-                    "probe target closed connection without response",
-                )
-                .into());
-            }
-
-            Ok(started_at.elapsed().as_millis() as u64)
-        })
-        .await
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "urltest probe timed out"))?
-    }
-
-    fn resolve_target_id(
-        &self,
-        target_id: TargetId,
-    ) -> Option<(ResolvedOutbound<'static>, Arc<zero_engine::EnginePlan>)> {
-        self.services
-            .engine()
-            .resolve_target_id_in_snapshot(self.services.snapshot(), target_id)
-    }
-
-    fn resolve_target_chains(&self, target_id: TargetId) -> Vec<Vec<TargetId>> {
-        self.services
-            .engine()
-            .resolve_target_chains_in_snapshot(self.services.snapshot(), target_id)
-    }
-
-    fn target_tag(&self, target_id: TargetId) -> Option<String> {
-        self.services
-            .engine()
-            .target_tag_in_snapshot(self.services.snapshot(), target_id)
-    }
-
-    fn urltest_selected_target(&self, group_id: TargetId) -> Option<TargetId> {
-        self.services.engine().urltest_selected_target(group_id)
-    }
-
-    fn update_urltest_state(
-        &self,
-        group_id: TargetId,
-        selected: TargetId,
-        latency_ms: Option<u64>,
-        members: Vec<UrlTestMemberState>,
-        selection: zero_engine::UrlTestSelection,
-    ) {
-        self.services
-            .engine()
-            .update_urltest_state(group_id, selected, latency_ms, members, selection);
-    }
-}
-
-fn normalize_probe_error(error: EngineError) -> String {
-    let message = error.to_string();
-    message
-        .strip_prefix("io error: ")
-        .unwrap_or(message.as_str())
-        .to_owned()
-}
-
-fn probe_error_code(error: &str) -> String {
-    let normalized = error.to_ascii_lowercase();
-    if normalized.contains("timed out") || normalized.contains("timeout") {
-        "timeout"
-    } else if normalized.contains("resolve") || normalized.contains("dns") {
-        "resolution_failed"
-    } else if normalized.contains("invalid") || normalized.contains("unsupported") {
-        "invalid_probe"
-    } else {
-        "probe_failed"
-    }
-    .to_owned()
 }
 
 fn unix_timestamp_ms() -> u64 {
@@ -653,73 +216,4 @@ fn unix_timestamp_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("system clock should be after unix epoch")
         .as_millis() as u64
-}
-
-#[derive(Clone)]
-struct UrlTestProbe {
-    url: String,
-    host: String,
-    port: u16,
-    request: String,
-}
-
-impl UrlTestProbe {
-    fn parse(url: &str) -> Result<Self, String> {
-        let rest = url
-            .strip_prefix("http://")
-            .ok_or_else(|| "urltest currently only supports `http://` probe urls".to_owned())?;
-
-        let (authority, path) = match rest.split_once('/') {
-            Some((authority, suffix)) => (authority, format!("/{}", suffix)),
-            None => (rest, "/".to_owned()),
-        };
-
-        if authority.trim().is_empty() {
-            return Err("urltest probe url requires a host".to_owned());
-        }
-
-        let (host, port) = parse_authority(authority)?;
-        let host_header = if port == 80 {
-            authority.to_owned()
-        } else if authority.contains(':') && !authority.starts_with('[') {
-            format!("{host}:{port}")
-        } else {
-            authority.to_owned()
-        };
-
-        let request =
-            format!("HEAD {path} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n\r\n");
-
-        Ok(Self {
-            url: url.to_owned(),
-            host,
-            port,
-            request,
-        })
-    }
-}
-
-fn parse_authority(authority: &str) -> Result<(String, u16), String> {
-    if let Some(rest) = authority.strip_prefix('[') {
-        let (host, port_part) = rest
-            .split_once(']')
-            .ok_or_else(|| "invalid bracketed host in urltest probe url".to_owned())?;
-        let port = match port_part.strip_prefix(':') {
-            Some(port) => port
-                .parse::<u16>()
-                .map_err(|_| "invalid port in urltest probe url".to_owned())?,
-            None if port_part.is_empty() => 80,
-            _ => return Err("invalid authority in urltest probe url".to_owned()),
-        };
-        return Ok((host.to_owned(), port));
-    }
-
-    match authority.rsplit_once(':') {
-        Some((host, port)) if !host.contains(':') => Ok((
-            host.to_owned(),
-            port.parse::<u16>()
-                .map_err(|_| "invalid port in urltest probe url".to_owned())?,
-        )),
-        _ => Ok((authority.to_owned(), 80)),
-    }
 }

--- a/crates/proxy/src/groups/urltest/refresh.rs
+++ b/crates/proxy/src/groups/urltest/refresh.rs
@@ -1,0 +1,254 @@
+use std::time::Instant;
+
+use futures_util::stream::{self, StreamExt};
+use tracing::{debug, info, warn};
+use zero_engine::{PolicyProbeCompletedPayload, PolicyProbeMember, TargetId, UrlTestMemberState};
+
+use crate::runtime::outbound_probe::{OutboundProbeRequest, MAX_CONCURRENT_OUTBOUND_PROBES};
+
+use super::{unix_timestamp_ms, UrlTestRuntime};
+use crate::logging::log_urltest_group_target_changed;
+
+impl UrlTestRuntime {
+    pub(super) async fn refresh_urltest_group(
+        &self,
+        group_id: TargetId,
+        probe: &OutboundProbeRequest,
+        trigger: &'static str,
+        operation_id: &str,
+    ) {
+        let runtime_snapshot = self.services.snapshot();
+        let config_revision = runtime_snapshot.config_revision();
+        let plan = runtime_snapshot.plan();
+        let Some(group) = plan.target(group_id) else {
+            debug!(
+                group_id = group_id.index(),
+                trigger, "urltest group disappeared during config reload"
+            );
+            return;
+        };
+        let Some(urltest) = group.as_urltest() else {
+            debug!(
+                group_id = group_id.index(),
+                trigger, "urltest group changed during config reload"
+            );
+            return;
+        };
+        let group_tag = group.tag();
+        let started_at_unix_ms = unix_timestamp_ms();
+        let started_at = Instant::now();
+
+        // The shared neutral probe runtime keeps real socket concurrency bounded
+        // across URLTest groups and synchronous diagnostics.
+        let mut probe_results = stream::iter(urltest.members().iter().copied().enumerate())
+            .map(|(index, member_id)| async move {
+                let member = self
+                    .target_tag(member_id)
+                    .unwrap_or_else(|| "<unknown>".to_owned());
+                let effective_chains = self.resolve_target_chains(member_id);
+
+                match self
+                    .outbound_probe
+                    .probe_target_shared(member_id, probe)
+                    .await
+                {
+                    Ok(latency_ms) => (
+                        index,
+                        UrlTestMemberState {
+                            member_id,
+                            healthy: true,
+                            latency_ms: Some(latency_ms),
+                            last_checked_unix_ms: Some(started_at_unix_ms),
+                            last_error: None,
+                            effective_chains,
+                        },
+                        PolicyProbeMember {
+                            target_tag: member,
+                            healthy: true,
+                            latency_ms: Some(latency_ms),
+                            error_code: None,
+                            error: None,
+                        },
+                        Some((member_id, latency_ms)),
+                    ),
+                    Err(error) => {
+                        debug!(
+                            group_tag,
+                            outbound_tag = member,
+                            error = %error,
+                            "urltest probe failed"
+                        );
+                        (
+                            index,
+                            UrlTestMemberState {
+                                member_id,
+                                healthy: false,
+                                latency_ms: None,
+                                last_checked_unix_ms: Some(started_at_unix_ms),
+                                last_error: Some(error.message().to_owned()),
+                                effective_chains,
+                            },
+                            PolicyProbeMember {
+                                target_tag: member,
+                                healthy: false,
+                                latency_ms: None,
+                                error_code: Some(policy_probe_error_code(error.code()).to_owned()),
+                                error: Some(error.message().to_owned()),
+                            },
+                            None,
+                        )
+                    }
+                }
+            })
+            .buffer_unordered(MAX_CONCURRENT_OUTBOUND_PROBES)
+            .collect::<Vec<_>>()
+            .await;
+
+        probe_results.sort_by_key(|(index, _, _, _)| *index);
+        let mut member_states = Vec::with_capacity(probe_results.len());
+        let mut probe_members = Vec::with_capacity(probe_results.len());
+        let mut successful_members = Vec::with_capacity(probe_results.len());
+        for (_, member_state, probe_member, success) in probe_results {
+            if let Some(success) = success {
+                successful_members.push(success);
+            }
+            member_states.push(member_state);
+            probe_members.push(probe_member);
+        }
+
+        let previous = self.urltest_selected_target(group_id);
+        let selection = urltest.select(previous, &successful_members);
+        let selected = selection.selected;
+        let selected_tag = self
+            .target_tag(selected)
+            .unwrap_or_else(|| "<unknown>".to_owned());
+        let previous_tag = previous.and_then(|target| self.target_tag(target));
+        let latency_ms = successful_members
+            .iter()
+            .find(|(member_id, _)| *member_id == selected)
+            .map(|(_, latency_ms)| *latency_ms);
+
+        let healthy_members = member_states.iter().filter(|member| member.healthy).count();
+        let total_members = member_states.len();
+        self.update_urltest_state(
+            group_id,
+            selected,
+            latency_ms,
+            member_states,
+            selection.clone(),
+        );
+
+        let completed_at_unix_ms = unix_timestamp_ms();
+        let duration_ms = started_at.elapsed().as_millis() as u64;
+        let terminal_status = match healthy_members {
+            count if count == total_members => "succeeded",
+            0 => "failed",
+            _ => "partial_failure",
+        };
+        let event_payload = PolicyProbeCompletedPayload {
+            operation_id: operation_id.to_owned(),
+            core_instance_id: self.services.engine().core_instance_id().to_owned(),
+            config_revision,
+            policy_tag: group_tag.to_owned(),
+            trigger: trigger.to_owned(),
+            url: probe.url.clone(),
+            started_at_unix_ms,
+            completed_at_unix_ms,
+            duration_ms,
+            terminal_status: terminal_status.to_owned(),
+            selected: Some(selected_tag.clone()),
+            selection: Some(zero_api::UrlTestSelectionSnapshot {
+                previous_selected: selection
+                    .previous
+                    .and_then(|target| self.target_tag(target)),
+                selected: selected_tag.clone(),
+                best_candidate: selection.best.and_then(|target| self.target_tag(target)),
+                current_latency_ms: selection.current_latency_ms,
+                best_latency_ms: selection.best_latency_ms,
+                tolerance_ms: selection.tolerance_ms,
+                switched: selection.switched,
+                reason: selection.reason.as_str().to_owned(),
+            }),
+            members: probe_members,
+        };
+
+        info!(
+            event_type = "policy.probe.completed",
+            operation_kind = "policy_urltest",
+            group_kind = "url_test",
+            group_tag,
+            trigger,
+            url = probe.url.as_str(),
+            started_at_unix_ms,
+            completed_at_unix_ms,
+            duration_ms,
+            operation_id,
+            config_revision,
+            terminal_status,
+            selection_reason = selection.reason.as_str(),
+            tolerance_ms = selection.tolerance_ms,
+            switched = selection.switched,
+            selected = %selected_tag,
+            healthy_members,
+            total_members,
+            members = ?event_payload.members,
+            "urltest probe completed"
+        );
+
+        self.services
+            .engine()
+            .push_policy_probe_completed(group_tag, event_payload);
+        log_urltest_group_target_changed(
+            group_tag,
+            previous_tag.as_deref(),
+            &selected_tag,
+            latency_ms,
+        );
+
+        if selection.best.is_none() {
+            warn!(
+                group_tag,
+                selected = selected_tag,
+                "urltest probe found no healthy outbound; keeping current selection"
+            );
+        }
+    }
+
+    fn resolve_target_chains(&self, target_id: TargetId) -> Vec<Vec<TargetId>> {
+        self.services
+            .engine()
+            .resolve_target_chains_in_snapshot(self.services.snapshot(), target_id)
+    }
+
+    fn target_tag(&self, target_id: TargetId) -> Option<String> {
+        self.services
+            .engine()
+            .target_tag_in_snapshot(self.services.snapshot(), target_id)
+    }
+
+    fn urltest_selected_target(&self, group_id: TargetId) -> Option<TargetId> {
+        self.services.engine().urltest_selected_target(group_id)
+    }
+
+    fn update_urltest_state(
+        &self,
+        group_id: TargetId,
+        selected: TargetId,
+        latency_ms: Option<u64>,
+        members: Vec<UrlTestMemberState>,
+        selection: zero_engine::UrlTestSelection,
+    ) {
+        self.services
+            .engine()
+            .update_urltest_state(group_id, selected, latency_ms, members, selection);
+    }
+}
+
+fn policy_probe_error_code(code: &str) -> &'static str {
+    match code {
+        "probe_timeout" => "timeout",
+        "target_resolution_failed" => "resolution_failed",
+        "invalid_probe_url" | "unsupported_target" | "invalid_probe" => "invalid_probe",
+        _ => "probe_failed",
+    }
+}

--- a/crates/proxy/src/runtime.rs
+++ b/crates/proxy/src/runtime.rs
@@ -32,6 +32,7 @@ pub(crate) mod mux_tcp;
 #[cfg(feature = "managed-stream-runtime")]
 pub(crate) mod mux_udp;
 pub(crate) mod orchestration;
+pub(crate) mod outbound_probe;
 #[cfg(feature = "managed-stream-runtime")]
 pub(crate) mod packet_session_udp;
 mod passive_relay_health;
@@ -231,9 +232,12 @@ impl Proxy {
         target_tag: &str,
         url: &str,
     ) -> Result<u64, EngineError> {
-        crate::groups::UrlTestRuntime::new(self.tcp_runtime_services())
-            .probe_outbound_single(target_tag, url)
+        let request = outbound_probe::OutboundProbeRequest::parse(url)
+            .map_err(|error| EngineError::Io(std::io::Error::other(error)))?;
+        outbound_probe::OutboundProbeRuntime::new(self.tcp_runtime_services())
+            .probe_target_tag(target_tag, &request)
             .await
+            .map_err(|error| EngineError::Io(std::io::Error::other(error)))
     }
 }
 

--- a/crates/proxy/src/runtime/handle/command/diagnostics.rs
+++ b/crates/proxy/src/runtime/handle/command/diagnostics.rs
@@ -1,5 +1,8 @@
-use crate::groups::UrlTestRuntime;
+use crate::runtime::outbound_probe::{
+    OutboundProbeRequest, OutboundProbeRuntime, OUTBOUND_PROBE_TIMEOUT_MS,
+};
 use crate::runtime::route_runtime::route_trace_for_session;
+use tracing::info;
 use zero_core::{Network, ProtocolType, Session};
 use zero_traits::{DnsResolver, IpAddress};
 
@@ -254,46 +257,115 @@ pub(super) fn execute_diagnostics_probe_outbound(
             rt.block_on(async move {
                 let started_at_unix_ms = unix_timestamp_ms();
                 let started = std::time::Instant::now();
-                match UrlTestRuntime::new(services)
-                    .probe_outbound_single(&target_tag, &url)
-                    .await
-                {
-                    Ok(latency_ms) => Ok(zero_api::CommandResponse {
-                        accepted: true,
-                        result: Some(serde_json::json!({
-                            "operation_id": operation_id,
-                            "core_instance_id": core_instance_id,
-                            "config_revision": config_revision,
-                            "target_tag": target_tag,
-                            "url": url,
-                            "via": "through_proxy",
-                            "reachable": true,
-                            "terminal_status": "succeeded",
-                            "latency_ms": latency_ms,
-                            "started_at_unix_ms": started_at_unix_ms,
-                            "completed_at_unix_ms": unix_timestamp_ms(),
-                            "duration_ms": started.elapsed().as_millis() as u64,
-                        })),
-                    }),
-                    Err(error) => Ok(zero_api::CommandResponse {
-                        accepted: true,
-                        result: Some(serde_json::json!({
-                            "operation_id": operation_id,
-                            "core_instance_id": core_instance_id,
-                            "config_revision": config_revision,
-                            "target_tag": target_tag,
-                            "url": url,
-                            "via": "through_proxy",
-                            "reachable": false,
-                            "terminal_status": "failed",
-                            "latency_ms": null,
-                            "error_code": "probe_failed",
-                            "error": error.to_string(),
-                            "started_at_unix_ms": started_at_unix_ms,
-                            "completed_at_unix_ms": unix_timestamp_ms(),
-                            "duration_ms": started.elapsed().as_millis() as u64,
-                        })),
-                    }),
+                info!(
+                    source = "core",
+                    method = "diagnostics.probe_outbound",
+                    operation_kind = "diagnostic_outbound",
+                    phase = "started",
+                    operation_id,
+                    core_instance_id,
+                    config_revision,
+                    target_tag,
+                    url,
+                    started_at_unix_ms,
+                    timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                    "outbound diagnostic probe started"
+                );
+                let request = OutboundProbeRequest::parse(&url);
+                let result = match request {
+                    Ok(request) => {
+                        OutboundProbeRuntime::new(services)
+                            .probe_target_tag(&target_tag, &request)
+                            .await
+                    }
+                    Err(error) => Err(error),
+                };
+                let completed_at_unix_ms = unix_timestamp_ms();
+                let duration_ms = started.elapsed().as_millis() as u64;
+                match result {
+                    Ok(latency_ms) => {
+                        info!(
+                            source = "core",
+                            method = "diagnostics.probe_outbound",
+                            operation_kind = "diagnostic_outbound",
+                            phase = "completed",
+                            operation_id,
+                            core_instance_id,
+                            config_revision,
+                            target_tag,
+                            url,
+                            started_at_unix_ms,
+                            completed_at_unix_ms,
+                            duration_ms,
+                            timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                            terminal_status = "succeeded",
+                            reachable = true,
+                            latency_ms,
+                            "outbound diagnostic probe completed"
+                        );
+                        Ok(zero_api::CommandResponse {
+                            accepted: true,
+                            result: Some(serde_json::json!({
+                                "operation_id": operation_id,
+                                "core_instance_id": core_instance_id,
+                                "config_revision": config_revision,
+                                "operation_kind": "diagnostic_outbound",
+                                "target_tag": target_tag,
+                                "url": url,
+                                "via": "through_proxy",
+                                "reachable": true,
+                                "terminal_status": "succeeded",
+                                "latency_ms": latency_ms,
+                                "timeout_ms": OUTBOUND_PROBE_TIMEOUT_MS,
+                                "started_at_unix_ms": started_at_unix_ms,
+                                "completed_at_unix_ms": completed_at_unix_ms,
+                                "duration_ms": duration_ms,
+                            })),
+                        })
+                    }
+                    Err(error) => {
+                        info!(
+                            source = "core",
+                            method = "diagnostics.probe_outbound",
+                            operation_kind = "diagnostic_outbound",
+                            phase = "completed",
+                            operation_id,
+                            core_instance_id,
+                            config_revision,
+                            target_tag,
+                            url,
+                            started_at_unix_ms,
+                            completed_at_unix_ms,
+                            duration_ms,
+                            timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                            terminal_status = "failed",
+                            reachable = false,
+                            error_code = error.code(),
+                            error = error.message(),
+                            "outbound diagnostic probe completed"
+                        );
+                        Ok(zero_api::CommandResponse {
+                            accepted: true,
+                            result: Some(serde_json::json!({
+                                "operation_id": operation_id,
+                                "core_instance_id": core_instance_id,
+                                "config_revision": config_revision,
+                                "operation_kind": "diagnostic_outbound",
+                                "target_tag": target_tag,
+                                "url": url,
+                                "via": "through_proxy",
+                                "reachable": false,
+                                "terminal_status": "failed",
+                                "latency_ms": null,
+                                "timeout_ms": OUTBOUND_PROBE_TIMEOUT_MS,
+                                "error_code": error.code(),
+                                "error": error.message(),
+                                "started_at_unix_ms": started_at_unix_ms,
+                                "completed_at_unix_ms": completed_at_unix_ms,
+                                "duration_ms": duration_ms,
+                            })),
+                        })
+                    }
                 }
             })
         },

--- a/crates/proxy/src/runtime/outbound_probe.rs
+++ b/crates/proxy/src/runtime/outbound_probe.rs
@@ -1,0 +1,216 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use futures_util::future::{BoxFuture, FutureExt, Shared};
+use tokio::sync::Semaphore;
+use tokio::time::timeout;
+use zero_core::{Address, Network, ProtocolType, Session};
+use zero_engine::{EngineError, ResolvedOutbound, TargetId};
+use zero_traits::AsyncSocket;
+
+use crate::protocol_registry::TcpRuntimeServices;
+use crate::transport::extract_tcp_stream;
+
+mod model;
+
+pub(crate) use model::{OutboundProbeError, OutboundProbeRequest};
+
+pub(crate) const MAX_CONCURRENT_OUTBOUND_PROBES: usize = 8;
+pub(crate) const OUTBOUND_PROBE_TIMEOUT_MS: u64 = 5_000;
+
+type SharedProbeFuture = Shared<BoxFuture<'static, Result<u64, OutboundProbeError>>>;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ProbeKey {
+    config_identity: usize,
+    target_tag: String,
+    url: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct OutboundProbeRuntime {
+    services: TcpRuntimeServices,
+    limiter: Arc<Semaphore>,
+    shared_probes: Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>,
+}
+
+impl OutboundProbeRuntime {
+    pub(crate) fn new(services: TcpRuntimeServices) -> Self {
+        Self {
+            services,
+            limiter: global_probe_limiter(),
+            shared_probes: global_shared_probes(),
+        }
+    }
+
+    pub(crate) fn clear_shared(&self) {
+        self.shared_probes
+            .lock()
+            .expect("shared outbound probe lock poisoned")
+            .clear();
+    }
+
+    pub(crate) async fn probe_target_tag(
+        &self,
+        target_tag: &str,
+        request: &OutboundProbeRequest,
+    ) -> Result<u64, OutboundProbeError> {
+        let target_id = self
+            .services
+            .snapshot()
+            .plan()
+            .target_id(target_tag)
+            .ok_or_else(|| {
+                OutboundProbeError::new(
+                    "target_not_found",
+                    format!("outbound probe target `{target_tag}` was not found"),
+                )
+            })?;
+        self.probe_target_shared(target_id, request).await
+    }
+
+    pub(crate) async fn probe_target_shared(
+        &self,
+        target_id: TargetId,
+        request: &OutboundProbeRequest,
+    ) -> Result<u64, OutboundProbeError> {
+        let target_tag = self.target_tag(target_id).ok_or_else(|| {
+            OutboundProbeError::new(
+                "target_resolution_failed",
+                "failed to resolve outbound probe target",
+            )
+        })?;
+        let key = ProbeKey {
+            config_identity: Arc::as_ptr(self.services.snapshot().config()) as usize,
+            target_tag,
+            url: request.url.clone(),
+        };
+        let shared = {
+            let mut probes = self
+                .shared_probes
+                .lock()
+                .expect("shared outbound probe lock poisoned");
+            if let Some(existing) = probes.get(&key) {
+                existing.clone()
+            } else {
+                let runtime = self.clone();
+                let request = request.clone();
+                let future = async move {
+                    let _permit = runtime.limiter.clone().acquire_owned().await.map_err(|_| {
+                        OutboundProbeError::new(
+                            "probe_unavailable",
+                            "outbound probe concurrency limiter is unavailable",
+                        )
+                    })?;
+                    let Some((resolved, _plan)) = runtime.resolve_target_id(target_id) else {
+                        return Err(OutboundProbeError::new(
+                            "target_resolution_failed",
+                            "failed to resolve outbound probe target",
+                        ));
+                    };
+                    runtime.probe_resolved_outbound(resolved, &request).await
+                }
+                .boxed()
+                .shared();
+                probes.insert(key.clone(), future.clone());
+                future
+            }
+        };
+
+        let result = shared.await;
+        self.shared_probes
+            .lock()
+            .expect("shared outbound probe lock poisoned")
+            .remove(&key);
+        result
+    }
+
+    async fn probe_resolved_outbound(
+        &self,
+        resolved: ResolvedOutbound<'static>,
+        request: &OutboundProbeRequest,
+    ) -> Result<u64, OutboundProbeError> {
+        if matches!(resolved, ResolvedOutbound::Relay { .. }) {
+            return Err(OutboundProbeError::new(
+                "unsupported_target",
+                "relay chain cannot be used as an outbound latency probe target",
+            ));
+        }
+
+        match timeout(Duration::from_millis(OUTBOUND_PROBE_TIMEOUT_MS), async {
+            let started_at = Instant::now();
+            let session = Session::new(
+                0,
+                Address::Domain(request.host.clone()),
+                request.port,
+                Network::Tcp,
+                ProtocolType::UNKNOWN,
+            );
+            let outbound = crate::runtime::tcp_dispatch::dispatch_tcp_outbound(
+                self.services.clone(),
+                &session,
+                resolved,
+            )
+            .await
+            .map_err(|failure| failure.error)?;
+            let result = extract_tcp_stream(outbound)?;
+            let mut socket = result.upstream;
+            socket
+                .write_all(request.request.as_bytes())
+                .await
+                .map_err(EngineError::from)?;
+
+            let mut response = [0_u8; 1];
+            let read = socket
+                .read(&mut response)
+                .await
+                .map_err(EngineError::from)?;
+            if read == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "outbound probe target closed without an HTTP response",
+                )
+                .into());
+            }
+            Ok(started_at.elapsed().as_millis() as u64)
+        })
+        .await
+        {
+            Ok(result) => result.map_err(OutboundProbeError::from_engine),
+            Err(_) => Err(OutboundProbeError::new(
+                "probe_timeout",
+                format!("outbound latency probe timed out after {OUTBOUND_PROBE_TIMEOUT_MS} ms"),
+            )),
+        }
+    }
+
+    fn resolve_target_id(
+        &self,
+        target_id: TargetId,
+    ) -> Option<(ResolvedOutbound<'static>, Arc<zero_engine::EnginePlan>)> {
+        self.services
+            .engine()
+            .resolve_target_id_in_snapshot(self.services.snapshot(), target_id)
+    }
+
+    fn target_tag(&self, target_id: TargetId) -> Option<String> {
+        self.services
+            .engine()
+            .target_tag_in_snapshot(self.services.snapshot(), target_id)
+    }
+}
+
+fn global_probe_limiter() -> Arc<Semaphore> {
+    static LIMITER: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    LIMITER
+        .get_or_init(|| Arc::new(Semaphore::new(MAX_CONCURRENT_OUTBOUND_PROBES)))
+        .clone()
+}
+
+fn global_shared_probes() -> Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>> {
+    static PROBES: OnceLock<Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>> = OnceLock::new();
+    PROBES
+        .get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+        .clone()
+}

--- a/crates/proxy/src/runtime/outbound_probe/model.rs
+++ b/crates/proxy/src/runtime/outbound_probe/model.rs
@@ -1,0 +1,147 @@
+use std::fmt;
+
+use zero_core::Error as CoreError;
+use zero_engine::EngineError;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OutboundProbeError {
+    code: &'static str,
+    message: String,
+}
+
+impl OutboundProbeError {
+    pub(super) fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub(super) fn from_engine(error: EngineError) -> Self {
+        let code = match &error {
+            EngineError::Io(error) => match error.kind() {
+                std::io::ErrorKind::TimedOut => "probe_timeout",
+                std::io::ErrorKind::UnexpectedEof => "empty_response",
+                std::io::ErrorKind::ConnectionRefused
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::NotConnected => "connection_failed",
+                _ => "probe_io_failed",
+            },
+            EngineError::Core(CoreError::Unsupported(_))
+            | EngineError::CompiledFeatureDisabled { .. } => "unsupported_target",
+            EngineError::Core(CoreError::Route(_))
+            | EngineError::MissingRouteTarget { .. }
+            | EngineError::SelectorGroupNotFound { .. }
+            | EngineError::SelectorTargetNotFound { .. } => "target_resolution_failed",
+            EngineError::Core(CoreError::Config(_)) | EngineError::Config(_) => "invalid_probe",
+            EngineError::Core(CoreError::Protocol(_)) => "probe_protocol_failed",
+            EngineError::Core(CoreError::Io(_)) => "connection_failed",
+            EngineError::UnhealthyOutbound { .. } => "outbound_unhealthy",
+            _ => "probe_failed",
+        };
+        Self::new(code, normalize_engine_error(&error))
+    }
+}
+
+impl fmt::Display for OutboundProbeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for OutboundProbeError {}
+
+#[derive(Clone)]
+pub(crate) struct OutboundProbeRequest {
+    pub(crate) url: String,
+    pub(super) host: String,
+    pub(super) port: u16,
+    pub(super) request: String,
+}
+
+impl OutboundProbeRequest {
+    pub(crate) fn parse(url: &str) -> Result<Self, OutboundProbeError> {
+        let rest = url.strip_prefix("http://").ok_or_else(|| {
+            OutboundProbeError::new(
+                "invalid_probe_url",
+                "outbound probe currently only supports `http://` URLs",
+            )
+        })?;
+        let (authority, path) = match rest.split_once('/') {
+            Some((authority, suffix)) => (authority, format!("/{suffix}")),
+            None => (rest, "/".to_owned()),
+        };
+        if authority.trim().is_empty() {
+            return Err(OutboundProbeError::new(
+                "invalid_probe_url",
+                "outbound probe URL requires a host",
+            ));
+        }
+
+        let (host, port) = parse_authority(authority)?;
+        let host_header = if port == 80 {
+            authority.to_owned()
+        } else if authority.contains(':') && !authority.starts_with('[') {
+            format!("{host}:{port}")
+        } else {
+            authority.to_owned()
+        };
+        let request =
+            format!("HEAD {path} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n\r\n");
+        Ok(Self {
+            url: url.to_owned(),
+            host,
+            port,
+            request,
+        })
+    }
+}
+
+fn normalize_engine_error(error: &EngineError) -> String {
+    let message = error.to_string();
+    message
+        .strip_prefix("io error: ")
+        .unwrap_or(message.as_str())
+        .to_owned()
+}
+
+fn parse_authority(authority: &str) -> Result<(String, u16), OutboundProbeError> {
+    let invalid_port =
+        || OutboundProbeError::new("invalid_probe_url", "invalid port in outbound probe URL");
+    if let Some(rest) = authority.strip_prefix('[') {
+        let (host, port_part) = rest.split_once(']').ok_or_else(|| {
+            OutboundProbeError::new(
+                "invalid_probe_url",
+                "invalid bracketed host in outbound probe URL",
+            )
+        })?;
+        let port = match port_part.strip_prefix(':') {
+            Some(port) => port.parse::<u16>().map_err(|_| invalid_port())?,
+            None if port_part.is_empty() => 80,
+            _ => {
+                return Err(OutboundProbeError::new(
+                    "invalid_probe_url",
+                    "invalid authority in outbound probe URL",
+                ))
+            }
+        };
+        return Ok((host.to_owned(), port));
+    }
+
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.contains(':') => {
+            Ok((host.to_owned(), port.parse().map_err(|_| invalid_port())?))
+        }
+        _ => Ok((authority.to_owned(), 80)),
+    }
+}

--- a/crates/proxy/tests/probe_outbound_diagnostics.rs
+++ b/crates/proxy/tests/probe_outbound_diagnostics.rs
@@ -1,0 +1,226 @@
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpListener;
+use tracing_subscriber::fmt::MakeWriter;
+use zero_api::{
+    event_type, CommandRequest, CommandService, DiagnosticsProbeOutboundCommand, EventFilter,
+    EventSource,
+};
+use zero_config::RuntimeConfig;
+use zero_engine::EngineHandle;
+use zero_proxy::{Proxy, ProxyHandle};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn diagnostic_outbound_probe_does_not_mutate_urltest_policy() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind probe server");
+    let port = listener.local_addr().expect("probe address").port();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept probe");
+        let mut request = [0_u8; 512];
+        let _ = socket.read(&mut request).await;
+        tokio::io::AsyncWriteExt::write_all(
+            &mut socket,
+            b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n",
+        )
+        .await
+        .expect("write probe response");
+    });
+    let url = format!("http://127.0.0.1:{port}/generate_204");
+    let config = RuntimeConfig::parse(&format!(
+        r#"{{
+            "inbounds": [],
+            "outbounds": [
+                {{ "tag": "node-a", "protocol": {{ "type": "direct" }} }},
+                {{ "tag": "node-b", "protocol": {{ "type": "direct" }} }}
+            ],
+            "outbound_groups": [{{
+                "tag": "auto",
+                "type": "url_test",
+                "outbounds": ["node-a", "node-b"],
+                "url": "{url}",
+                "interval_seconds": 3600,
+                "tolerance_ms": 50
+            }}],
+            "route": {{ "rules": [], "final": {{ "type": "direct" }} }}
+        }}"#
+    ))
+    .expect("parse config");
+    let proxy = Proxy::new(config).expect("build proxy");
+    let engine = proxy.engine().clone();
+    let before = engine.export_status().config.outbound_groups;
+    let subscriber = engine
+        .subscribe(EventFilter {
+            event_types: vec![event_type::POLICY_PROBE_COMPLETED.to_owned()],
+            ..EventFilter::default()
+        })
+        .expect("subscribe to policy probes");
+    let handle = ProxyHandle::new(EngineHandle::new(engine.clone()), proxy);
+
+    let response = tokio::task::block_in_place(|| {
+        handle.execute(CommandRequest::DiagnosticsProbeOutbound(
+            DiagnosticsProbeOutboundCommand {
+                target_tag: "node-a".to_owned(),
+                url: Some(url),
+                operation_id: Some("isolated-diagnostic".to_owned()),
+            },
+        ))
+    })
+    .expect("execute outbound diagnostic");
+    let result = response.result.expect("diagnostic result");
+
+    assert_eq!(result["operation_kind"], "diagnostic_outbound");
+    assert_eq!(result["terminal_status"], "succeeded");
+    assert_eq!(result["reachable"], true);
+    assert_eq!(result["timeout_ms"], 5_000);
+    assert_eq!(engine.export_status().config.outbound_groups, before);
+    assert!(
+        subscriber.try_recv().is_none(),
+        "single-outbound diagnostics must not emit policy.probe.completed"
+    );
+    assert!(!result.to_string().to_ascii_lowercase().contains("urltest"));
+    server.await.expect("probe server task");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn diagnostic_outbound_failure_has_stable_code_and_correlated_core_logs() {
+    let (handle, engine) = diagnostic_handle();
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_writer(BufferMakeWriter {
+            buffer: buffer.clone(),
+        })
+        .with_ansi(false)
+        .with_target(false)
+        .without_time()
+        .compact()
+        .finish();
+
+    let response = tracing::subscriber::with_default(subscriber, || {
+        tokio::task::block_in_place(|| {
+            handle.execute(CommandRequest::DiagnosticsProbeOutbound(
+                DiagnosticsProbeOutboundCommand {
+                    target_tag: "direct".to_owned(),
+                    url: Some("https://example.com/generate_204".to_owned()),
+                    operation_id: Some("diagnostic-log-1".to_owned()),
+                },
+            ))
+        })
+    })
+    .expect("execute invalid outbound diagnostic");
+    let result = response.result.expect("diagnostic result");
+
+    assert_eq!(result["operation_id"], "diagnostic-log-1");
+    assert_eq!(result["core_instance_id"], engine.core_instance_id());
+    assert_eq!(result["operation_kind"], "diagnostic_outbound");
+    assert_eq!(result["terminal_status"], "failed");
+    assert_eq!(result["reachable"], false);
+    assert_eq!(result["error_code"], "invalid_probe_url");
+    assert_eq!(result["timeout_ms"], 5_000);
+    assert!(!result.to_string().to_ascii_lowercase().contains("urltest"));
+
+    let logs = String::from_utf8(buffer.lock().expect("log buffer lock").clone())
+        .expect("utf-8 diagnostic logs");
+    assert!(
+        logs.contains("method=\"diagnostics.probe_outbound\""),
+        "{logs}"
+    );
+    assert!(logs.contains("operation_id=\"diagnostic-log-1\""), "{logs}");
+    assert!(logs.contains("phase=\"started\""), "{logs}");
+    assert!(logs.contains("phase=\"completed\""), "{logs}");
+    assert!(logs.contains("error_code=\"invalid_probe_url\""), "{logs}");
+    assert!(logs.contains("timeout_ms=5000"), "{logs}");
+    assert!(!logs.to_ascii_lowercase().contains("urltest"), "{logs}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn diagnostic_outbound_timeout_is_neutral_and_reports_limit() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind stalled probe server");
+    let port = listener.local_addr().expect("probe address").port();
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept probe");
+        let mut request = [0_u8; 512];
+        let _ = socket.read(&mut request).await;
+        tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+    });
+    let (handle, _) = diagnostic_handle();
+
+    let response = tokio::task::block_in_place(|| {
+        handle.execute(CommandRequest::DiagnosticsProbeOutbound(
+            DiagnosticsProbeOutboundCommand {
+                target_tag: "direct".to_owned(),
+                url: Some(format!("http://127.0.0.1:{port}/stalled")),
+                operation_id: Some("diagnostic-timeout-1".to_owned()),
+            },
+        ))
+    })
+    .expect("execute stalled outbound diagnostic");
+    let result = response.result.expect("diagnostic result");
+
+    assert_eq!(result["terminal_status"], "failed");
+    assert_eq!(result["reachable"], false);
+    assert_eq!(result["error_code"], "probe_timeout");
+    assert_eq!(result["timeout_ms"], 5_000);
+    assert!(result["error"]
+        .as_str()
+        .expect("error message")
+        .contains("outbound latency probe timed out after 5000 ms"));
+    assert!(!result.to_string().to_ascii_lowercase().contains("urltest"));
+    server.abort();
+}
+
+fn diagnostic_handle() -> (ProxyHandle, zero_engine::Engine) {
+    let config = RuntimeConfig::parse(
+        r#"{
+            "inbounds": [],
+            "outbounds": [{ "tag": "direct", "protocol": { "type": "direct" } }],
+            "route": { "rules": [], "final": { "type": "direct" } }
+        }"#,
+    )
+    .expect("parse config");
+    let proxy = Proxy::new(config).expect("build proxy");
+    let engine = proxy.engine().clone();
+    (
+        ProxyHandle::new(EngineHandle::new(engine.clone()), proxy),
+        engine,
+    )
+}
+
+#[derive(Clone)]
+struct BufferMakeWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl<'a> MakeWriter<'a> for BufferMakeWriter {
+    type Writer = BufferWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        BufferWriter {
+            buffer: self.buffer.clone(),
+        }
+    }
+}
+
+struct BufferWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for BufferWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer
+            .lock()
+            .expect("log buffer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/proxy/tests/runtime_boundary.rs
+++ b/crates/proxy/tests/runtime_boundary.rs
@@ -5068,11 +5068,19 @@ fn non_transport_bridge_adapters_offer_claim_time_udp_projection() {
 }
 
 #[test]
-fn urltest_probe_uses_generic_tcp_outbound_dispatch() {
+fn outbound_probe_owns_generic_tcp_dispatch_outside_urltest_policy() {
     let urltest = read(&proxy_src().join("groups/urltest.rs"));
+    let urltest_refresh = read(&proxy_src().join("groups/urltest/refresh.rs"));
+    let outbound_probe = read(&proxy_src().join("runtime/outbound_probe.rs"));
     let runtime_urltest = read(&proxy_src().join("runtime/listeners/urltest.rs"));
     assert!(urltest.contains("struct UrlTestRuntime"));
-    assert!(urltest.contains("dispatch_tcp_outbound("));
+    assert!(urltest.contains("OutboundProbeRuntime"));
+    assert!(urltest_refresh.contains("probe_target_shared("));
+    assert!(!urltest.contains("dispatch_tcp_outbound("));
+    assert!(!urltest_refresh.contains("dispatch_tcp_outbound("));
+    assert!(outbound_probe.contains("dispatch_tcp_outbound("));
+    assert!(!outbound_probe.contains("crate::groups"));
+    assert!(!outbound_probe.to_ascii_lowercase().contains("urltest"));
     assert!(!urltest.contains("use crate::runtime::Proxy"));
     assert!(!urltest.contains("from_proxy("));
     assert!(!urltest.contains("prepare_tcp_candidate("));

--- a/docs/control-plane/01-control-plane-roadmap.md
+++ b/docs/control-plane/01-control-plane-roadmap.md
@@ -284,7 +284,7 @@
 ### 路线图之外已实现
 
 - `mode.set` 命令（rule / global / direct 运行时切换）
-- `diagnostics.*` 三件套（probe_target / dns_lookup / trace_route）
+- `diagnostics.*`（probe_target / probe_outbound / dns_lookup / trace_route）
 - `tun.start` / `tun.stop` 命令（通过 ProxyHandle 拦截转发）
 - `ipc.connected` / `ipc.disconnected` 生命周期事件
 - HTTP 限流（Query 100/s、Command 10/s、SSE 5 并发）

--- a/docs/control-plane/02-api-endpoints.md
+++ b/docs/control-plane/02-api-endpoints.md
@@ -77,6 +77,7 @@ HTTP 和 IPC 响应共享 `zero_api::ApiResponse` 信封：
 | `tun.start` | 启动 TUN |
 | `tun.stop` | 停止 TUN |
 | `diagnostics.probe_target` | 探测目标 TCP 端点 |
+| `diagnostics.probe_outbound` | 经指定出站执行 HTTP 延迟探测，不修改 URLTest 策略状态 |
 | `diagnostics.dns_lookup` | 解析主机名 |
 | `diagnostics.trace_route` | 追踪目标的路由决策 |
 

--- a/docs/control-plane/05-auth-and-permissions.md
+++ b/docs/control-plane/05-auth-and-permissions.md
@@ -81,6 +81,7 @@ impl Permission {
 | config.validate | | | ✓ | ✓ |
 | config.apply | | | | ✓ |
 | diagnostics.probe_target | | | | ✓ |
+| diagnostics.probe_outbound | | | | ✓ |
 | diagnostics.dns_lookup | | | | ✓ |
 | diagnostics.trace_route | | | | ✓ |
 | mode.set | | | | ✓ |

--- a/docs/project/api.md
+++ b/docs/project/api.md
@@ -365,6 +365,8 @@ HTTP adapter 将这些能力暴露在 `/api/v1/*` 命名空间下，IPC 和 CLI 
   - 已实现。触发 `url_test` 立即探测
 - `diagnostics.probe_target`
   - 已实现。对指定出站做 TCP 可达性探测
+- `diagnostics.probe_outbound`
+  - 已实现。经指定出站执行中性的 HTTP 延迟探测，返回稳定错误码和实际超时上限，不修改 `url_test` 策略状态
 - `diagnostics.dns_lookup`
   - 已实现。解析域名
 - `diagnostics.trace_route`
@@ -399,6 +401,8 @@ HTTP adapter 将这些能力暴露在 `/api/v1/*` 命名空间下，IPC 和 CLI 
 
 - `diagnostics.probe_target`
   - 已实现。对指定出站做 TCP 可达性探测
+- `diagnostics.probe_outbound`
+  - 已实现。经指定出站执行中性的 HTTP 延迟探测；不触发 `url_test` 选路或策略事件
 - `diagnostics.dns_lookup`
   - 已实现。解析域名
 - `diagnostics.trace_route`

--- a/docs/project/control-plane-generation.md
+++ b/docs/project/control-plane-generation.md
@@ -58,6 +58,28 @@ accept an optional `operation_id` and return it with the instance, captured
 configuration revision, timestamps, terminal status, and result/error facts.
 They do not emit a separate completion event.
 
+`diagnostics.probe_outbound` is a neutral, synchronous single-outbound latency
+operation. It resolves and probes the requested target against one captured
+runtime snapshot, returns `operation_kind: diagnostic_outbound`, and reports
+the enforced limit as `timeout_ms`. It shares only the bounded HTTP probe
+executor with URLTest. It does not run URLTest policy logic, change a group's
+selected member or member health, or emit `policy.probe.completed`.
+
+Failures use stable `error_code` values. Callers should branch on the code and
+treat `error` as diagnostic text. The current codes are `invalid_probe_url`,
+`target_not_found`, `target_resolution_failed`, `unsupported_target`,
+`probe_unavailable`, `probe_timeout`, `empty_response`, `connection_failed`,
+`probe_io_failed`, `invalid_probe`, `probe_protocol_failed`,
+`outbound_unhealthy`, and the forward-compatible fallback `probe_failed`.
+
+The core writes structured `started` and terminal `completed` records for this
+operation. Both records carry `source=core`, method, operation kind,
+`operation_id`, `core_instance_id`, captured `config_revision`, target, URL,
+start time, and `timeout_ms`. The terminal record also carries completion time,
+duration, reachability, terminal status, latency or stable error code, and
+diagnostic error text. These are native core observations; controllers do not
+need to synthesize completion from request logs.
+
 ## Reconnect reconciliation
 
 After reconnect, a client should:

--- a/docs/project/urltest-selection.md
+++ b/docs/project/urltest-selection.md
@@ -46,3 +46,10 @@ current and best latency, tolerance, switch flag, and one stable reason:
 Changing `tolerance_ms` through configuration reload takes effect with the new
 committed configuration generation. Manual and scheduled cycles use the same
 selection function.
+
+URLTest and `diagnostics.probe_outbound` share the neutral, process-bounded
+outbound HTTP probe executor, but not policy state. Only a URLTest cycle applies
+selection tolerance, updates member health/selection snapshots, and emits
+`policy.probe.completed`. A single-outbound diagnostic is read-only with
+respect to every URLTest group. Native completion logs distinguish the paths as
+`operation_kind=policy_urltest` and `operation_kind=diagnostic_outbound`.

--- a/src/http_adapter/sse.rs
+++ b/src/http_adapter/sse.rs
@@ -65,7 +65,7 @@ pub async fn run_sse_stream(
         let mut last_event_at = std::time::Instant::now();
         loop {
             if let Some(event) = subscriber.try_recv() {
-                if event_tx.send(SseItem::Event(event)).is_err() {
+                if event_tx.send(SseItem::Event(Box::new(event))).is_err() {
                     break;
                 }
                 last_event_at = std::time::Instant::now();
@@ -88,7 +88,7 @@ pub async fn run_sse_stream(
                 };
                 match item {
                     SseItem::Event(event) => {
-                        if write_sse_event(&mut stream, &event).await.is_err() {
+                        if write_sse_event(&mut stream, event.as_ref()).await.is_err() {
                             break;
                         }
                     }
@@ -107,6 +107,6 @@ pub async fn run_sse_stream(
 }
 
 enum SseItem {
-    Event(RawApiEvent),
+    Event(Box<RawApiEvent>),
     Heartbeat,
 }


### PR DESCRIPTION
## Summary

- extract HTTP-through-outbound latency probing from `UrlTestRuntime` into a neutral, process-bounded runtime shared by diagnostics and URLTest
- make `diagnostics.probe_outbound` return operation-neutral wording, stable `error_code`, `timeout_ms`, and `operation_kind=diagnostic_outbound`
- emit native core start/completion tracing correlated by operation ID, instance, and captured config revision
- preserve URLTest policy ownership and legacy policy error codes; single-outbound diagnostics never mutate URLTest snapshots or emit `policy.probe.completed`
- document the diagnostic/policy boundary and API surface
- box the existing SSE queue event payload to satisfy Rust 1.97 `large_enum_variant` under CI's `-D warnings`, without changing wire behavior

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- pre-commit: `cargo clippy --workspace --all-targets --features full`
- focused probe and architecture tests: 187 passed

Closes #8