### PR TITLE
fix(runtime): fail fast when proxy listeners terminate

### DIFF
--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -107,6 +107,7 @@ zero-stack = { path = "../stack" }
 zero-transport = { path = "../transport" }
 
 [dev-dependencies]
+quinn = { version = "0.11", default-features = false, features = ["rustls-ring", "runtime-tokio"] }
 tempfile.workspace = true
 rcgen = "0.14"
 rustls = { workspace = true }

--- a/crates/proxy/src/runtime/listener_loop.rs
+++ b/crates/proxy/src/runtime/listener_loop.rs
@@ -9,6 +9,8 @@ mod tests;
 pub(crate) use quic::{run_logged_quic_stream_listener_loop, LoggedQuicStreamListenerRequest};
 #[cfg(feature = "authenticated-quic-inbound-runtime")]
 pub(crate) use quic::{run_quic_listener_loop, QuicListenerLoopRequest};
+#[cfg(all(test, feature = "transport_quic"))]
+pub(crate) use quic::{run_quic_stream_listener_loop, QuicStreamListenerLoopRequest};
 pub(crate) use system::{run_system_tcp_stack_loop, SystemTcpStackLoopRequest};
 pub(crate) use tcp::{run_logged_tcp_socket_listener_loop, LoggedTcpSocketListenerRequest};
 #[cfg(test)]

--- a/crates/proxy/src/runtime/listener_loop/quic.rs
+++ b/crates/proxy/src/runtime/listener_loop/quic.rs
@@ -6,3 +6,5 @@ mod stream;
 #[cfg(feature = "authenticated-quic-inbound-runtime")]
 pub(crate) use connection::{run_quic_listener_loop, QuicListenerLoopRequest};
 pub(crate) use logged::{run_logged_quic_stream_listener_loop, LoggedQuicStreamListenerRequest};
+#[cfg(test)]
+pub(crate) use stream::{run_quic_stream_listener_loop, QuicStreamListenerLoopRequest};

--- a/crates/proxy/src/runtime/listener_loop/quic/connection.rs
+++ b/crates/proxy/src/runtime/listener_loop/quic/connection.rs
@@ -1,8 +1,9 @@
 use std::future::Future;
+use std::io;
 
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use zero_engine::EngineError;
 
 use crate::runtime::route_runtime::{InboundRouteRuntime, InboundRouteRuntimeFactory};
@@ -34,46 +35,97 @@ where
     info!(
         inbound_tag = %runtime_factory.inbound_tag(),
         protocol = protocol_name,
+        transport = "quic",
         "inbound listener ready"
     );
 
-    loop {
+    let stop_reason = loop {
         tokio::select! {
             changed = shutdown.changed() => {
                 match changed {
-                    Ok(()) if *shutdown.borrow() => break,
+                    Ok(()) if *shutdown.borrow() => break "shutdown_signal",
                     Ok(()) => {}
-                    Err(_) => break,
+                    Err(error) => {
+                        warn!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            protocol = protocol_name,
+                            transport = "quic",
+                            reason = "shutdown_channel_closed",
+                            error = %error,
+                            "inbound listener shutdown channel closed"
+                        );
+                        break "shutdown_channel_closed";
+                    }
                 }
             }
-            accept_result = listener.accept_connection() => {
-                match accept_result {
-                    Ok(conn) => {
-                        let runtime = runtime_factory.for_connection(None);
-                        let handler = handler.clone();
-                        connections.spawn(handler(runtime, conn));
+            incoming = listener.accept_incoming() => {
+                let Some(incoming) = incoming else {
+                    error!(
+                        inbound_tag = %runtime_factory.inbound_tag(),
+                        protocol = protocol_name,
+                        transport = "quic",
+                        reason = "listener_endpoint_closed",
+                        "inbound listener endpoint closed unexpectedly"
+                    );
+                    connections.abort_all();
+                    while connections.join_next().await.is_some() {}
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionAborted,
+                        format!(
+                            "{protocol_name} QUIC inbound endpoint closed for {}",
+                            runtime_factory.inbound_tag()
+                        ),
+                    )
+                    .into());
+                };
+                let remote_address = incoming.remote_address();
+                let runtime = runtime_factory.for_connection(None);
+                let handler = handler.clone();
+                let inbound_tag = runtime_factory.inbound_tag().to_owned();
+                connections.spawn(async move {
+                    match crate::transport::QuicInbound::establish_incoming(incoming).await {
+                        Ok(connection) => handler(runtime, connection).await,
+                        Err(connection_error) => error!(
+                            inbound_tag = %inbound_tag,
+                            protocol = protocol_name,
+                            transport = "quic",
+                            remote_address = %remote_address,
+                            reason = "connection_accept_error",
+                            error = %connection_error,
+                            "inbound QUIC connection handshake failed"
+                        ),
                     }
-                    Err(error) => {
-                        error!(error = %error, protocol = protocol_name, "inbound accept error");
-                        break;
-                    }
-                }
+                });
             }
             result = connections.join_next(), if !connections.is_empty() => {
                 if let Some(Err(error)) = result {
                     if !error.is_cancelled() {
-                        error!(error = %error, protocol = protocol_name, "inbound connection task panicked");
+                        error!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            error = %error,
+                            protocol = protocol_name,
+                            transport = "quic",
+                            reason = "connection_task_panic",
+                            "inbound connection task panicked"
+                        );
                     }
                 }
             }
         }
-    }
+    };
 
     connections.abort_all();
     while let Some(result) = connections.join_next().await {
         if let Err(error) = result {
             if !error.is_cancelled() {
-                error!(error = %error, protocol = protocol_name, "inbound connection task panicked during shutdown");
+                error!(
+                    inbound_tag = %runtime_factory.inbound_tag(),
+                    error = %error,
+                    protocol = protocol_name,
+                    transport = "quic",
+                    reason = "connection_task_panic_during_shutdown",
+                    "inbound connection task panicked during shutdown"
+                );
             }
         }
     }
@@ -81,6 +133,8 @@ where
     info!(
         inbound_tag = %runtime_factory.inbound_tag(),
         protocol = protocol_name,
+        transport = "quic",
+        reason = stop_reason,
         "inbound listener stopped"
     );
     Ok(())

--- a/crates/proxy/src/runtime/listener_loop/quic/stream.rs
+++ b/crates/proxy/src/runtime/listener_loop/quic/stream.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use zero_engine::EngineError;
 
 use crate::runtime::route_runtime::{InboundRouteRuntime, InboundRouteRuntimeFactory};
@@ -39,13 +39,23 @@ where
         "inbound listener ready"
     );
 
-    loop {
+    let stop_reason = loop {
         tokio::select! {
             changed = shutdown.changed() => {
                 match changed {
-                    Ok(()) if *shutdown.borrow() => break,
+                    Ok(()) if *shutdown.borrow() => break "shutdown_signal",
                     Ok(()) => {}
-                    Err(_) => break,
+                    Err(error) => {
+                        warn!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            protocol = protocol_name,
+                            transport = "quic",
+                            reason = "shutdown_channel_closed",
+                            error = %error,
+                            "inbound listener shutdown channel closed"
+                        );
+                        break "shutdown_channel_closed";
+                    }
                 }
             }
             accept_result = listener.accept() => {
@@ -61,6 +71,7 @@ where
                             error = %error,
                             protocol = protocol_name,
                             transport = "quic",
+                            reason = "accept_error",
                             "inbound accept error"
                         );
                         connections.abort_all();
@@ -68,8 +79,11 @@ where
                             if let Err(join_error) = result {
                                 if !join_error.is_cancelled() {
                                     error!(
+                                        inbound_tag = %runtime_factory.inbound_tag(),
                                         error = %join_error,
                                         protocol = protocol_name,
+                                        transport = "quic",
+                                        reason = "connection_task_panic_during_failed_listener_cleanup",
                                         "inbound connection task panicked during failed listener cleanup"
                                     );
                                 }
@@ -86,18 +100,32 @@ where
             result = connections.join_next(), if !connections.is_empty() => {
                 if let Some(Err(error)) = result {
                     if !error.is_cancelled() {
-                        error!(error = %error, protocol = protocol_name, "inbound connection task panicked");
+                        error!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            error = %error,
+                            protocol = protocol_name,
+                            transport = "quic",
+                            reason = "connection_task_panic",
+                            "inbound connection task panicked"
+                        );
                     }
                 }
             }
         }
-    }
+    };
 
     connections.abort_all();
     while let Some(result) = connections.join_next().await {
         if let Err(error) = result {
             if !error.is_cancelled() {
-                error!(error = %error, protocol = protocol_name, "inbound connection task panicked during shutdown");
+                error!(
+                    inbound_tag = %runtime_factory.inbound_tag(),
+                    error = %error,
+                    protocol = protocol_name,
+                    transport = "quic",
+                    reason = "connection_task_panic_during_shutdown",
+                    "inbound connection task panicked during shutdown"
+                );
             }
         }
     }
@@ -106,6 +134,7 @@ where
         inbound_tag = %runtime_factory.inbound_tag(),
         protocol = protocol_name,
         transport = "quic",
+        reason = stop_reason,
         "inbound listener stopped"
     );
     Ok(())

--- a/crates/proxy/src/runtime/listener_loop/quic/stream.rs
+++ b/crates/proxy/src/runtime/listener_loop/quic/stream.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::io;
 
 use tokio::sync::watch;
 use tokio::task::JoinSet;
@@ -55,8 +56,30 @@ where
                         connections.spawn(handler(runtime, stream));
                     }
                     Err(error) => {
-                        error!(error = %error, protocol = protocol_name, "inbound accept error");
-                        break;
+                        error!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            error = %error,
+                            protocol = protocol_name,
+                            transport = "quic",
+                            "inbound accept error"
+                        );
+                        connections.abort_all();
+                        while let Some(result) = connections.join_next().await {
+                            if let Err(join_error) = result {
+                                if !join_error.is_cancelled() {
+                                    error!(
+                                        error = %join_error,
+                                        protocol = protocol_name,
+                                        "inbound connection task panicked during failed listener cleanup"
+                                    );
+                                }
+                            }
+                        }
+                        return Err(io::Error::other(format!(
+                            "{protocol_name} QUIC inbound accept failed for {}: {error}",
+                            runtime_factory.inbound_tag()
+                        ))
+                        .into());
                     }
                 }
             }

--- a/crates/proxy/src/runtime/listener_loop/quic/stream.rs
+++ b/crates/proxy/src/runtime/listener_loop/quic/stream.rs
@@ -58,44 +58,44 @@ where
                     }
                 }
             }
-            accept_result = listener.accept() => {
-                match accept_result {
-                    Ok(stream) => {
-                        let runtime = runtime_factory.for_connection(None);
-                        let handler = handler.clone();
-                        connections.spawn(handler(runtime, stream));
-                    }
-                    Err(error) => {
-                        error!(
-                            inbound_tag = %runtime_factory.inbound_tag(),
-                            error = %error,
+            incoming = listener.accept_incoming() => {
+                let Some(incoming) = incoming else {
+                    error!(
+                        inbound_tag = %runtime_factory.inbound_tag(),
+                        protocol = protocol_name,
+                        transport = "quic",
+                        reason = "listener_endpoint_closed",
+                        "inbound listener endpoint closed unexpectedly"
+                    );
+                    connections.abort_all();
+                    while connections.join_next().await.is_some() {}
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionAborted,
+                        format!(
+                            "{protocol_name} QUIC inbound endpoint closed for {}",
+                            runtime_factory.inbound_tag()
+                        ),
+                    )
+                    .into());
+                };
+                let remote_address = incoming.remote_address();
+                let runtime = runtime_factory.for_connection(None);
+                let handler = handler.clone();
+                let inbound_tag = runtime_factory.inbound_tag().to_owned();
+                connections.spawn(async move {
+                    match crate::transport::QuicInbound::establish_incoming_stream(incoming).await {
+                        Ok(stream) => handler(runtime, stream).await,
+                        Err(connection_error) => error!(
+                            inbound_tag = %inbound_tag,
                             protocol = protocol_name,
                             transport = "quic",
-                            reason = "accept_error",
-                            "inbound accept error"
-                        );
-                        connections.abort_all();
-                        while let Some(result) = connections.join_next().await {
-                            if let Err(join_error) = result {
-                                if !join_error.is_cancelled() {
-                                    error!(
-                                        inbound_tag = %runtime_factory.inbound_tag(),
-                                        error = %join_error,
-                                        protocol = protocol_name,
-                                        transport = "quic",
-                                        reason = "connection_task_panic_during_failed_listener_cleanup",
-                                        "inbound connection task panicked during failed listener cleanup"
-                                    );
-                                }
-                            }
-                        }
-                        return Err(io::Error::other(format!(
-                            "{protocol_name} QUIC inbound accept failed for {}: {error}",
-                            runtime_factory.inbound_tag()
-                        ))
-                        .into());
+                            remote_address = %remote_address,
+                            reason = "connection_accept_error",
+                            error = %connection_error,
+                            "inbound QUIC connection failed before stream dispatch"
+                        ),
                     }
-                }
+                });
             }
             result = connections.join_next(), if !connections.is_empty() => {
                 if let Some(Err(error)) = result {

--- a/crates/proxy/src/runtime/listener_loop/system.rs
+++ b/crates/proxy/src/runtime/listener_loop/system.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use tokio::net::TcpStream;
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use zero_stack::SystemTcpStack;
 use zero_traits::TcpStack;
 
@@ -33,18 +33,30 @@ where
     } = request;
     let mut connections = JoinSet::new();
 
-    loop {
+    let stop_reason = loop {
         tokio::select! {
             biased;
 
             changed = shutdown.changed() => {
                 match changed {
                     Ok(()) if *shutdown.borrow() => {
-                        info!(inbound_tag = %runtime_factory.inbound_tag(), "system inbound shutdown");
-                        break;
+                        info!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            reason = "shutdown_signal",
+                            "system inbound shutdown"
+                        );
+                        break "shutdown_signal";
                     }
                     Ok(()) => {}
-                    Err(_) => break,
+                    Err(error) => {
+                        warn!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            reason = "shutdown_channel_closed",
+                            error = %error,
+                            "system inbound shutdown channel closed"
+                        );
+                        break "shutdown_channel_closed";
+                    }
                 }
             }
 
@@ -57,26 +69,49 @@ where
                         let handler = handler.clone();
                         connections.spawn(handler(runtime, stream, destination));
                     }
-                    None => break,
+                    None => {
+                        warn!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            reason = "accept_source_closed",
+                            "system inbound accept source closed"
+                        );
+                        break "accept_source_closed";
+                    }
                 }
             }
 
             result = connections.join_next(), if !connections.is_empty() => {
                 if let Some(Err(error)) = result {
                     if !error.is_cancelled() {
-                        error!(error = %error, "system connection task panicked");
+                        error!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            reason = "connection_task_panic",
+                            error = %error,
+                            "system connection task panicked"
+                        );
                     }
                 }
             }
         }
-    }
+    };
 
     connections.abort_all();
     while let Some(result) = connections.join_next().await {
         if let Err(error) = result {
             if !error.is_cancelled() {
-                error!(error = %error, "system connection task panicked during shutdown");
+                error!(
+                    inbound_tag = %runtime_factory.inbound_tag(),
+                    reason = "connection_task_panic_during_shutdown",
+                    error = %error,
+                    "system connection task panicked during shutdown"
+                );
             }
         }
     }
+
+    info!(
+        inbound_tag = %runtime_factory.inbound_tag(),
+        reason = stop_reason,
+        "system inbound stopped"
+    );
 }

--- a/crates/proxy/src/runtime/listener_loop/tcp/connection.rs
+++ b/crates/proxy/src/runtime/listener_loop/tcp/connection.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use zero_engine::EngineError;
 
 use crate::runtime::route_runtime::{InboundRouteRuntime, InboundRouteRuntimeFactory};
@@ -39,17 +39,29 @@ where
     info!(
         inbound_tag = %runtime_factory.inbound_tag(),
         protocol = protocol_name,
+        transport = "tcp",
         listen = %local_addr,
         "inbound listener ready"
     );
 
-    loop {
+    let stop_reason = loop {
         tokio::select! {
             changed = shutdown.changed() => {
                 match changed {
-                    Ok(()) if *shutdown.borrow() => break,
+                    Ok(()) if *shutdown.borrow() => break "shutdown_signal",
                     Ok(()) => {}
-                    Err(_) => break,
+                    Err(error) => {
+                        warn!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            protocol = protocol_name,
+                            transport = "tcp",
+                            listen = %local_addr,
+                            reason = "shutdown_channel_closed",
+                            error = %error,
+                            "inbound listener shutdown channel closed"
+                        );
+                        break "shutdown_channel_closed";
+                    }
                 }
             }
             accept_result = listener.accept() => {
@@ -62,25 +74,49 @@ where
                         connections.spawn(handler(runtime, stream));
                     }
                     Err(error) => {
-                        error!(error = %error, protocol = protocol_name, "inbound accept error");
+                        error!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            protocol = protocol_name,
+                            transport = "tcp",
+                            listen = %local_addr,
+                            reason = "accept_error",
+                            error = %error,
+                            "inbound accept error"
+                        );
                     }
                 }
             }
             result = connections.join_next(), if !connections.is_empty() => {
                 if let Some(Err(error)) = result {
                     if !error.is_cancelled() {
-                        error!(error = %error, protocol = protocol_name, "inbound connection task panicked");
+                        error!(
+                            inbound_tag = %runtime_factory.inbound_tag(),
+                            protocol = protocol_name,
+                            transport = "tcp",
+                            listen = %local_addr,
+                            reason = "connection_task_panic",
+                            error = %error,
+                            "inbound connection task panicked"
+                        );
                     }
                 }
             }
         }
-    }
+    };
 
     connections.abort_all();
     while let Some(result) = connections.join_next().await {
         if let Err(error) = result {
             if !error.is_cancelled() {
-                error!(error = %error, protocol = protocol_name, "inbound connection task panicked during shutdown");
+                error!(
+                    inbound_tag = %runtime_factory.inbound_tag(),
+                    protocol = protocol_name,
+                    transport = "tcp",
+                    listen = %local_addr,
+                    reason = "connection_task_panic_during_shutdown",
+                    error = %error,
+                    "inbound connection task panicked during shutdown"
+                );
             }
         }
     }
@@ -88,7 +124,9 @@ where
     info!(
         inbound_tag = %runtime_factory.inbound_tag(),
         protocol = protocol_name,
+        transport = "tcp",
         listen = %local_addr,
+        reason = stop_reason,
         "inbound listener stopped"
     );
     Ok(())

--- a/crates/proxy/src/runtime/listener_loop/tests.rs
+++ b/crates/proxy/src/runtime/listener_loop/tests.rs
@@ -4,15 +4,26 @@ use std::time::Duration;
 use tokio::sync::{watch, Notify};
 use zero_config::RuntimeConfig;
 
+#[cfg(feature = "authenticated-quic-inbound-runtime")]
+use super::{run_quic_listener_loop, QuicListenerLoopRequest};
+#[cfg(feature = "transport_quic")]
+use super::{run_quic_stream_listener_loop, QuicStreamListenerLoopRequest};
 use super::{run_tcp_listener_loop, TcpListenerLoopRequest};
 use crate::runtime::route_runtime::{InboundRouteRuntimeFactory, SharedIngressRuntimeServices};
 
-#[tokio::test]
-async fn tcp_listener_accepts_connection_and_stops_on_shutdown() {
+fn test_runtime_factory(inbound_tag: &str) -> InboundRouteRuntimeFactory {
     let config =
         RuntimeConfig::parse(r#"{ "route": { "rules": [], "final": { "type": "direct" } } }"#)
             .expect("minimal runtime config");
     let proxy = crate::runtime::Proxy::new(config).expect("minimal proxy");
+    InboundRouteRuntimeFactory::new(
+        SharedIngressRuntimeServices::new(proxy.tcp_runtime_services()),
+        inbound_tag.to_owned(),
+    )
+}
+
+#[tokio::test]
+async fn tcp_listener_accepts_connection_and_stops_on_shutdown() {
     let listener = zero_platform_tokio::TokioListener::bind("127.0.0.1:0")
         .await
         .expect("test listener");
@@ -25,10 +36,7 @@ async fn tcp_listener_accepts_connection_and_stops_on_shutdown() {
         let observations = observations.clone();
         tokio::spawn(async move {
             run_tcp_listener_loop(TcpListenerLoopRequest {
-                runtime_factory: InboundRouteRuntimeFactory::new(
-                    SharedIngressRuntimeServices::new(proxy.tcp_runtime_services()),
-                    "listener-test".to_owned(),
-                ),
+                runtime_factory: test_runtime_factory("listener-test"),
                 protocol_name: "test",
                 listener,
                 shutdown: shutdown_rx,
@@ -67,4 +75,167 @@ async fn tcp_listener_accepts_connection_and_stops_on_shutdown() {
     assert_eq!(observations.len(), 1);
     assert_eq!(observations[0].0, "listener-test");
     assert!(observations[0].1.is_some());
+}
+
+#[cfg(feature = "transport_quic")]
+struct TestQuicMaterial {
+    _directory: tempfile::TempDir,
+    cert_path: std::path::PathBuf,
+    key_path: std::path::PathBuf,
+    certificate: rustls::pki_types::CertificateDer<'static>,
+}
+
+#[cfg(feature = "transport_quic")]
+fn test_quic_material() -> TestQuicMaterial {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
+        .expect("generate QUIC certificate");
+    let directory = tempfile::tempdir().expect("create QUIC certificate directory");
+    let cert_path = directory.path().join("server.crt");
+    let key_path = directory.path().join("server.key");
+    std::fs::write(&cert_path, certified.cert.pem()).expect("write QUIC certificate");
+    std::fs::write(&key_path, certified.signing_key.serialize_pem())
+        .expect("write QUIC private key");
+    TestQuicMaterial {
+        _directory: directory,
+        cert_path,
+        key_path,
+        certificate: certified.cert.der().clone(),
+    }
+}
+
+#[cfg(feature = "transport_quic")]
+fn quic_client_endpoint(
+    certificate: rustls::pki_types::CertificateDer<'static>,
+    alpn: &[u8],
+) -> quinn::Endpoint {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.add(certificate).expect("trust QUIC test certificate");
+    let mut tls = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    tls.alpn_protocols = vec![alpn.to_vec()];
+    let crypto =
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls).expect("build QUIC client crypto");
+    let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse().expect("client bind address"))
+        .expect("create QUIC client endpoint");
+    endpoint.set_default_client_config(quinn::ClientConfig::new(Arc::new(crypto)));
+    endpoint
+}
+
+#[cfg(feature = "transport_quic")]
+async fn bind_quic_listener(
+    material: &TestQuicMaterial,
+) -> (zero_transport::quic::QuicInbound, std::net::SocketAddr) {
+    let listener = zero_transport::quic::QuicInbound::bind(
+        "127.0.0.1:0",
+        material.cert_path.to_str().expect("certificate path"),
+        material.key_path.to_str().expect("private key path"),
+        None,
+        &[b"zero-listener-test".to_vec()],
+    )
+    .await
+    .expect("bind QUIC listener");
+    let address = listener.local_addr().expect("QUIC listener address");
+    (listener, address)
+}
+
+#[cfg(feature = "transport_quic")]
+#[tokio::test]
+async fn quic_stream_listener_survives_client_close_before_first_stream() {
+    let material = test_quic_material();
+    let (listener, listen_address) = bind_quic_listener(&material).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let accepted = Arc::new(Notify::new());
+    let task = {
+        let accepted = accepted.clone();
+        tokio::spawn(async move {
+            run_quic_stream_listener_loop(QuicStreamListenerLoopRequest {
+                runtime_factory: test_runtime_factory("quic-stream-test"),
+                protocol_name: "test",
+                listener,
+                shutdown: shutdown_rx,
+                handler: move |_, _| {
+                    let accepted = accepted.clone();
+                    async move { accepted.notify_one() }
+                },
+            })
+            .await
+        })
+    };
+
+    let client = quic_client_endpoint(material.certificate.clone(), b"zero-listener-test");
+    let abandoned = client
+        .connect(listen_address, "localhost")
+        .expect("start abandoned QUIC connection")
+        .await
+        .expect("complete abandoned QUIC handshake");
+    abandoned.close(quinn::VarInt::from_u32(0), b"close-before-stream");
+
+    let connection = client
+        .connect(listen_address, "localhost")
+        .expect("start valid QUIC connection")
+        .await
+        .expect("complete valid QUIC handshake");
+    let (mut send, _receive) = connection.open_bi().await.expect("open QUIC stream");
+    send.write_all(b"x").await.expect("announce QUIC stream");
+    tokio::time::timeout(Duration::from_secs(2), accepted.notified())
+        .await
+        .expect("listener stopped after one client abandoned its connection");
+
+    shutdown_tx.send(true).expect("send QUIC listener shutdown");
+    tokio::time::timeout(Duration::from_secs(2), task)
+        .await
+        .expect("QUIC stream listener did not stop")
+        .expect("QUIC stream listener task panicked")
+        .expect("QUIC stream listener failed");
+}
+
+#[cfg(feature = "authenticated-quic-inbound-runtime")]
+#[tokio::test]
+async fn quic_connection_listener_survives_failed_client_handshake() {
+    let material = test_quic_material();
+    let (listener, listen_address) = bind_quic_listener(&material).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let accepted = Arc::new(Notify::new());
+    let task = {
+        let accepted = accepted.clone();
+        tokio::spawn(async move {
+            run_quic_listener_loop(QuicListenerLoopRequest {
+                runtime_factory: test_runtime_factory("quic-connection-test"),
+                protocol_name: "test",
+                listener,
+                shutdown: shutdown_rx,
+                handler: move |_, _| {
+                    let accepted = accepted.clone();
+                    async move { accepted.notify_one() }
+                },
+            })
+            .await
+        })
+    };
+
+    let incompatible = quic_client_endpoint(material.certificate.clone(), b"wrong-alpn");
+    let failed = incompatible
+        .connect(listen_address, "localhost")
+        .expect("start incompatible QUIC connection")
+        .await;
+    assert!(failed.is_err(), "incompatible ALPN must fail the handshake");
+
+    let client = quic_client_endpoint(material.certificate.clone(), b"zero-listener-test");
+    let _connection = client
+        .connect(listen_address, "localhost")
+        .expect("start valid QUIC connection")
+        .await
+        .expect("complete valid QUIC handshake");
+    tokio::time::timeout(Duration::from_secs(2), accepted.notified())
+        .await
+        .expect("listener stopped after one client failed its handshake");
+
+    shutdown_tx.send(true).expect("send QUIC listener shutdown");
+    tokio::time::timeout(Duration::from_secs(2), task)
+        .await
+        .expect("QUIC connection listener did not stop")
+        .expect("QUIC connection listener task panicked")
+        .expect("QUIC connection listener failed");
 }

--- a/crates/proxy/src/runtime/listeners/inbound.rs
+++ b/crates/proxy/src/runtime/listeners/inbound.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use zero_config::{InboundConfig, RuntimeConfig};
 use zero_engine::EngineError;
 
@@ -37,14 +37,53 @@ pub(in crate::runtime) fn spawn_inbound_listener(
     let operation = protocols
         .prepare_inbound_listener(inbound.clone(), source_dir)
         .map_err(|error| {
-            warn!(tag = %inbound.tag, error = %error, "inbound listener adapter preparation failed");
+            warn!(
+                inbound_tag = %inbound.tag,
+                protocol = inbound.protocol.protocol_name(),
+                listen_address = %inbound.listen.address,
+                listen_port = inbound.listen.port,
+                reason = "adapter_prepare_error",
+                error = %error,
+                "inbound listener adapter preparation failed"
+            );
             error
         })?;
-    listeners.spawn(operation.execute(
-        runtime_factory.for_inbound(inbound.tag.clone()),
-        bound,
-        shutdown_rx,
-    ));
+    let inbound_tag = inbound.tag.clone();
+    let protocol = inbound.protocol.protocol_name();
+    let listen_address = inbound.listen.address.clone();
+    let listen_port = inbound.listen.port;
+    let listener_runtime = runtime_factory.for_inbound(inbound_tag.clone());
+
+    listeners.spawn(async move {
+        info!(
+            inbound_tag = %inbound_tag,
+            protocol,
+            listen_address = %listen_address,
+            listen_port,
+            "inbound listener task started"
+        );
+        let result = operation.execute(listener_runtime, bound, shutdown_rx).await;
+        match &result {
+            Ok(()) => info!(
+                inbound_tag = %inbound_tag,
+                protocol,
+                listen_address = %listen_address,
+                listen_port,
+                reason = "listener_task_returned",
+                "inbound listener task returned"
+            ),
+            Err(listener_error) => error!(
+                inbound_tag = %inbound_tag,
+                protocol,
+                listen_address = %listen_address,
+                listen_port,
+                reason = "listener_task_error",
+                error = %listener_error,
+                "inbound listener task failed"
+            ),
+        }
+        result
+    });
     Ok(())
 }
 
@@ -68,7 +107,7 @@ pub(in crate::runtime) async fn reconcile_inbounds(
         } else {
             let _ = shutdown.send(true);
             *state.expected_listener_exits = state.expected_listener_exits.saturating_add(1);
-            info!(%tag, "signalled shutdown for removed inbound listener");
+            info!(%tag, reason = "config_removed", "signalled shutdown for removed inbound listener");
             false
         }
     });
@@ -91,7 +130,14 @@ pub(in crate::runtime) async fn reconcile_inbounds(
         if let Some(shutdown) = state.listener_stops.remove(&inbound.tag) {
             let _ = shutdown.send(true);
             *state.expected_listener_exits = state.expected_listener_exits.saturating_add(1);
-            info!(tag = %inbound.tag, "signalled shutdown for changed inbound listener");
+            info!(
+                inbound_tag = %inbound.tag,
+                protocol = inbound.protocol.protocol_name(),
+                listen_address = %inbound.listen.address,
+                listen_port = inbound.listen.port,
+                reason = "config_changed",
+                "signalled shutdown for changed inbound listener"
+            );
         }
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -112,16 +158,39 @@ pub(in crate::runtime) async fn reconcile_inbounds(
                     state
                         .active_inbounds
                         .insert(inbound.tag.clone(), inbound.clone());
-                    info!(tag = %inbound.tag, "started new inbound listener");
+                    info!(
+                        inbound_tag = %inbound.tag,
+                        protocol = inbound.protocol.protocol_name(),
+                        listen_address = %inbound.listen.address,
+                        listen_port = inbound.listen.port,
+                        reason = "config_reconciled",
+                        "started new inbound listener"
+                    );
                     continue;
                 }
                 Err(error) => {
-                    warn!(tag = %inbound.tag, error = %error, "failed to prepare inbound listener");
+                    warn!(
+                        inbound_tag = %inbound.tag,
+                        protocol = inbound.protocol.protocol_name(),
+                        listen_address = %inbound.listen.address,
+                        listen_port = inbound.listen.port,
+                        reason = "listener_prepare_error",
+                        error = %error,
+                        "failed to prepare inbound listener"
+                    );
                     error
                 }
             },
             Err(error) => {
-                warn!(tag = %inbound.tag, error = %error, "failed to bind inbound listener");
+                warn!(
+                    inbound_tag = %inbound.tag,
+                    protocol = inbound.protocol.protocol_name(),
+                    listen_address = %inbound.listen.address,
+                    listen_port = inbound.listen.port,
+                    reason = "listener_bind_error",
+                    error = %error,
+                    "failed to bind inbound listener"
+                );
                 error
             }
         };
@@ -138,17 +207,35 @@ pub(in crate::runtime) async fn reconcile_inbounds(
                     state.listeners,
                 ) {
                     Ok(()) => {
+                        info!(
+                            inbound_tag = %previous.tag,
+                            protocol = previous.protocol.protocol_name(),
+                            listen_address = %previous.listen.address,
+                            listen_port = previous.listen.port,
+                            reason = "reload_rollback",
+                            "restored previous inbound listener"
+                        );
                         state
                             .listener_stops
                             .insert(previous.tag.clone(), rollback_tx);
                         state.active_inbounds.insert(previous.tag.clone(), previous);
                     }
                     Err(rollback_error) => {
-                        warn!(tag = %inbound.tag, %rollback_error, "failed to prepare previous inbound during rollback");
+                        warn!(
+                            inbound_tag = %inbound.tag,
+                            reason = "rollback_prepare_error",
+                            %rollback_error,
+                            "failed to prepare previous inbound during rollback"
+                        );
                     }
                 },
                 Err(rollback_error) => {
-                    warn!(tag = %inbound.tag, %rollback_error, "failed to rebind previous inbound during rollback");
+                    warn!(
+                        inbound_tag = %inbound.tag,
+                        reason = "rollback_bind_error",
+                        %rollback_error,
+                        "failed to rebind previous inbound during rollback"
+                    );
                 }
             }
         }

--- a/crates/proxy/src/runtime/listeners/inbound.rs
+++ b/crates/proxy/src/runtime/listeners/inbound.rs
@@ -57,26 +57,26 @@ pub(in crate::runtime) fn spawn_inbound_listener(
     listeners.spawn(async move {
         info!(
             inbound_tag = %inbound_tag,
-            protocol,
+            protocol = protocol,
             listen_address = %listen_address,
-            listen_port,
+            listen_port = listen_port,
             "inbound listener task started"
         );
         let result = operation.execute(listener_runtime, bound, shutdown_rx).await;
         match &result {
             Ok(()) => info!(
                 inbound_tag = %inbound_tag,
-                protocol,
+                protocol = protocol,
                 listen_address = %listen_address,
-                listen_port,
+                listen_port = listen_port,
                 reason = "listener_task_returned",
                 "inbound listener task returned"
             ),
             Err(listener_error) => error!(
                 inbound_tag = %inbound_tag,
-                protocol,
+                protocol = protocol,
                 listen_address = %listen_address,
-                listen_port,
+                listen_port = listen_port,
                 reason = "listener_task_error",
                 error = %listener_error,
                 "inbound listener task failed"

--- a/crates/proxy/src/runtime/listeners/inbound.rs
+++ b/crates/proxy/src/runtime/listeners/inbound.rs
@@ -62,7 +62,9 @@ pub(in crate::runtime) fn spawn_inbound_listener(
             listen_port = listen_port,
             "inbound listener task started"
         );
-        let result = operation.execute(listener_runtime, bound, shutdown_rx).await;
+        let result = operation
+            .execute(listener_runtime, bound, shutdown_rx)
+            .await;
         match &result {
             Ok(()) => info!(
                 inbound_tag = %inbound_tag,

--- a/crates/proxy/src/runtime/listeners/urltest.rs
+++ b/crates/proxy/src/runtime/listeners/urltest.rs
@@ -16,7 +16,7 @@ pub(in crate::runtime) async fn reconcile_urltests(
     runtime.clear_probe_triggers();
 
     info!(
-        previous_tasks,
+        previous_tasks = previous_tasks,
         reason = "config_reload",
         "reconciled previous urltest runtime tasks"
     );
@@ -27,16 +27,20 @@ pub(in crate::runtime) async fn reconcile_urltests(
         let runtime = runtime.clone();
         let shutdown = shutdown_rx.clone();
         urltests.spawn(async move {
-            info!(group_id, reason = "config_reload", "urltest runtime task started");
+            info!(
+                group_id = group_id,
+                reason = "config_reload",
+                "urltest runtime task started"
+            );
             let result = runtime.run_urltest_group(group_id, shutdown).await;
             match &result {
                 Ok(()) => info!(
-                    group_id,
+                    group_id = group_id,
                     reason = "urltest_task_returned",
                     "urltest runtime task returned"
                 ),
                 Err(urltest_error) => error!(
-                    group_id,
+                    group_id = group_id,
                     reason = "urltest_task_error",
                     error = %urltest_error,
                     "urltest runtime task failed"

--- a/crates/proxy/src/runtime/listeners/urltest.rs
+++ b/crates/proxy/src/runtime/listeners/urltest.rs
@@ -1,5 +1,6 @@
 use tokio::sync::watch;
 use tokio::task::JoinSet;
+use tracing::{error, info};
 use zero_engine::EngineError;
 
 use crate::groups::UrlTestRuntime;
@@ -9,15 +10,39 @@ pub(in crate::runtime) async fn reconcile_urltests(
     shutdown_rx: &watch::Receiver<bool>,
     urltests: &mut JoinSet<Result<(), EngineError>>,
 ) {
+    let previous_tasks = urltests.len();
     urltests.abort_all();
     while urltests.join_next().await.is_some() {}
     runtime.clear_probe_triggers();
+
+    info!(
+        previous_tasks,
+        reason = "config_reload",
+        "reconciled previous urltest runtime tasks"
+    );
 
     let group_ids = runtime.group_ids();
 
     for group_id in group_ids {
         let runtime = runtime.clone();
         let shutdown = shutdown_rx.clone();
-        urltests.spawn(async move { runtime.run_urltest_group(group_id, shutdown).await });
+        urltests.spawn(async move {
+            info!(group_id, reason = "config_reload", "urltest runtime task started");
+            let result = runtime.run_urltest_group(group_id, shutdown).await;
+            match &result {
+                Ok(()) => info!(
+                    group_id,
+                    reason = "urltest_task_returned",
+                    "urltest runtime task returned"
+                ),
+                Err(urltest_error) => error!(
+                    group_id,
+                    reason = "urltest_task_error",
+                    error = %urltest_error,
+                    "urltest runtime task failed"
+                ),
+            }
+            result
+        });
     }
 }

--- a/crates/proxy/src/runtime/listeners/urltest.rs
+++ b/crates/proxy/src/runtime/listeners/urltest.rs
@@ -28,19 +28,19 @@ pub(in crate::runtime) async fn reconcile_urltests(
         let shutdown = shutdown_rx.clone();
         urltests.spawn(async move {
             info!(
-                group_id = group_id,
+                group_id = group_id.index(),
                 reason = "config_reload",
                 "urltest runtime task started"
             );
             let result = runtime.run_urltest_group(group_id, shutdown).await;
             match &result {
                 Ok(()) => info!(
-                    group_id = group_id,
+                    group_id = group_id.index(),
                     reason = "urltest_task_returned",
                     "urltest runtime task returned"
                 ),
                 Err(urltest_error) => error!(
-                    group_id = group_id,
+                    group_id = group_id.index(),
                     reason = "urltest_task_error",
                     error = %urltest_error,
                     "urltest runtime task failed"

--- a/crates/proxy/src/runtime/orchestration.rs
+++ b/crates/proxy/src/runtime/orchestration.rs
@@ -6,5 +6,7 @@
 mod lifecycle;
 mod logging;
 mod state;
+#[cfg(test)]
+mod tests;
 
 pub(super) use lifecycle::run_until;

--- a/crates/proxy/src/runtime/orchestration/lifecycle.rs
+++ b/crates/proxy/src/runtime/orchestration/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::io;
 
+use tracing::{error, info};
 use zero_engine::EngineError;
 
 use super::logging::log_stopped;
@@ -28,19 +29,57 @@ where
         tokio::select! {
             _ = &mut shutdown, if !shutting_down => {
                 shutting_down = true;
+                info!(
+                    core_instance_id = proxy.core_instance_id(),
+                    config_revision = proxy.config_revision(),
+                    reason = "shutdown_signal",
+                    "proxy orchestration shutdown requested"
+                );
                 state.propagate_shutdown();
             }
             Some(()) = state.reload_async_rx.recv() => {
                 if shutting_down {
                     continue;
                 }
+                info!(
+                    core_instance_id = proxy.core_instance_id(),
+                    config_revision = proxy.config_revision(),
+                    reason = "config_reload",
+                    "proxy orchestration reload requested"
+                );
                 state.reconcile_reload(proxy).await;
             }
             result = state.listeners.join_next(), if !state.listeners.is_empty() => {
-                handle_listener_result(result, shutting_down, &mut state.expected_listener_exits)?;
+                if let Err(listener_error) = handle_listener_result(
+                    result,
+                    shutting_down,
+                    &mut state.expected_listener_exits,
+                ) {
+                    error!(
+                        core_instance_id = proxy.core_instance_id(),
+                        config_revision = proxy.config_revision(),
+                        expected_listener_exits = state.expected_listener_exits,
+                        active_listener_tasks = state.listeners.len(),
+                        reason = "listener_task_exit",
+                        error = %listener_error,
+                        "proxy orchestration observed unexpected inbound listener termination"
+                    );
+                    return Err(listener_error);
+                }
             }
             result = state.urltests.join_next(), if !state.urltests.is_empty() => {
-                handle_urltest_result(result, shutting_down)?;
+                if let Err(urltest_error) = handle_urltest_result(result, shutting_down) {
+                    error!(
+                        core_instance_id = proxy.core_instance_id(),
+                        config_revision = proxy.config_revision(),
+                        active_listener_tasks = state.listeners.len(),
+                        active_urltest_tasks = state.urltests.len(),
+                        reason = "urltest_task_exit",
+                        error = %urltest_error,
+                        "proxy orchestration observed unexpected urltest termination"
+                    );
+                    return Err(urltest_error);
+                }
             }
         }
     }

--- a/crates/proxy/src/runtime/orchestration/lifecycle.rs
+++ b/crates/proxy/src/runtime/orchestration/lifecycle.rs
@@ -85,7 +85,7 @@ where
     }
 }
 
-fn handle_listener_result(
+pub(super) fn handle_listener_result(
     result: Option<Result<Result<(), EngineError>, tokio::task::JoinError>>,
     shutting_down: bool,
     expected_exits: &mut usize,
@@ -104,7 +104,7 @@ fn handle_listener_result(
     }
 }
 
-fn handle_urltest_result(
+pub(super) fn handle_urltest_result(
     result: Option<Result<Result<(), EngineError>, tokio::task::JoinError>>,
     shutting_down: bool,
 ) -> Result<(), EngineError> {

--- a/crates/proxy/src/runtime/orchestration/state.rs
+++ b/crates/proxy/src/runtime/orchestration/state.rs
@@ -179,16 +179,16 @@ impl OrchestrationState {
             let runtime = self.urltest_runtime.clone();
             let shutdown = self.shutdown_rx.clone();
             self.urltests.spawn(async move {
-                info!(group_id = group_id, "urltest runtime task started");
+                info!(group_id = group_id.index(), "urltest runtime task started");
                 let result = runtime.run_urltest_group(group_id, shutdown).await;
                 match &result {
                     Ok(()) => info!(
-                        group_id = group_id,
+                        group_id = group_id.index(),
                         reason = "urltest_task_returned",
                         "urltest runtime task returned"
                     ),
                     Err(urltest_error) => error!(
-                        group_id = group_id,
+                        group_id = group_id.index(),
                         reason = "urltest_task_error",
                         error = %urltest_error,
                         "urltest runtime task failed"

--- a/crates/proxy/src/runtime/orchestration/state.rs
+++ b/crates/proxy/src/runtime/orchestration/state.rs
@@ -179,16 +179,16 @@ impl OrchestrationState {
             let runtime = self.urltest_runtime.clone();
             let shutdown = self.shutdown_rx.clone();
             self.urltests.spawn(async move {
-                info!(group_id, "urltest runtime task started");
+                info!(group_id = group_id, "urltest runtime task started");
                 let result = runtime.run_urltest_group(group_id, shutdown).await;
                 match &result {
                     Ok(()) => info!(
-                        group_id,
+                        group_id = group_id,
                         reason = "urltest_task_returned",
                         "urltest runtime task returned"
                     ),
                     Err(urltest_error) => error!(
-                        group_id,
+                        group_id = group_id,
                         reason = "urltest_task_error",
                         error = %urltest_error,
                         "urltest runtime task failed"

--- a/crates/proxy/src/runtime/orchestration/state.rs
+++ b/crates/proxy/src/runtime/orchestration/state.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use tokio::sync::watch;
 use tokio::task::JoinSet;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use zero_config::{InboundConfig, RuntimeConfig};
 use zero_engine::EngineError;
 
@@ -72,7 +72,12 @@ impl OrchestrationState {
         for tx in self.listener_stops.values() {
             let _ = tx.send(true);
         }
-        info!("propagated proxy shutdown to background tasks");
+        info!(
+            listener_tasks = self.listeners.len(),
+            urltest_tasks = self.urltests.len(),
+            reason = "proxy_shutdown",
+            "propagated proxy shutdown to background tasks"
+        );
     }
 
     pub(super) async fn reconcile_reload(&mut self, proxy: &Proxy) {
@@ -86,7 +91,7 @@ impl OrchestrationState {
         let rollback_runtime_factory = self.inbound_runtime_factory.clone();
         let source_dir = self.source_dir.clone();
         if let Err(error) = proxy.resolver.reload(new_config.runtime.dns.as_ref()) {
-            warn!(%error, "failed to reload dns config");
+            warn!(%error, reason = "dns_reload_error", "failed to reload dns config");
         }
         let inbound_result = listeners::reconcile_inbounds(
             &proxy.protocols,
@@ -104,7 +109,13 @@ impl OrchestrationState {
         .await;
         if let Err(error) = inbound_result {
             let message = error.to_string();
-            warn!(%error, "config reload listener reconciliation failed; restoring last known-good config");
+            warn!(
+                core_instance_id = proxy.core_instance_id(),
+                config_revision = proxy.config_revision(),
+                reason = "listener_reconcile_error",
+                %error,
+                "config reload listener reconciliation failed; restoring last known-good config"
+            );
             let persist = proxy.pending_reload_persists(&new_config);
             let rollback = if persist {
                 proxy.engine.stage_config((*self.applied_config).clone())
@@ -114,7 +125,13 @@ impl OrchestrationState {
                     .stage_runtime_config((*self.applied_config).clone())
             };
             let acknowledgement = if let Err(rollback_error) = rollback {
-                warn!(%rollback_error, "failed to restore last known-good config after reload failure");
+                warn!(
+                    core_instance_id = proxy.core_instance_id(),
+                    config_revision = proxy.config_revision(),
+                    reason = "reload_rollback_error",
+                    %rollback_error,
+                    "failed to restore last known-good config after reload failure"
+                );
                 format!("{message}; last-known-good config restore failed: {rollback_error}")
             } else {
                 message
@@ -161,8 +178,24 @@ impl OrchestrationState {
         for group_id in self.urltest_runtime.group_ids() {
             let runtime = self.urltest_runtime.clone();
             let shutdown = self.shutdown_rx.clone();
-            self.urltests
-                .spawn(async move { runtime.run_urltest_group(group_id, shutdown).await });
+            self.urltests.spawn(async move {
+                info!(group_id, "urltest runtime task started");
+                let result = runtime.run_urltest_group(group_id, shutdown).await;
+                match &result {
+                    Ok(()) => info!(
+                        group_id,
+                        reason = "urltest_task_returned",
+                        "urltest runtime task returned"
+                    ),
+                    Err(urltest_error) => error!(
+                        group_id,
+                        reason = "urltest_task_error",
+                        error = %urltest_error,
+                        "urltest runtime task failed"
+                    ),
+                }
+                result
+            });
         }
     }
 }

--- a/crates/proxy/src/runtime/orchestration/tests.rs
+++ b/crates/proxy/src/runtime/orchestration/tests.rs
@@ -1,0 +1,55 @@
+use zero_engine::EngineError;
+
+use super::lifecycle::{handle_listener_result, handle_urltest_result};
+
+#[test]
+fn unexpected_clean_listener_exit_is_fatal() {
+    let mut expected_exits = 0;
+    let result = handle_listener_result(Some(Ok(Ok(()))), false, &mut expected_exits);
+
+    assert!(matches!(result, Err(EngineError::InboundTaskExited)));
+}
+
+#[test]
+fn expected_listener_exit_is_consumed_during_reconciliation() {
+    let mut expected_exits = 1;
+    let result = handle_listener_result(Some(Ok(Ok(()))), false, &mut expected_exits);
+
+    assert!(result.is_ok());
+    assert_eq!(expected_exits, 0);
+}
+
+#[test]
+fn listener_error_is_preserved_during_reconciliation() {
+    let mut expected_exits = 1;
+    let result = handle_listener_result(
+        Some(Ok(Err(EngineError::NoInbounds))),
+        false,
+        &mut expected_exits,
+    );
+
+    assert!(matches!(result, Err(EngineError::NoInbounds)));
+    assert_eq!(expected_exits, 1);
+}
+
+#[test]
+fn clean_listener_exit_is_allowed_during_shutdown() {
+    let mut expected_exits = 0;
+    let result = handle_listener_result(Some(Ok(Ok(()))), true, &mut expected_exits);
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn unexpected_clean_urltest_exit_is_fatal() {
+    let result = handle_urltest_result(Some(Ok(Ok(()))), false);
+
+    assert!(matches!(result, Err(EngineError::UrlTestTaskExited)));
+}
+
+#[test]
+fn clean_urltest_exit_is_allowed_during_shutdown() {
+    let result = handle_urltest_result(Some(Ok(Ok(()))), true);
+
+    assert!(result.is_ok());
+}

--- a/crates/proxy/tests/runtime_boundary.rs
+++ b/crates/proxy/tests/runtime_boundary.rs
@@ -656,7 +656,8 @@ fn listener_and_task_lifecycle_are_runtime_owned() {
     assert!(!inventory_inbound.contains("JoinSet"));
     assert!(!inventory_inbound.contains("listeners.spawn("));
     assert!(!inventory_inbound.contains("operation.execute("));
-    assert!(runtime_listeners.contains("listeners.spawn(operation.execute("));
+    assert!(runtime_listeners.contains("listeners.spawn("));
+    assert!(runtime_listeners.contains(".execute(listener_runtime, bound, shutdown_rx)"));
 }
 
 #[test]
@@ -2549,7 +2550,8 @@ fn udp_ingress_runtime_collapses_proxy_and_services_for_session_loops() {
     let listener_inbound = read(&proxy_src().join("runtime/listeners/inbound.rs"));
     assert!(listener_inbound.contains("ProtocolInventory"));
     assert!(listener_inbound.contains("InboundListenerRuntimeFactory"));
-    assert!(listener_inbound.contains("listeners.spawn(operation.execute("));
+    assert!(listener_inbound.contains("listeners.spawn("));
+    assert!(listener_inbound.contains(".execute(listener_runtime, bound, shutdown_rx)"));
     assert!(!listener_inbound.contains("use super::super::Proxy"));
     assert!(!listener_inbound.contains("proxy: &Proxy"));
     assert!(!listener_inbound.contains("proxy.config.source_dir()"));

--- a/crates/transport/src/quic.rs
+++ b/crates/transport/src/quic.rs
@@ -17,6 +17,8 @@ use zero_traits::AsyncSocket;
 
 use zero_platform_tokio::ClientStream;
 
+mod inbound_accept;
+
 /// Bidirectional QUIC stream wrapping quinn SendStream and RecvStream.
 pub struct QuicStream {
     send: quinn::SendStream,
@@ -228,33 +230,6 @@ impl QuicInbound {
         .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic endpoint: {e}"))))?;
 
         Ok(Self { endpoint })
-    }
-
-    pub async fn accept(&self) -> Result<QuicStream, RuntimeError> {
-        let conn = self.accept_connection().await?;
-
-        let (send, recv) = conn
-            .accept_bi()
-            .await
-            .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic accept stream: {e}"))))?;
-
-        Ok(QuicStream::new(send, recv))
-    }
-
-    /// Accept a raw QUIC connection for callers that need multi-stream support
-    /// and key export.
-    pub async fn accept_connection(&self) -> Result<quinn::Connection, RuntimeError> {
-        self.endpoint
-            .accept()
-            .await
-            .ok_or_else(|| {
-                RuntimeError::Io(io::Error::new(
-                    io::ErrorKind::ConnectionAborted,
-                    "quic endpoint closed",
-                ))
-            })?
-            .await
-            .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic connection: {e}"))))
     }
 }
 

--- a/crates/transport/src/quic/inbound_accept.rs
+++ b/crates/transport/src/quic/inbound_accept.rs
@@ -1,0 +1,59 @@
+use std::io;
+use std::net::SocketAddr;
+
+use crate::RuntimeError;
+
+use super::{QuicInbound, QuicStream};
+
+impl QuicInbound {
+    pub fn local_addr(&self) -> Result<SocketAddr, RuntimeError> {
+        self.endpoint.local_addr().map_err(RuntimeError::Io)
+    }
+
+    /// Wait for the endpoint to yield a new connection attempt.
+    ///
+    /// This boundary intentionally does not await the client handshake. A
+    /// failed handshake belongs to one remote connection and must not be
+    /// confused with termination of the listening endpoint.
+    pub async fn accept_incoming(&self) -> Option<quinn::Incoming> {
+        self.endpoint.accept().await
+    }
+
+    pub async fn establish_incoming(
+        incoming: quinn::Incoming,
+    ) -> Result<quinn::Connection, RuntimeError> {
+        incoming
+            .await
+            .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic connection: {e}"))))
+    }
+
+    pub async fn establish_incoming_stream(
+        incoming: quinn::Incoming,
+    ) -> Result<QuicStream, RuntimeError> {
+        let connection = Self::establish_incoming(incoming).await?;
+        let (send, recv) = connection
+            .accept_bi()
+            .await
+            .map_err(|e| RuntimeError::Io(io::Error::other(format!("quic accept stream: {e}"))))?;
+        Ok(QuicStream::new(send, recv))
+    }
+
+    pub async fn accept(&self) -> Result<QuicStream, RuntimeError> {
+        let incoming = self.accept_incoming().await.ok_or_else(endpoint_closed)?;
+        Self::establish_incoming_stream(incoming).await
+    }
+
+    /// Accept a raw QUIC connection for callers that need multi-stream support
+    /// and key export.
+    pub async fn accept_connection(&self) -> Result<quinn::Connection, RuntimeError> {
+        let incoming = self.accept_incoming().await.ok_or_else(endpoint_closed)?;
+        Self::establish_incoming(incoming).await
+    }
+}
+
+fn endpoint_closed() -> RuntimeError {
+    RuntimeError::Io(io::Error::new(
+        io::ErrorKind::ConnectionAborted,
+        "quic endpoint closed",
+    ))
+}

--- a/src/application/run.rs
+++ b/src/application/run.rs
@@ -97,17 +97,27 @@ async fn run(
     };
 
     let stats_sampler = spawn_stats_sampler(engine.clone());
-    let running = proxy.spawn();
 
-    wait_for_shutdown_signal().await;
+    // The proxy data plane is a critical application service. Run it under the
+    // root application lifecycle instead of detaching it into an unsupervised
+    // task. If listener orchestration exits unexpectedly, surface the error
+    // immediately so the process cannot remain control-plane alive while its
+    // configured inbound ports have already disappeared.
+    let proxy_result = proxy.run_until(wait_for_shutdown_signal()).await;
+    if let Err(error) = &proxy_result {
+        tracing::error!(error = %error, "proxy runtime terminated unexpectedly");
+    }
 
     stats_sampler.abort();
-    running.shutdown().await?;
     // Proxy shutdown emits terminal flow.completed facts. Stop only status
     // polling here; the dispatcher remains alive for the terminal events.
     services.shutdown_status_monitor().await;
 
-    engine.push_engine_stopped("signal");
+    engine.push_engine_stopped(if proxy_result.is_ok() {
+        "signal"
+    } else {
+        "runtime_error"
+    });
     // Allow the event dispatcher to observe the terminal engine event before
     // its final drain persists any remaining deliveries to the outbox.
     tokio::task::yield_now().await;
@@ -122,6 +132,8 @@ async fn run(
     if let Some(s) = grpc_server {
         s.shutdown().await;
     }
+
+    proxy_result?;
     Ok(())
 }
 

--- a/src/application/run.rs
+++ b/src/application/run.rs
@@ -105,7 +105,13 @@ async fn run(
     // configured inbound ports have already disappeared.
     let proxy_result = proxy.run_until(wait_for_shutdown_signal()).await;
     if let Err(error) = &proxy_result {
-        tracing::error!(error = %error, "proxy runtime terminated unexpectedly");
+        tracing::error!(
+            core_instance_id = engine.core_instance_id(),
+            config_revision = engine.config_revision(),
+            reason = "runtime_error",
+            error = %error,
+            "proxy runtime terminated unexpectedly"
+        );
     }
 
     stats_sampler.abort();

--- a/src/application/run.rs
+++ b/src/application/run.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::future::Future;
 
 use crate::cli::Command;
 #[cfg(any(feature = "status-api", feature = "grpc-api"))]
@@ -10,6 +11,9 @@ use super::services::ApplicationServices;
 #[cfg(feature = "status-api")]
 use crate::http_adapter;
 use crate::{ipc, rule_set_fetch};
+
+#[cfg(test)]
+mod tests;
 
 pub async fn execute(command: Command) -> Result<(), Box<dyn Error>> {
     let Command::Run {
@@ -103,7 +107,7 @@ async fn run(
     // task. If listener orchestration exits unexpectedly, surface the error
     // immediately so the process cannot remain control-plane alive while its
     // configured inbound ports have already disappeared.
-    let proxy_result = proxy.run_until(wait_for_shutdown_signal()).await;
+    let proxy_result = run_supervised_proxy(&proxy, wait_for_shutdown_signal()).await;
     if let Err(error) = &proxy_result {
         tracing::error!(
             core_instance_id = engine.core_instance_id(),
@@ -119,11 +123,7 @@ async fn run(
     // polling here; the dispatcher remains alive for the terminal events.
     services.shutdown_status_monitor().await;
 
-    engine.push_engine_stopped(if proxy_result.is_ok() {
-        "signal"
-    } else {
-        "runtime_error"
-    });
+    engine.push_engine_stopped(proxy_stop_reason(&proxy_result));
     // Allow the event dispatcher to observe the terminal engine event before
     // its final drain persists any remaining deliveries to the outbox.
     tokio::task::yield_now().await;
@@ -141,6 +141,21 @@ async fn run(
 
     proxy_result?;
     Ok(())
+}
+
+async fn run_supervised_proxy<F>(proxy: &Proxy, shutdown: F) -> Result<(), zero_engine::EngineError>
+where
+    F: Future<Output = ()> + Send,
+{
+    proxy.run_until(shutdown).await
+}
+
+fn proxy_stop_reason(result: &Result<(), zero_engine::EngineError>) -> &'static str {
+    if result.is_ok() {
+        "signal"
+    } else {
+        "runtime_error"
+    }
 }
 
 #[cfg(any(feature = "status-api", feature = "grpc-api"))]

--- a/src/application/run/tests.rs
+++ b/src/application/run/tests.rs
@@ -1,0 +1,26 @@
+use zero_config::RuntimeConfig;
+use zero_engine::EngineError;
+use zero_proxy::Proxy;
+
+use super::{proxy_stop_reason, run_supervised_proxy};
+
+#[tokio::test]
+async fn proxy_runtime_error_reaches_application_supervisor() {
+    let config =
+        RuntimeConfig::parse(r#"{ "route": { "rules": [], "final": { "type": "direct" } } }"#)
+            .expect("minimal runtime config");
+    let proxy = Proxy::new(config).expect("minimal proxy");
+
+    let result = run_supervised_proxy(&proxy, std::future::pending()).await;
+
+    assert!(matches!(result, Err(EngineError::NoInbounds)));
+}
+
+#[test]
+fn proxy_stop_reason_distinguishes_signal_from_runtime_failure() {
+    assert_eq!(proxy_stop_reason(&Ok(())), "signal");
+    assert_eq!(
+        proxy_stop_reason(&Err(EngineError::NoInbounds)),
+        "runtime_error"
+    );
+}


### PR DESCRIPTION
## Related

- Closes #15

## Problem

The Zero application starts proxy orchestration in a detached Tokio task, then the root task waits only for Ctrl-C. If proxy/listener orchestration terminates unexpectedly, inbound sockets are dropped but IPC/control services and the process remain alive. This produces a false-healthy state: systemd sees a running Zero process while protocol ports have disappeared.

This matches a field report from one VPS where Zero remained responsive through its control plane after the configured listener ports stopped listening.

## Changes

### Supervise the data plane from the root application lifecycle

- Run `proxy.run_until(wait_for_shutdown_signal())` directly under the application root instead of `proxy.spawn()` + an unsupervised join handle.
- Log any unexpected proxy runtime error immediately.
- Continue orderly shutdown of status monitoring, event dispatcher and control servers.
- Emit `engine.stopped` with `runtime_error` for unexpected data-plane termination and `signal` for normal shutdown.
- Return the proxy error after cleanup so the process exits non-zero and systemd/container restart policy can recover it.

### Distinguish QUIC endpoint failure from per-client failure

The QUIC stream listener previously awaited both the client handshake and first bidirectional stream inline. A failed or abandoned client could therefore terminate the listener and, once root supervision was added, force the whole process to restart.

Now QUIC listener lifecycle and connection lifecycle are separated:

- the endpoint accept loop yields incoming connection attempts and remains runtime-owned;
- client handshake, authentication and first-stream establishment run inside per-connection tasks;
- a failed or abandoned client is logged with inbound identity and remote address, then the listener continues accepting;
- only unexpected endpoint termination returns an `EngineError` and triggers the application supervisor;
- normal explicit listener shutdown remains a clean `Ok(())` path.

### Add structured listener/runtime diagnostics

The field incident cannot be reproduced reliably, so this PR also makes the next occurrence actionable instead of leaving only a generic task-exit error.

Listener lifecycle logs now carry stable fields such as:

- `inbound_tag`;
- `protocol`;
- `transport` where known;
- configured/listening address and port where available;
- explicit `reason` values including `shutdown_signal`, `shutdown_channel_closed`, `listener_endpoint_closed`, `connection_accept_error`, connection-task panic and listener-task error;
- the original error text.

The listener task wrapper logs the configured inbound identity both when a task returns cleanly and when it fails. This covers protocols whose inner listener loop does not expose all configured address metadata itself.

The orchestration supervisor logs unexpected listener and URLTest termination with:

- `core_instance_id`;
- `config_revision`;
- active listener/URLTest task counts;
- pending expected listener exits during reconciliation;
- structured termination reason and root error.

TCP `accept()` errors retain the listener instead of terminating it, but now include inbound tag, transport and local listen address so host-specific resource failures can be diagnosed from the journal. System-stack closure and shutdown-channel loss are also logged explicitly.

URLTest runtime tasks log their group ID and task result so a URLTest task cannot collapse into an untraceable `UrlTestTaskExited` if it becomes the orchestration failure source.

## Scope

This PR intentionally does not add an in-process listener restart loop. The safe first recovery boundary is the Zero process: an unexpected data-plane failure must become visible and cause a non-zero exit rather than leave a partially alive process.

The exact host-specific trigger on the affected VPS still requires runtime evidence. This change makes that evidence observable and prevents the trigger from being hidden behind a false-healthy process.

## Validation

Added focused regressions for application-level error supervision, expected versus unexpected listener/URLTest exits, QUIC handshake failure isolation, QUIC client close before first stream, and runtime ownership boundaries.

Repository formatting, workspace checks/tests, all-target/all-feature clippy, optional surfaces, musl compatibility, and GitHub CI pass. Follow-up host-side diagnostics in Zboard are tracked separately in zerodenet/zboard#42.