### PR TITLE
Fix tun.stop empty command params

### DIFF
--- a/crates/api/src/command.rs
+++ b/crates/api/src/command.rs
@@ -256,5 +256,25 @@ fn default_tun_mask() -> String {
     "255.255.255.0".to_owned()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TunStopCommand;
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TunStopCommand {}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandRequest, TunStopCommand};
+    use serde_json::json;
+
+    #[test]
+    fn tun_stop_accepts_and_serializes_empty_object_params() {
+        let request: CommandRequest = serde_json::from_value(json!({
+            "method": "tun.stop",
+            "params": {}
+        }))
+        .expect("deserialize tun.stop with standard command object params");
+
+        assert_eq!(request, CommandRequest::TunStop(TunStopCommand {}));
+        let value = serde_json::to_value(request).expect("serialize tun.stop command");
+        assert_eq!(value["method"], "tun.stop");
+        assert_eq!(value["params"], json!({}));
+    }
+}


### PR DESCRIPTION
## Problem

ZNet-Sink sends the standard command envelope for `tun.stop` with an empty JSON object:

```json
{
  "method": "tun.stop",
  "params": {}
}
```

Core currently models `TunStopCommand` as a serde unit struct (`pub struct TunStopCommand;`), so `{}` fails during command deserialization with:

```text
invalid type: map, expected unit struct TunStopCommand
```

This makes an otherwise running TUN impossible to stop through clients that consistently model command params as JSON objects.

## Fix

- model `TunStopCommand` as an empty object struct instead of a unit struct;
- add a serialization/deserialization contract test for `{ "method": "tun.stop", "params": {} }`.

This keeps `tun.stop` consistent with the existing command envelope and requires no TUN runtime behavior change.

## Observed from ZNet-Sink PR #15 validation

```text
断开失败: invalid type: map, expected unit struct TunStopCommand
```
