### PR TITLE
ci: harden dependency setup and reduce matrix runner stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,28 +112,23 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install musl toolchain
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross@0.2.5
+          fallback: none
+
+      - name: Verify cross environment
         shell: bash
         run: |
-          set -euo pipefail
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            update
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            install -y --no-install-recommends musl-tools
+          cross --version
+          docker version --format '{{.Server.Version}}'
 
       - name: Build compatibility binary
-        run: cargo build --features full,status-api,connector --release --target x86_64-unknown-linux-musl
+        run: cross build --features full,status-api,connector --release --target x86_64-unknown-linux-musl
 
       - name: Verify static linkage
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            update
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            install -y --no-install-recommends protobuf-compiler
-          protoc --version
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify protoc
+        run: protoc --version
 
       - name: Format
         run: cargo fmt --all --check
@@ -71,20 +64,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            update
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            install -y --no-install-recommends protobuf-compiler
-          protoc --version
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify protoc
+        run: protoc --version
 
       - name: Check (all features)
         run: cargo check --workspace --all-features
@@ -178,20 +164,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            update
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            install -y --no-install-recommends protobuf-compiler
-          protoc --version
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify protoc
+        run: protoc --version
 
       - name: Check proxy feature (core-only)
         run: cargo check -p zero-proxy --no-default-features
@@ -230,20 +209,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            update
-          sudo timeout 5m apt-get \
-            -o Acquire::Retries=3 \
-            -o Acquire::http::Timeout=30 \
-            -o Acquire::https::Timeout=30 \
-            install -y --no-install-recommends protobuf-compiler
-          protoc --version
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "35.0"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify protoc
+        run: protoc --version
 
       - name: Check optional surface (status-api)
         run: cargo check --no-default-features --features status-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   static:
     name: Static checks (fmt + clippy)
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +37,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends protobuf-compiler
+          protoc --version
 
       - name: Format
         run: cargo fmt --all --check
@@ -47,6 +61,7 @@ jobs:
   check-and-test:
     name: Check & Test (Linux)
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     needs: static
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +71,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends protobuf-compiler
+          protoc --version
 
       - name: Check (all features)
         run: cargo check --workspace --all-features
@@ -70,6 +98,7 @@ jobs:
   tun-platform-check:
     name: TUN platform check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: static
     strategy:
       fail-fast: false
@@ -91,6 +120,7 @@ jobs:
   linux-musl-compat:
     name: Build Linux musl compatibility artifact
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     needs: static
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +132,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install musl toolchain
-        run: sudo apt-get update && sudo apt-get install --yes musl-tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends musl-tools
 
       - name: Build compatibility binary
         run: cargo build --features full,status-api,connector --release --target x86_64-unknown-linux-musl
@@ -123,30 +165,11 @@ jobs:
             exit 1
           fi
 
-  proxy-feature-matrix:
-    name: Proxy feature (${{ matrix.name }})
+  proxy-feature-compat:
+    name: Proxy feature compatibility
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     needs: static
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: core-only
-            args: ""
-          - name: simple-tcp
-            args: "--features http"
-          - name: registered-association
-            args: "--features socks5"
-          - name: socket-datagram-packet-path
-            args: "--features shadowsocks"
-          - name: quic-flow-datagram
-            args: "--features hysteria2"
-          - name: packet-stream
-            args: "--features trojan"
-          - name: tuple-two-stream
-            args: "--features vless"
-          - name: generic-tuple-stream
-            args: "--features mieru"
     steps:
       - uses: actions/checkout@v4
 
@@ -155,23 +178,50 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends protobuf-compiler
+          protoc --version
 
-      - name: Check representative proxy feature family
-        run: cargo check -p zero-proxy --no-default-features ${{ matrix.args }}
+      - name: Check proxy feature (core-only)
+        run: cargo check -p zero-proxy --no-default-features
 
-  optional-surface-matrix:
-    name: Optional surface (${{ matrix.feature }})
+      - name: Check proxy feature (simple-tcp)
+        run: cargo check -p zero-proxy --no-default-features --features http
+
+      - name: Check proxy feature (registered-association)
+        run: cargo check -p zero-proxy --no-default-features --features socks5
+
+      - name: Check proxy feature (socket-datagram-packet-path)
+        run: cargo check -p zero-proxy --no-default-features --features shadowsocks
+
+      - name: Check proxy feature (quic-flow-datagram)
+        run: cargo check -p zero-proxy --no-default-features --features hysteria2
+
+      - name: Check proxy feature (packet-stream)
+        run: cargo check -p zero-proxy --no-default-features --features trojan
+
+      - name: Check proxy feature (tuple-two-stream)
+        run: cargo check -p zero-proxy --no-default-features --features vless
+
+      - name: Check proxy feature (generic-tuple-stream)
+        run: cargo check -p zero-proxy --no-default-features --features mieru
+
+  optional-surface-compat:
+    name: Optional surface compatibility
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     needs: static
-    strategy:
-      fail-fast: false
-      matrix:
-        feature:
-          - status-api
-          - event-dispatcher
-          - connector
-          - grpc-api
     steps:
       - uses: actions/checkout@v4
 
@@ -180,7 +230,29 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout 5m apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y --no-install-recommends protobuf-compiler
+          protoc --version
 
-      - name: Check optional surface independently
-        run: cargo check --no-default-features --features ${{ matrix.feature }}
+      - name: Check optional surface (status-api)
+        run: cargo check --no-default-features --features status-api
+
+      - name: Check optional surface (event-dispatcher)
+        run: cargo check --no-default-features --features event-dispatcher
+
+      - name: Check optional surface (connector)
+        run: cargo check --no-default-features --features connector
+
+      - name: Check optional surface (grpc-api)
+        run: cargo check --no-default-features --features grpc-api


### PR DESCRIPTION
## 背景

CI run #209 长时间保持 `in_progress`，实际卡在多个 Ubuntu job 的系统依赖安装，并不是 Rust 编译或测试。

- #210 证明 `protoc` 的 `apt-get update` 会在 GitHub Hosted Runner / Ubuntu mirror 路径上持续无响应，最终由 5 分钟超时以 exit code `124` 终止。
- #211 证明将 `protoc` 改为 GitHub Release 安装后相关 job 全部恢复正常；唯一失败项变成 `linux-musl-compat`，原因仍然是它残留的 `apt-get install musl-tools`，同样在 Ubuntu mirror 阶段超时并以 `124` 结束。

发布流程本身独立执行并已成功，因此这里处理的是普通 CI 的依赖安装稳定性。

## 变更

- 为 CI jobs 增加 `timeout-minutes`，避免异常 runner 无限占用工作流
- `protoc` 不再通过 Ubuntu `apt-get` 安装，改为 `arduino/setup-protoc@v3` 从 GitHub Releases 获取，并固定到 `35.0`
- 为 protoc 安装传入 `GITHUB_TOKEN`，并增加 `protoc --version` 显式校验
- 将 8 个 proxy feature matrix runner 收敛为 1 个兼容性 job，在同一 runner 上逐项执行全部原有 feature checks
- 将 4 个 optional surface matrix runner 收敛为 1 个兼容性 job，在同一 runner 上逐项执行全部原有 surface checks
- 保留原有检查覆盖范围，不删除任何 feature / surface 校验
- `linux-musl-compat` 不再依赖 `apt-get install musl-tools`，改用 `cross@0.2.5` 的预编译工具 + Docker musl 构建环境
- 继续保留 musl 静态链接 / GLIBC 依赖校验

## 失败复现

CI #210 和 #211 都出现同一种模式：

- `azure.archive.ubuntu.com` 连续超时
- fallback 到 `archive.ubuntu.com` 后 package index 获取仍阻塞
- 5 分钟后由 `timeout` 主动终止，exit code `124`

#211 同时验证了 `arduino/setup-protoc` 路径有效：Static checks、Check & Test、Proxy feature compatibility、Optional surface compatibility 的 protoc 安装及后续 Rust 校验全部成功。

## 预期效果

- 普通 CI 不再为了 protoc 或 musl 工具链依赖 Ubuntu apt mirror
- feature / optional surface runner 数量显著减少
- 外部依赖异常时仍有 job 级超时兜底，不再让 workflow 长时间悬挂

基于当前 `develop` 创建；只修改 `.github/workflows/ci.yml`。