### PR TITLE
chore: add issue templates and contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a reproducible problem with Zero
+labels:
+  - bug
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Zero version
+      description: Provide the exact Zero version or commit.
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: OS and architecture.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - Runtime
+        - TUN
+        - DNS
+        - Routing
+        - Protocol
+        - API
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest an improvement or new capability
+labels:
+  - feature
+body:
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: Explain the problem or use case.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,19 @@
+name: Question
+description: Ask about configuration or usage
+labels:
+  - question
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Zero version
+  - type: textarea
+    id: context
+    attributes:
+      label: Configuration and context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description
+
+## Related Issue
+
+## Changes
+
+## Testing
+
+## Breaking Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Issue Reporting
+
+When submitting an issue, please provide enough context to help diagnose the problem.
+
+Include:
+
+- Zero version
+- Platform and runtime environment
+- Affected component
+- Steps to reproduce
+- Expected behavior
+- Actual behavior
+- Relevant configuration
+- Logs or error output
+
+## Issue Labels
+
+Keep labels lightweight and focused on maintenance workflow.
+
+Recommended labels:
+
+- `bug` - unexpected behavior, crashes, compatibility issues, or runtime failures
+- `feature` - new capabilities or improvements
+- `question` - usage or configuration questions
+- `documentation` - documentation improvements or corrections
+- `needs-info` - additional information is required before investigation
+- `priority:critical` - critical availability, security, or widespread impact issues
+- `priority:high` - important issues requiring early attention
+
+Labels are intended to help triage and prioritize work. Detailed technical context should be provided in the issue body.


### PR DESCRIPTION
## Description

Add lightweight GitHub contribution templates to improve issue quality and maintenance workflow.

## Changes

- Add bug report template with version, platform, affected component, configuration and logs.
- Add feature request template.
- Add question template.
- Add pull request template.

## Related Issue

N/A

## Testing

Template-only change.

## Breaking Changes

None.