### PR TITLE
feat(tun): sniff HTTP hosts and handle ECH safely

### DIFF
--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -12,6 +12,7 @@ pub enum Network {
 pub enum TargetHostSource {
     FakeIp,
     DnsReverse,
+    HttpHost,
     TlsSni,
 }
 
@@ -20,6 +21,7 @@ impl TargetHostSource {
         match self {
             Self::FakeIp => "fake_ip",
             Self::DnsReverse => "dns_reverse",
+            Self::HttpHost => "http_host",
             Self::TlsSni => "tls_sni",
         }
     }

--- a/crates/proxy/src/inbound/tun/runtime.rs
+++ b/crates/proxy/src/inbound/tun/runtime.rs
@@ -14,7 +14,7 @@ use crate::runtime::tcp_ingress::{InboundProtocol, TcpIngressRuntime};
 use crate::runtime::Proxy;
 use crate::transport::ReplayStream;
 
-use super::sniff::sniff_tls_target;
+use super::sniff::sniff_tcp_target;
 
 const TCP_STATE_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 const TCP_STATE_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
@@ -263,7 +263,7 @@ async fn accept_tcp(
                     Some(source_addr),
                 );
                 connections.spawn(async move {
-                    let (session, stream) = sniff_tls_target(session, stream).await;
+                    let (session, stream) = sniff_tcp_target(session, stream).await;
                     runtime.serve(session, stream, &TunProtocol).await
                 });
             }

--- a/crates/proxy/src/inbound/tun/runtime/tests.rs
+++ b/crates/proxy/src/inbound/tun/runtime/tests.rs
@@ -9,7 +9,7 @@ use zero_config::RuntimeConfig;
 use zero_stack::{packet, UserNetworkStack, UserTcpStack};
 use zero_traits::{TcpStack, UdpStack};
 
-use super::{accept_tcp, feed_packets, should_drop_non_unicast_udp, sniff_tls_target};
+use super::{accept_tcp, feed_packets, should_drop_non_unicast_udp, sniff_tcp_target};
 
 const CLIENT_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 99, 0, 2));
 const CLIENT_PORT: u16 = 49152;
@@ -88,7 +88,7 @@ async fn tun_tls_sniff_overrides_ip_target_and_preserves_client_hello() {
         zero_core::ProtocolType::UNKNOWN,
     );
 
-    let (session, mut stream) = sniff_tls_target(session, reader).await;
+    let (session, mut stream) = sniff_tcp_target(session, reader).await;
 
     assert_eq!(
         session.target,
@@ -132,7 +132,7 @@ async fn tun_tls_sniff_handles_client_hello_split_across_records() {
         zero_core::ProtocolType::UNKNOWN,
     );
 
-    let (session, mut stream) = sniff_tls_target(session, reader).await;
+    let (session, mut stream) = sniff_tcp_target(session, reader).await;
 
     assert_eq!(
         session.target,
@@ -161,7 +161,7 @@ async fn tun_non_tls_probe_keeps_ip_target_and_preserves_payload() {
         zero_core::ProtocolType::UNKNOWN,
     );
 
-    let (session, mut stream) = sniff_tls_target(session, reader).await;
+    let (session, mut stream) = sniff_tcp_target(session, reader).await;
 
     assert_eq!(session.target, original_target);
     assert!(session.direct_target.is_none());
@@ -194,7 +194,7 @@ async fn tun_tls_without_sni_keeps_deterministic_ip_fallback() {
         zero_core::ProtocolType::UNKNOWN,
     );
 
-    let (session, mut stream) = sniff_tls_target(session, reader).await;
+    let (session, mut stream) = sniff_tcp_target(session, reader).await;
 
     assert_eq!(session.target, original_target);
     assert!(session.direct_target.is_none());
@@ -202,6 +202,45 @@ async fn tun_tls_without_sni_keeps_deterministic_ip_fallback() {
     assert!(session.target_host_source.is_none());
     let mut replayed = Vec::new();
     stream.read_to_end(&mut replayed).await.unwrap();
+    assert_eq!(replayed, original);
+}
+
+#[tokio::test]
+async fn tun_http_host_recovers_domain_and_preserves_request() {
+    let original = b"GET /mail HTTP/1.1\r\nHost: ExMail.QQ.Com:80\r\nConnection: close\r\n\r\n";
+    let (mut writer, reader) = tokio::io::duplex(256);
+    writer
+        .write_all(original)
+        .await
+        .expect("write HTTP request");
+    writer.shutdown().await.expect("close writer");
+    let original_target = zero_core::Address::Ipv4([183, 2, 144, 108]);
+    let session = zero_core::Session::new(
+        0,
+        original_target.clone(),
+        80,
+        zero_core::Network::Tcp,
+        zero_core::ProtocolType::UNKNOWN,
+    );
+
+    let (session, mut stream) = sniff_tcp_target(session, reader).await;
+
+    assert_eq!(
+        session.target,
+        zero_core::Address::Domain("exmail.qq.com".to_owned())
+    );
+    assert_eq!(session.direct_target, Some(original_target.clone()));
+    assert_eq!(session.original_target, Some(original_target));
+    assert_eq!(
+        session.target_host_source,
+        Some(zero_core::TargetHostSource::HttpHost)
+    );
+    assert!(session.sni.is_none());
+    let mut replayed = Vec::new();
+    stream
+        .read_to_end(&mut replayed)
+        .await
+        .expect("read replayed HTTP request");
     assert_eq!(replayed, original);
 }
 

--- a/crates/proxy/src/inbound/tun/sniff.rs
+++ b/crates/proxy/src/inbound/tun/sniff.rs
@@ -7,57 +7,93 @@ use zero_core::{Address, Session, TargetHostSource};
 
 use crate::transport::{RecordingStream, ReplayStream};
 
-const TLS_SNI_SNIFF_TIMEOUT: Duration = Duration::from_millis(200);
+const TARGET_SNIFF_TIMEOUT: Duration = Duration::from_millis(200);
 const MAX_TLS_RECORD_LENGTH: usize = 18_432;
 const MAX_CLIENT_HELLO_LENGTH: usize = 65_535;
+const MAX_HTTP_HEADER_LENGTH: usize = 32 * 1024;
 
-pub(super) async fn sniff_tls_target<S>(
+pub(super) async fn sniff_tcp_target<S>(
     mut session: Session,
     stream: S,
 ) -> (Session, ReplayStream<S>)
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    if !matches!(session.port, 443 | 8443)
-        || !matches!(&session.target, Address::Ipv4(_) | Address::Ipv6(_))
-    {
+    if !matches!(&session.target, Address::Ipv4(_) | Address::Ipv6(_)) {
         return (session, ReplayStream::new(stream, Vec::new()));
     }
 
+    let protocol = match session.port {
+        443 | 8443 => SniffProtocol::Tls,
+        80 | 8000 | 8080 | 8888 => SniffProtocol::Http,
+        _ => return (session, ReplayStream::new(stream, Vec::new())),
+    };
+
     let mut recording = RecordingStream::new(stream);
-    let sniffed = tokio::time::timeout(TLS_SNI_SNIFF_TIMEOUT, peek_tls_sni(&mut recording)).await;
+    let sniffed = match protocol {
+        SniffProtocol::Tls => {
+            tokio::time::timeout(TARGET_SNIFF_TIMEOUT, peek_tls_target(&mut recording)).await
+        }
+        SniffProtocol::Http => {
+            tokio::time::timeout(TARGET_SNIFF_TIMEOUT, peek_http_target(&mut recording)).await
+        }
+    };
     let (stream, prefix) = recording.into_parts();
 
     match sniffed {
-        Ok(Ok(Some(domain))) => {
+        Ok(Ok(SniffOutcome::Domain { domain, source })) => {
             if let Some(domain) = normalize_sniffed_domain(domain) {
                 tracing::debug!(
                     original_target = ?session.target,
                     sniffed_domain = %domain,
-                    "TUN recovered domain from TLS ClientHello"
+                    source = source.as_str(),
+                    "TUN recovered domain from application traffic"
                 );
                 if session.original_target.is_none() {
                     session.original_target = Some(session.target.clone());
                 }
                 session.direct_target = Some(session.target.clone());
-                session.sni = Some(domain.clone());
+                if source == TargetHostSource::TlsSni {
+                    session.sni = Some(domain.clone());
+                }
                 session.target = Address::Domain(domain);
-                session.target_host_source = Some(TargetHostSource::TlsSni);
+                session.target_host_source = Some(source);
             }
         }
+        Ok(Ok(SniffOutcome::EncryptedClientHello)) => {
+            tracing::debug!(
+                original_target = ?session.target,
+                "TUN observed ECH and retained deterministic DNS-reverse/IP fallback"
+            );
+        }
         Ok(Err(error)) => {
-            tracing::trace!(error = %error, "TUN TLS ClientHello sniff failed");
+            tracing::trace!(error = %error, "TUN application target sniff failed");
         }
         Err(_) => {
-            tracing::trace!("TUN TLS ClientHello sniff timed out");
+            tracing::trace!("TUN application target sniff timed out");
         }
-        Ok(Ok(None)) => {}
+        Ok(Ok(SniffOutcome::None)) => {}
     }
 
     (session, ReplayStream::new(stream, prefix))
 }
 
-async fn peek_tls_sni<R>(reader: &mut R) -> io::Result<Option<String>>
+#[derive(Clone, Copy)]
+enum SniffProtocol {
+    Tls,
+    Http,
+}
+
+enum SniffOutcome {
+    Domain {
+        domain: String,
+        source: TargetHostSource,
+    },
+    EncryptedClientHello,
+    None,
+}
+
+async fn peek_tls_target<R>(reader: &mut R) -> io::Result<SniffOutcome>
 where
     R: AsyncRead + Unpin,
 {
@@ -66,7 +102,7 @@ where
         let mut record_header = [0_u8; 5];
         reader.read_exact(&mut record_header).await?;
         if record_header[0] != 0x16 {
-            return Ok(None);
+            return Ok(SniffOutcome::None);
         }
         let record_length = u16::from_be_bytes([record_header[3], record_header[4]]) as usize;
         if record_length == 0 || record_length > MAX_TLS_RECORD_LENGTH {
@@ -81,7 +117,7 @@ where
 
         if handshake.len() >= 4 {
             if handshake[0] != 0x01 {
-                return Ok(None);
+                return Ok(SniffOutcome::None);
             }
             let length = ((handshake[1] as usize) << 16)
                 | ((handshake[2] as usize) << 8)
@@ -98,10 +134,24 @@ where
         }
     };
 
-    parse_client_hello_sni(&handshake[4..4 + handshake_length])
+    let parsed = parse_client_hello(&handshake[4..4 + handshake_length])?;
+    if parsed.encrypted_client_hello {
+        return Ok(SniffOutcome::EncryptedClientHello);
+    }
+    Ok(parsed
+        .sni
+        .map_or(SniffOutcome::None, |domain| SniffOutcome::Domain {
+            domain,
+            source: TargetHostSource::TlsSni,
+        }))
 }
 
-fn parse_client_hello_sni(client_hello: &[u8]) -> io::Result<Option<String>> {
+struct ParsedTlsHello {
+    sni: Option<String>,
+    encrypted_client_hello: bool,
+}
+
+fn parse_client_hello(client_hello: &[u8]) -> io::Result<ParsedTlsHello> {
     let mut offset = 34;
     let session_id_length = take_u8(client_hello, &mut offset)? as usize;
     take(client_hello, &mut offset, session_id_length)?;
@@ -110,35 +160,141 @@ fn parse_client_hello_sni(client_hello: &[u8]) -> io::Result<Option<String>> {
     let compression_methods_length = take_u8(client_hello, &mut offset)? as usize;
     take(client_hello, &mut offset, compression_methods_length)?;
     if offset == client_hello.len() {
-        return Ok(None);
+        return Ok(ParsedTlsHello {
+            sni: None,
+            encrypted_client_hello: false,
+        });
     }
     let extensions_length = take_u16(client_hello, &mut offset)? as usize;
     let extensions = take(client_hello, &mut offset, extensions_length)?;
-    Ok(parse_sni_extension(extensions))
+    Ok(parse_tls_extensions(extensions))
 }
 
-fn parse_sni_extension(extensions: &[u8]) -> Option<String> {
+fn parse_tls_extensions(extensions: &[u8]) -> ParsedTlsHello {
     let mut offset = 0;
+    let mut sni = None;
+    let mut encrypted_client_hello = false;
     while offset + 4 <= extensions.len() {
         let extension_type = u16::from_be_bytes([extensions[offset], extensions[offset + 1]]);
         let extension_length =
             u16::from_be_bytes([extensions[offset + 2], extensions[offset + 3]]) as usize;
         offset += 4;
         if offset + extension_length > extensions.len() {
-            return None;
+            break;
         }
         let extension = &extensions[offset..offset + extension_length];
         if extension_type == 0 && extension.len() >= 5 && extension[2] == 0 {
             let name_length = u16::from_be_bytes([extension[3], extension[4]]) as usize;
             if 5 + name_length <= extension.len() {
-                return std::str::from_utf8(&extension[5..5 + name_length])
+                sni = std::str::from_utf8(&extension[5..5 + name_length])
                     .ok()
                     .map(ToOwned::to_owned);
             }
+        } else if extension_type == 0xfe0d {
+            encrypted_client_hello = true;
         }
         offset += extension_length;
     }
-    None
+    ParsedTlsHello {
+        sni,
+        encrypted_client_hello,
+    }
+}
+
+async fn peek_http_target<R>(reader: &mut R) -> io::Result<SniffOutcome>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut headers = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 1024];
+    loop {
+        let size = reader.read(&mut chunk).await?;
+        if size == 0 {
+            return Ok(SniffOutcome::None);
+        }
+        headers.extend_from_slice(&chunk[..size]);
+        if headers.len() > MAX_HTTP_HEADER_LENGTH {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP request headers exceed sniffing limit",
+            ));
+        }
+        if let Some(end) = find_http_header_end(&headers) {
+            return Ok(
+                parse_http_host(&headers[..end]).map_or(SniffOutcome::None, |domain| {
+                    SniffOutcome::Domain {
+                        domain,
+                        source: TargetHostSource::HttpHost,
+                    }
+                }),
+            );
+        }
+        if headers.len() >= 16 && !looks_like_http_request(&headers) {
+            return Ok(SniffOutcome::None);
+        }
+    }
+}
+
+fn find_http_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|offset| offset + 4)
+}
+
+fn looks_like_http_request(bytes: &[u8]) -> bool {
+    let Some(space) = bytes.iter().position(|byte| *byte == b' ') else {
+        return false;
+    };
+    space > 0
+        && bytes[..space]
+            .iter()
+            .all(|byte| byte.is_ascii_uppercase() || *byte == b'-')
+}
+
+fn parse_http_host(headers: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(headers).ok()?;
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next()?;
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next()?;
+    let target = request_parts.next()?;
+    let version = request_parts.next()?;
+    if request_parts.next().is_some()
+        || method.is_empty()
+        || !method
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte == b'-')
+        || !matches!(version, "HTTP/1.0" | "HTTP/1.1")
+    {
+        return None;
+    }
+    let host = lines.find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("host").then(|| value.trim())
+    });
+    host.or_else(|| absolute_form_authority(target))
+        .and_then(strip_http_port)
+        .map(ToOwned::to_owned)
+}
+
+fn absolute_form_authority(target: &str) -> Option<&str> {
+    let remainder = target
+        .strip_prefix("http://")
+        .or_else(|| target.strip_prefix("https://"))?;
+    let authority = remainder.split(['/', '?', '#']).next()?;
+    (!authority.is_empty() && !authority.contains('@')).then_some(authority)
+}
+
+fn strip_http_port(authority: &str) -> Option<&str> {
+    if authority.starts_with('[') {
+        return None;
+    }
+    match authority.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() && port.parse::<u16>().is_ok() => Some(host),
+        Some(_) => None,
+        None => Some(authority),
+    }
 }
 
 fn take_u8(bytes: &[u8], offset: &mut usize) -> io::Result<u8> {
@@ -183,3 +339,6 @@ fn normalize_sniffed_domain(domain: String) -> Option<String> {
     }
     Some(domain)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/proxy/src/inbound/tun/sniff/tests.rs
+++ b/crates/proxy/src/inbound/tun/sniff/tests.rs
@@ -1,0 +1,35 @@
+use super::{parse_http_host, parse_tls_extensions};
+
+#[test]
+fn detects_ech_and_does_not_treat_outer_sni_as_the_hidden_name() {
+    let hostname = b"public.example";
+    let mut extensions = Vec::new();
+    extensions.extend_from_slice(&0_u16.to_be_bytes());
+    extensions.extend_from_slice(&((hostname.len() + 5) as u16).to_be_bytes());
+    extensions.extend_from_slice(&((hostname.len() + 3) as u16).to_be_bytes());
+    extensions.push(0);
+    extensions.extend_from_slice(&(hostname.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(hostname);
+    extensions.extend_from_slice(&0xfe0d_u16.to_be_bytes());
+    extensions.extend_from_slice(&0_u16.to_be_bytes());
+
+    let parsed = parse_tls_extensions(&extensions);
+    assert_eq!(parsed.sni.as_deref(), Some("public.example"));
+    assert!(parsed.encrypted_client_hello);
+}
+
+#[test]
+fn parses_host_header_and_absolute_form_without_accepting_userinfo() {
+    assert_eq!(
+        parse_http_host(b"GET / HTTP/1.1\r\nhOsT: Example.COM:8080\r\n\r\n"),
+        Some("Example.COM".to_owned())
+    );
+    assert_eq!(
+        parse_http_host(b"GET http://absolute.example/path HTTP/1.1\r\n\r\n"),
+        Some("absolute.example".to_owned())
+    );
+    assert_eq!(
+        parse_http_host(b"GET http://user@unsafe.example/ HTTP/1.1\r\n\r\n"),
+        None
+    );
+}

--- a/crates/proxy/tests/runtime_boundary.rs
+++ b/crates/proxy/tests/runtime_boundary.rs
@@ -542,9 +542,16 @@ fn protocol_identity_is_open_and_engine_does_not_enumerate_protocols() {
     assert!(session.contains("pub const fn new(name: &'static str) -> Self"));
     assert!(session.contains("pub const fn as_str(self) -> &'static str"));
     assert!(!session.contains("pub enum ProtocolType"));
-    let session_lower = session.to_ascii_lowercase();
+    let protocol_identity = session
+        .split_once("pub struct ProtocolType")
+        .expect("ProtocolType declaration")
+        .1
+        .split_once("pub struct SessionAuth")
+        .expect("SessionAuth declaration after ProtocolType")
+        .0
+        .to_ascii_lowercase();
     for protocol in adapter_feature_names() {
-        assert!(!session_lower.contains(protocol.as_str()));
+        assert!(!protocol_identity.contains(protocol.as_str()));
     }
     assert_sources_exclude(
         &workspace_root().join("crates/engine/src"),

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -132,11 +132,15 @@ journals are migrated in place and retain their live IPv4 mappings while IPv6
 addresses are allocated from the configured v2 pool.
 
 TUN without Fake-IP remains supported. For TLS on ports 443 and 8443 Zero can
-recover a plaintext SNI and route by domain; otherwise routing and dialing stay
-on the original IP. ECH and application-owned encrypted DNS are intentionally
-not decrypted. Port-53 hijacking therefore does not intercept an application's
-own DoH, DoT, or DoQ connection. Use existing traffic route rules to route or
-block known encrypted-DNS endpoints when deployment policy requires it.
+recover a plaintext SNI; for HTTP/1.x on ports 80, 8000, 8080, and 8888 it can
+recover a Host header or absolute-form authority. The consumed prefix is always
+replayed byte-for-byte. When a TLS ClientHello carries ECH, Zero does not treat
+the outer public name as the hidden application name: it falls back to an
+unambiguous DNS reverse mapping and then to the original IP. ECH and
+application-owned encrypted DNS are intentionally not decrypted. Port-53
+hijacking therefore does not intercept an application's own DoH, DoT, or DoQ
+connection. Use existing traffic route rules to route or block known
+encrypted-DNS endpoints when deployment policy requires it.
 
 Flow records expose `target.original_ip`, `target.host_source`, and
 `target.fake_ip_reverse_status`. Together with `target.host`, `resolved_ip`, and

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -195,6 +195,11 @@ sudo tcpdump -i physical0 -nn 'udp port 3478 or udp port 5349'
 - `zero-proxy`：TUN UDP direct、block、防网络泄露以及 DNS/Fake-IP 响应；
 - 平台 CI：Linux、macOS、Windows 原生检查并编译特权 E2E harness。
 
+透明 TCP 嗅探覆盖 TLS SNI 与 HTTP/1.x Host。所有已读取前缀必须原样回放；
+ECH 连接不得把 outer public name 猜作真实目标，先尝试无歧义 DNS 反向映射，
+否则继续使用原始 IP。QUIC Initial/SNI 属于独立 UDP 状态机能力，不能用
+TCP ClientHello 解析器或单包字符串扫描替代。
+
 真实路由和设备操作需要管理员权限，不能由普通单元测试模拟。仓库中的 `tun_privileged_e2e` 会直接读取系统网络状态，校验接口 MTU、地址、拆分默认路由、TCP、DNS 劫持、STUN 基线与 block、强杀后的恢复日志，以及配置移除后的设备和日志清理。IPv4/IPv6 STUN 用例分别以单栈配置运行，需要对应地址族的原生网络和可达 STUN 服务。独立的离线双栈用例通过本地模拟 DNS 和 SOCKS5 出站，验证同一设备的 IPv4/IPv6 地址、四条 `/1` 路由、双族 TCP/DNS 流量和两份恢复日志；它也覆盖物理出口仅有 IPv4 时 IPv6 经代理载荷出站的情形。为公网 STUN 用例提供可达服务并运行：
 
 ```bash


### PR DESCRIPTION
## Summary

- replace the TLS-only TUN TCP probe with a bounded application-target sniffer
- recover HTTP/1.0 and HTTP/1.1 Host headers or absolute-form authorities on common HTTP ports
- keep TLS SNI recovery, including ClientHello split across TLS records
- detect the TLS encrypted_client_hello extension and refuse to route by the outer public name
- replay every consumed byte before relay
- preserve the intercepted IP as the direct socket target

## Safe fallback

For ECH, the session remains an IP target at the sniffer boundary. The lower stacked PR may then recover an unambiguous DNS reverse mapping; otherwise routing continues on the original IP. The implementation never guesses the hidden ECH name.

## Architecture

- parsing remains within the TUN inbound boundary
- recovered target provenance uses neutral `TargetHostSource` values
- HTTP Host does not populate the TLS-specific `Session.sni` fact
- QUIC Initial/SNI is intentionally a separate UDP state-machine capability; this PR does not use unsafe packet string scanning

## Validation

Tests cover TLS replay, split records, non-TLS fallback, SNI-less TLS, HTTP Host normalization/replay, absolute-form parsing, malformed authority rejection, and ECH detection.

This stacked P1 PR is based on #36.