### PR TITLE
fix(tun): serialize route ownership across instances

### DIFF
--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -13,6 +13,7 @@ pub enum TargetHostSource {
     FakeIp,
     DnsReverse,
     HttpHost,
+    QuicSni,
     TlsSni,
 }
 
@@ -22,6 +23,7 @@ impl TargetHostSource {
             Self::FakeIp => "fake_ip",
             Self::DnsReverse => "dns_reverse",
             Self::HttpHost => "http_host",
+            Self::QuicSni => "quic_sni",
             Self::TlsSni => "tls_sni",
         }
     }

--- a/crates/core/src/udp.rs
+++ b/crates/core/src/udp.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 use zero_traits::{AsyncSocket, SocketAddress};
 
-use crate::{Address, Error, ProtocolType, Session, SessionAuth};
+use crate::{Address, Error, ProtocolType, Session, SessionAuth, TargetHostSource};
 
 /// Neutral UDP payload routed by proxy/runtime glue.
 ///
@@ -97,6 +97,8 @@ pub struct InboundUdpDispatch {
     protocol: ProtocolType,
     client_session_id: Option<u64>,
     transparent_target: bool,
+    transparent_original_target: Option<Address>,
+    transparent_host_source: Option<TargetHostSource>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -369,12 +371,27 @@ impl InboundUdpDispatch {
             protocol,
             client_session_id,
             transparent_target: false,
+            transparent_original_target: None,
+            transparent_host_source: None,
         }
     }
 
     /// Mark this packet as originating from transparent interception.
     pub fn with_transparent_target(mut self) -> Self {
         self.transparent_target = true;
+        self
+    }
+
+    /// Preserve the intercepted IP while routing a transparent datagram by a
+    /// hostname recovered from its application traffic.
+    pub fn with_transparent_domain(
+        mut self,
+        original_target: Address,
+        source: TargetHostSource,
+    ) -> Self {
+        self.transparent_target = true;
+        self.transparent_original_target = Some(original_target);
+        self.transparent_host_source = Some(source);
         self
     }
 
@@ -400,6 +417,14 @@ impl InboundUdpDispatch {
 
     pub fn transparent_target(&self) -> bool {
         self.transparent_target
+    }
+
+    pub fn transparent_original_target(&self) -> Option<&Address> {
+        self.transparent_original_target.as_ref()
+    }
+
+    pub fn transparent_host_source(&self) -> Option<TargetHostSource> {
+        self.transparent_host_source
     }
 
     pub fn into_parts(self) -> (ProtocolType, Address, u16, Vec<u8>, Option<u64>) {
@@ -448,3 +473,6 @@ impl UdpFlowPacket {
         (self.target, self.port, self.payload)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/udp/tests.rs
+++ b/crates/core/src/udp/tests.rs
@@ -1,0 +1,23 @@
+use alloc::{string::String, vec};
+
+use crate::{Address, InboundUdpDispatch, ProtocolType, TargetHostSource};
+
+#[test]
+fn transparent_domain_preserves_original_target_metadata() {
+    let original = Address::Ipv6([0x20, 1, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    let dispatch = InboundUdpDispatch::new(
+        ProtocolType::UNKNOWN,
+        Address::Domain(String::from("mail.example")),
+        443,
+        vec![1, 2, 3],
+        None,
+    )
+    .with_transparent_domain(original.clone(), TargetHostSource::QuicSni);
+
+    assert!(dispatch.transparent_target());
+    assert_eq!(dispatch.transparent_original_target(), Some(&original));
+    assert_eq!(
+        dispatch.transparent_host_source(),
+        Some(TargetHostSource::QuicSni)
+    );
+}

--- a/crates/proxy/src/inbound/tun/sniff.rs
+++ b/crates/proxy/src/inbound/tun/sniff.rs
@@ -7,6 +7,9 @@ use zero_core::{Address, Session, TargetHostSource};
 
 use crate::transport::{RecordingStream, ReplayStream};
 
+#[cfg(feature = "udp-runtime")]
+pub(super) mod udp;
+
 const TARGET_SNIFF_TIMEOUT: Duration = Duration::from_millis(200);
 const MAX_TLS_RECORD_LENGTH: usize = 18_432;
 const MAX_CLIENT_HELLO_LENGTH: usize = 65_535;
@@ -84,7 +87,7 @@ enum SniffProtocol {
     Http,
 }
 
-enum SniffOutcome {
+pub(super) enum SniffOutcome {
     Domain {
         domain: String,
         source: TargetHostSource,
@@ -134,7 +137,25 @@ where
         }
     };
 
-    let parsed = parse_client_hello(&handshake[4..4 + handshake_length])?;
+    sniff_tls_handshake(&handshake[..4 + handshake_length])
+}
+
+pub(super) fn sniff_tls_handshake(handshake: &[u8]) -> io::Result<SniffOutcome> {
+    if handshake.len() < 4 || handshake[0] != 0x01 {
+        return Ok(SniffOutcome::None);
+    }
+    let handshake_length =
+        ((handshake[1] as usize) << 16) | ((handshake[2] as usize) << 8) | handshake[3] as usize;
+    if handshake_length > MAX_CLIENT_HELLO_LENGTH {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TLS ClientHello exceeds sniffing limit",
+        ));
+    }
+    let client_hello = handshake
+        .get(4..4 + handshake_length)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "truncated TLS ClientHello"))?;
+    let parsed = parse_client_hello(client_hello)?;
     if parsed.encrypted_client_hello {
         return Ok(SniffOutcome::EncryptedClientHello);
     }

--- a/crates/proxy/src/inbound/tun/sniff/udp.rs
+++ b/crates/proxy/src/inbound/tun/sniff/udp.rs
@@ -1,0 +1,191 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use tokio::sync::mpsc;
+use zero_core::{Address, TargetHostSource};
+use zero_traits::SocketAddress;
+use zero_transport::quic_initial::{
+    looks_like_client_initial, QuicInitialOutcome, QuicInitialSniffer,
+};
+
+use super::{normalize_sniffed_domain, sniff_tls_handshake, SniffOutcome};
+use crate::inbound::tun::udp::TunDatagram;
+
+const QUIC_SNIFF_TIMEOUT: Duration = Duration::from_millis(200);
+const MAX_PENDING_DESTINATIONS: usize = 32;
+const MAX_DECIDED_DESTINATIONS: usize = 64;
+const MAX_BUFFERED_DATAGRAMS: usize = 8;
+const MAX_BUFFERED_BYTES: usize = 64 * 1024;
+
+pub(in crate::inbound::tun) struct SniffedTunDatagram {
+    pub(in crate::inbound::tun) original_destination: SocketAddress,
+    pub(in crate::inbound::tun) target: Address,
+    pub(in crate::inbound::tun) payload: Vec<u8>,
+    pub(in crate::inbound::tun) host_source: Option<TargetHostSource>,
+}
+
+struct PendingQuic {
+    sniffer: QuicInitialSniffer,
+    datagrams: VecDeque<TunDatagram>,
+    buffered_bytes: usize,
+    deadline: Instant,
+}
+
+#[derive(Clone)]
+enum Decision {
+    Domain(String),
+    Fallback,
+}
+
+#[derive(Default)]
+pub(in crate::inbound::tun) struct TunQuicSniffer {
+    pending: HashMap<SocketAddress, PendingQuic>,
+    decisions: HashMap<SocketAddress, Decision>,
+    ready: VecDeque<SniffedTunDatagram>,
+}
+
+impl TunQuicSniffer {
+    pub(in crate::inbound::tun) async fn next(
+        &mut self,
+        receiver: &mut mpsc::Receiver<TunDatagram>,
+    ) -> Option<SniffedTunDatagram> {
+        loop {
+            if let Some(datagram) = self.ready.pop_front() {
+                return Some(datagram);
+            }
+
+            let received = if let Some(deadline) = self.next_deadline() {
+                match tokio::time::timeout_at(deadline.into(), receiver.recv()).await {
+                    Ok(received) => received,
+                    Err(_) => {
+                        self.flush_expired(Instant::now());
+                        continue;
+                    }
+                }
+            } else {
+                receiver.recv().await
+            };
+            let datagram = received?;
+            self.observe(datagram);
+        }
+    }
+
+    fn observe(&mut self, datagram: TunDatagram) {
+        let destination = datagram.destination;
+        if let Some(decision) = self.decisions.get(&destination).cloned() {
+            self.ready.push_back(apply_decision(datagram, decision));
+            return;
+        }
+        if !self.pending.contains_key(&destination)
+            && (!quic_sniff_port(destination.port) || !looks_like_client_initial(&datagram.payload))
+        {
+            self.ready
+                .push_back(apply_decision(datagram, Decision::Fallback));
+            return;
+        }
+        if !self.pending.contains_key(&destination)
+            && self.pending.len() >= MAX_PENDING_DESTINATIONS
+        {
+            self.ready
+                .push_back(apply_decision(datagram, Decision::Fallback));
+            return;
+        }
+
+        let pending = self
+            .pending
+            .entry(destination)
+            .or_insert_with(|| PendingQuic {
+                sniffer: QuicInitialSniffer::new(),
+                datagrams: VecDeque::new(),
+                buffered_bytes: 0,
+                deadline: Instant::now() + QUIC_SNIFF_TIMEOUT,
+            });
+        pending.buffered_bytes = pending
+            .buffered_bytes
+            .saturating_add(datagram.payload.len());
+        let outcome = pending.sniffer.ingest(&datagram.payload);
+        pending.datagrams.push_back(datagram);
+        if pending.datagrams.len() > MAX_BUFFERED_DATAGRAMS
+            || pending.buffered_bytes > MAX_BUFFERED_BYTES
+        {
+            self.resolve(destination, Decision::Fallback);
+            return;
+        }
+        match outcome {
+            QuicInitialOutcome::Pending => {}
+            QuicInitialOutcome::ClientHello(client_hello) => {
+                let decision = match sniff_tls_handshake(&client_hello) {
+                    Ok(SniffOutcome::Domain { domain, .. }) => normalize_sniffed_domain(domain)
+                        .map_or(Decision::Fallback, Decision::Domain),
+                    Ok(SniffOutcome::EncryptedClientHello | SniffOutcome::None) | Err(_) => {
+                        Decision::Fallback
+                    }
+                };
+                self.resolve(destination, decision);
+            }
+            QuicInitialOutcome::NotInitial | QuicInitialOutcome::Rejected => {
+                self.resolve(destination, Decision::Fallback);
+            }
+        }
+    }
+
+    fn resolve(&mut self, destination: SocketAddress, decision: Decision) {
+        let Some(mut pending) = self.pending.remove(&destination) else {
+            return;
+        };
+        if self.decisions.len() < MAX_DECIDED_DESTINATIONS {
+            self.decisions.insert(destination, decision.clone());
+        }
+        while let Some(datagram) = pending.datagrams.pop_front() {
+            self.ready
+                .push_back(apply_decision(datagram, decision.clone()));
+        }
+    }
+
+    fn flush_expired(&mut self, now: Instant) {
+        let expired = self
+            .pending
+            .iter()
+            .filter_map(|(destination, pending)| (pending.deadline <= now).then_some(*destination))
+            .collect::<Vec<_>>();
+        for destination in expired {
+            self.resolve(destination, Decision::Fallback);
+        }
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        self.pending.values().map(|pending| pending.deadline).min()
+    }
+}
+
+fn quic_sniff_port(port: u16) -> bool {
+    matches!(port, 443 | 8443)
+}
+
+fn apply_decision(datagram: TunDatagram, decision: Decision) -> SniffedTunDatagram {
+    let original_destination = datagram.destination;
+    match decision {
+        Decision::Domain(domain) => SniffedTunDatagram {
+            original_destination,
+            target: Address::Domain(domain),
+            payload: datagram.payload,
+            host_source: Some(TargetHostSource::QuicSni),
+        },
+        Decision::Fallback => SniffedTunDatagram {
+            original_destination,
+            target: socket_address_to_address(original_destination),
+            payload: datagram.payload,
+            host_source: None,
+        },
+    }
+}
+
+fn socket_address_to_address(address: SocketAddress) -> Address {
+    match address.ip {
+        zero_traits::IpAddress::V4(ip) => Address::Ipv4(ip),
+        zero_traits::IpAddress::V6(ip) => Address::Ipv6(ip),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/proxy/src/inbound/tun/sniff/udp/tests.rs
+++ b/crates/proxy/src/inbound/tun/sniff/udp/tests.rs
@@ -1,0 +1,28 @@
+use tokio::sync::mpsc;
+use zero_core::Address;
+use zero_traits::{IpAddress, SocketAddress};
+
+use super::TunQuicSniffer;
+use crate::inbound::tun::udp::TunDatagram;
+
+#[tokio::test]
+async fn non_quic_udp_is_forwarded_without_sniff_delay() {
+    let destination = SocketAddress::new(IpAddress::V4([203, 0, 113, 9]), 443);
+    let (sender, mut receiver) = mpsc::channel(1);
+    sender
+        .send(TunDatagram {
+            destination,
+            payload: b"ordinary datagram".to_vec(),
+        })
+        .await
+        .unwrap();
+
+    let datagram = TunQuicSniffer::default()
+        .next(&mut receiver)
+        .await
+        .expect("forward datagram");
+    assert_eq!(datagram.original_destination, destination);
+    assert_eq!(datagram.target, Address::Ipv4([203, 0, 113, 9]));
+    assert!(datagram.host_source.is_none());
+    assert_eq!(datagram.payload, b"ordinary datagram");
+}

--- a/crates/proxy/src/inbound/tun/udp.rs
+++ b/crates/proxy/src/inbound/tun/udp.rs
@@ -12,6 +12,7 @@ use zero_engine::EngineError;
 use zero_stack::UserUdpStack;
 use zero_traits::{IpAddress, SocketAddress, UdpStack};
 
+use super::sniff::udp::TunQuicSniffer;
 use crate::runtime::udp_ingress::UdpIngressRuntime;
 use crate::runtime::Proxy;
 
@@ -23,8 +24,8 @@ const ASSOCIATION_QUEUE_CAPACITY: usize = 128;
 const MAX_CONCURRENT_DNS_QUERIES: usize = 256;
 
 pub(super) struct TunDatagram {
-    destination: SocketAddress,
-    payload: Vec<u8>,
+    pub(super) destination: SocketAddress,
+    pub(super) payload: Vec<u8>,
 }
 
 struct TunUdpRelay {
@@ -37,6 +38,7 @@ struct TunUdpResponder {
     receiver: mpsc::Receiver<TunDatagram>,
     current_destination: Option<SocketAddress>,
     session_destinations: HashMap<u64, SocketAddress>,
+    quic_sniffer: TunQuicSniffer,
 }
 
 struct AssociationStart {
@@ -58,6 +60,7 @@ impl InboundDatagramUdpRelay<Arc<UserUdpStack>> for TunUdpRelay {
                 receiver: self.receiver,
                 current_destination: None,
                 session_destinations: HashMap::new(),
+                quic_sniffer: TunQuicSniffer::default(),
             },
             None,
         )
@@ -70,22 +73,28 @@ impl DatagramUdpResponder<Arc<UserUdpStack>> for TunUdpResponder {
         &mut self,
         _stack: &Arc<UserUdpStack>,
     ) -> Result<Option<InboundUdpDispatch>, Error> {
-        let datagram =
-            match tokio::time::timeout(ASSOCIATION_IDLE_TIMEOUT, self.receiver.recv()).await {
-                Ok(Some(datagram)) => datagram,
-                Ok(None) | Err(_) => return Ok(None),
-            };
-        self.current_destination = Some(datagram.destination);
-        Ok(Some(
-            InboundUdpDispatch::new(
-                ProtocolType::UNKNOWN,
-                socket_address_to_address(datagram.destination),
-                datagram.destination.port,
-                datagram.payload,
-                None,
-            )
-            .with_transparent_target(),
-        ))
+        let datagram = match tokio::time::timeout(
+            ASSOCIATION_IDLE_TIMEOUT,
+            self.quic_sniffer.next(&mut self.receiver),
+        )
+        .await
+        {
+            Ok(Some(datagram)) => datagram,
+            Ok(None) | Err(_) => return Ok(None),
+        };
+        self.current_destination = Some(datagram.original_destination);
+        let original_target = socket_address_to_address(datagram.original_destination);
+        let dispatch = InboundUdpDispatch::new(
+            ProtocolType::UNKNOWN,
+            datagram.target,
+            datagram.original_destination.port,
+            datagram.payload,
+            None,
+        );
+        Ok(Some(match datagram.host_source {
+            Some(source) => dispatch.with_transparent_domain(original_target, source),
+            None => dispatch.with_transparent_target(),
+        }))
     }
 
     fn on_dispatch_success(&mut self, session_id: u64, _dispatch: &InboundUdpDispatch) {

--- a/crates/proxy/src/runtime/pipe/udp.rs
+++ b/crates/proxy/src/runtime/pipe/udp.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-use zero_core::{Address, InboundUdpDispatch, ProtocolType, SessionAuth};
+use zero_core::{Address, InboundUdpDispatch, ProtocolType, SessionAuth, TargetHostSource};
 use zero_engine::EngineError;
 
 use crate::runtime::udp_dispatch::UdpDispatch;
@@ -22,6 +22,8 @@ pub(crate) struct UdpPipeInput<'a> {
     pub(crate) client_session_id: Option<u64>,
     /// Whether the IP target came from transparent interception.
     pub(crate) transparent_target: bool,
+    pub(crate) transparent_original_target: Option<Address>,
+    pub(crate) transparent_host_source: Option<TargetHostSource>,
 }
 
 /// UDP datagram pipe.
@@ -60,6 +62,8 @@ impl<'a> UdpPipeInput<'a> {
             source_addr,
             client_session_id: dispatch.client_session_id(),
             transparent_target: dispatch.transparent_target(),
+            transparent_original_target: dispatch.transparent_original_target().cloned(),
+            transparent_host_source: dispatch.transparent_host_source(),
         }
     }
 }

--- a/crates/proxy/src/runtime/udp_dispatch/dispatch.rs
+++ b/crates/proxy/src/runtime/udp_dispatch/dispatch.rs
@@ -53,6 +53,16 @@ impl UdpDispatch {
         let ingress_key = UdpFlowKey::new(&input.target, input.port, input.client_session_id);
         let mut session = Session::new(0, input.target, input.port, Network::Udp, input.protocol);
         session.transparent_target = input.transparent_target;
+        if let Some(original_target) = input.transparent_original_target {
+            session.original_target = Some(original_target.clone());
+            session.direct_target = Some(original_target);
+            session.target_host_source = input.transparent_host_source;
+            if input.transparent_host_source == Some(zero_core::TargetHostSource::QuicSni) {
+                if let zero_core::Address::Domain(domain) = &session.target {
+                    session.sni = Some(domain.clone());
+                }
+            }
+        }
         if let Some(auth) = input.auth {
             session.apply_auth(auth.clone());
         }

--- a/crates/proxy/src/runtime/udp_dispatch/dispatch/tests.rs
+++ b/crates/proxy/src/runtime/udp_dispatch/dispatch/tests.rs
@@ -22,6 +22,8 @@ fn input<'a>(
         source_addr: None,
         client_session_id: None,
         transparent_target: false,
+        transparent_original_target: None,
+        transparent_host_source: None,
     }
 }
 

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -18,6 +18,7 @@ tls = []
 ws = []
 
 [dependencies]
+aes = "0.8"
 bytes = "1"
 futures-util = "0.3"
 h2 = "0.4"

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -21,6 +21,7 @@ pub mod outbound_stack;
 pub mod profile;
 #[cfg(feature = "quic")]
 pub mod quic;
+pub mod quic_initial;
 #[cfg(feature = "split_http")]
 pub mod split_http;
 pub mod stream;

--- a/crates/transport/src/quic_initial.rs
+++ b/crates/transport/src/quic_initial.rs
@@ -1,0 +1,88 @@
+//! Bounded, passive QUIC Initial decryption for traffic classification.
+//!
+//! Initial keys are public by design. This module only reconstructs the client
+//! Initial CRYPTO stream; it does not terminate QUIC or retain application data.
+
+mod crypto;
+mod frame;
+mod packet;
+
+use std::collections::HashMap;
+
+use frame::CryptoReassembler;
+use packet::decrypt_client_initial;
+
+const MAX_CONNECTION_IDS: usize = 8;
+
+/// Result of observing one UDP datagram for a possible QUIC ClientHello.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum QuicInitialOutcome {
+    /// The datagram is not a supported QUIC client Initial.
+    NotInitial,
+    /// More Initial CRYPTO data is required.
+    Pending,
+    /// A complete TLS ClientHello handshake message, including its 4-byte
+    /// handshake header, has been reconstructed.
+    ClientHello(Vec<u8>),
+    /// The datagram looked like an Initial but was malformed or could not be
+    /// authenticated. Callers must fall back without guessing a hostname.
+    Rejected,
+}
+
+/// Per-UDP-flow QUIC Initial state.
+#[derive(Default)]
+pub struct QuicInitialSniffer {
+    crypto: CryptoReassembler,
+    largest_packet_numbers: HashMap<Vec<u8>, u64>,
+}
+
+impl QuicInitialSniffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Observe all coalesced packets in one UDP datagram.
+    pub fn ingest(&mut self, datagram: &[u8]) -> QuicInitialOutcome {
+        if !looks_like_client_initial(datagram) {
+            return QuicInitialOutcome::NotInitial;
+        }
+
+        let decrypted = match decrypt_client_initial(datagram, &mut self.largest_packet_numbers) {
+            Ok(Some(decrypted)) => decrypted,
+            Ok(None) => return QuicInitialOutcome::Pending,
+            Err(()) => return QuicInitialOutcome::Rejected,
+        };
+        if self.largest_packet_numbers.len() > MAX_CONNECTION_IDS {
+            return QuicInitialOutcome::Rejected;
+        }
+        for plaintext in decrypted {
+            if frame::collect_crypto_frames(&plaintext, &mut self.crypto).is_err() {
+                return QuicInitialOutcome::Rejected;
+            }
+        }
+        match self.crypto.client_hello() {
+            Ok(Some(client_hello)) => QuicInitialOutcome::ClientHello(client_hello),
+            Ok(None) => QuicInitialOutcome::Pending,
+            Err(()) => QuicInitialOutcome::Rejected,
+        }
+    }
+}
+
+/// Cheap classification used before allocating per-flow state.
+pub fn looks_like_client_initial(datagram: &[u8]) -> bool {
+    let Some((&first, remainder)) = datagram.split_first() else {
+        return false;
+    };
+    if first & 0xc0 != 0xc0 || remainder.len() < 4 {
+        return false;
+    }
+    let version = u32::from_be_bytes([remainder[0], remainder[1], remainder[2], remainder[3]]);
+    match version {
+        packet::QUIC_V1 => (first >> 4) & 0x03 == 0,
+        packet::QUIC_V2 => (first >> 4) & 0x03 == 1,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/transport/src/quic_initial/crypto.rs
+++ b/crates/transport/src/quic_initial/crypto.rs
@@ -1,0 +1,111 @@
+use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::Aes128;
+use ring::{aead, hkdf};
+
+const INITIAL_SALT_V1: [u8; 20] = [
+    0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17, 0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad,
+    0xcc, 0xbb, 0x7f, 0x0a,
+];
+const INITIAL_SALT_V2: [u8; 20] = [
+    0x0d, 0xed, 0xe3, 0xde, 0xf7, 0x00, 0xa6, 0xdb, 0x81, 0x93, 0x81, 0xbe, 0x6e, 0x26, 0x9d, 0xcb,
+    0xf9, 0xbd, 0x2e, 0xd9,
+];
+
+pub(super) struct InitialKeys {
+    key: [u8; 16],
+    iv: [u8; 12],
+    hp: [u8; 16],
+}
+
+impl InitialKeys {
+    pub(super) fn derive(version: u32, destination_connection_id: &[u8]) -> Result<Self, ()> {
+        let (salt, key_label, iv_label, hp_label) = match version {
+            super::packet::QUIC_V1 => {
+                (INITIAL_SALT_V1.as_slice(), "quic key", "quic iv", "quic hp")
+            }
+            super::packet::QUIC_V2 => (
+                INITIAL_SALT_V2.as_slice(),
+                "quicv2 key",
+                "quicv2 iv",
+                "quicv2 hp",
+            ),
+            _ => return Err(()),
+        };
+        let initial = hkdf::Salt::new(hkdf::HKDF_SHA256, salt).extract(destination_connection_id);
+        let client_secret = expand::<32>(&initial, "client in")?;
+        let client = hkdf::Prk::new_less_safe(hkdf::HKDF_SHA256, &client_secret);
+        Ok(Self {
+            key: expand::<16>(&client, key_label)?,
+            iv: expand::<12>(&client, iv_label)?,
+            hp: expand::<16>(&client, hp_label)?,
+        })
+    }
+
+    pub(super) fn header_mask(&self, sample: &[u8]) -> Result<[u8; 5], ()> {
+        let mut block = aes::Block::clone_from_slice(sample.get(..16).ok_or(())?);
+        Aes128::new_from_slice(&self.hp)
+            .map_err(|_| ())?
+            .encrypt_block(&mut block);
+        let mut mask = [0_u8; 5];
+        mask.copy_from_slice(&block[..5]);
+        Ok(mask)
+    }
+
+    pub(super) fn decrypt(
+        &self,
+        packet_number: u64,
+        header: &[u8],
+        ciphertext: &mut [u8],
+    ) -> Result<Vec<u8>, ()> {
+        let mut nonce = self.iv;
+        for (left, right) in nonce[4..].iter_mut().zip(packet_number.to_be_bytes()) {
+            *left ^= right;
+        }
+        let key = aead::UnboundKey::new(&aead::AES_128_GCM, &self.key).map_err(|_| ())?;
+        let key = aead::LessSafeKey::new(key);
+        let plaintext = key
+            .open_in_place(
+                aead::Nonce::assume_unique_for_key(nonce),
+                aead::Aad::from(header),
+                ciphertext,
+            )
+            .map_err(|_| ())?;
+        Ok(plaintext.to_vec())
+    }
+}
+
+struct OutputLength(usize);
+
+impl hkdf::KeyType for OutputLength {
+    fn len(&self) -> usize {
+        self.0
+    }
+}
+
+fn expand<const N: usize>(secret: &hkdf::Prk, label: &str) -> Result<[u8; N], ()> {
+    let label = format!("tls13 {label}");
+    let mut info = Vec::with_capacity(4 + label.len());
+    info.extend_from_slice(&(N as u16).to_be_bytes());
+    info.push(label.len().try_into().map_err(|_| ())?);
+    info.extend_from_slice(label.as_bytes());
+    info.push(0);
+    let mut output = [0_u8; N];
+    let info_parts = [info.as_slice()];
+    let output_key = secret
+        .expand(&info_parts, OutputLength(N))
+        .map_err(|_| ())?;
+    output_key.fill(&mut output).map_err(|_| ())?;
+    Ok(output)
+}
+
+#[cfg(test)]
+pub(super) fn vector_keys(destination_connection_id: &[u8]) -> Result<InitialKeys, ()> {
+    InitialKeys::derive(super::packet::QUIC_V1, destination_connection_id)
+}
+
+#[cfg(test)]
+impl InitialKeys {
+    pub(super) fn parts(&self) -> (&[u8], &[u8], &[u8]) {
+        (&self.key, &self.iv, &self.hp)
+    }
+}

--- a/crates/transport/src/quic_initial/frame.rs
+++ b/crates/transport/src/quic_initial/frame.rs
@@ -1,0 +1,118 @@
+const MAX_CLIENT_HELLO_LENGTH: usize = 65_535;
+
+#[derive(Default)]
+pub(super) struct CryptoReassembler {
+    bytes: Vec<u8>,
+    present: Vec<bool>,
+}
+
+impl CryptoReassembler {
+    fn insert(&mut self, offset: usize, data: &[u8]) -> Result<(), ()> {
+        let end = offset.checked_add(data.len()).ok_or(())?;
+        if end > MAX_CLIENT_HELLO_LENGTH + 4 {
+            return Err(());
+        }
+        if self.bytes.len() < end {
+            self.bytes.resize(end, 0);
+            self.present.resize(end, false);
+        }
+        for (index, byte) in data.iter().copied().enumerate() {
+            let position = offset + index;
+            if self.present[position] && self.bytes[position] != byte {
+                return Err(());
+            }
+            self.bytes[position] = byte;
+            self.present[position] = true;
+        }
+        Ok(())
+    }
+
+    pub(super) fn client_hello(&self) -> Result<Option<Vec<u8>>, ()> {
+        if self.present.len() < 4 || !self.present[..4].iter().all(|present| *present) {
+            return Ok(None);
+        }
+        if self.bytes[0] != 0x01 {
+            return Err(());
+        }
+        let length = ((self.bytes[1] as usize) << 16)
+            | ((self.bytes[2] as usize) << 8)
+            | self.bytes[3] as usize;
+        if length > MAX_CLIENT_HELLO_LENGTH {
+            return Err(());
+        }
+        let end = 4 + length;
+        if self.present.len() < end || !self.present[..end].iter().all(|present| *present) {
+            return Ok(None);
+        }
+        Ok(Some(self.bytes[..end].to_vec()))
+    }
+}
+
+pub(super) fn collect_crypto_frames(
+    plaintext: &[u8],
+    crypto: &mut CryptoReassembler,
+) -> Result<(), ()> {
+    let mut offset = 0;
+    while offset < plaintext.len() {
+        let frame_type = read_varint(plaintext, &mut offset)?;
+        match frame_type {
+            0x00 => {}
+            0x01 => {}
+            0x02 | 0x03 => skip_ack(plaintext, &mut offset, frame_type == 0x03)?,
+            0x06 => {
+                let crypto_offset =
+                    usize::try_from(read_varint(plaintext, &mut offset)?).map_err(|_| ())?;
+                let length =
+                    usize::try_from(read_varint(plaintext, &mut offset)?).map_err(|_| ())?;
+                let end = offset.checked_add(length).ok_or(())?;
+                let data = plaintext.get(offset..end).ok_or(())?;
+                crypto.insert(crypto_offset, data)?;
+                offset = end;
+            }
+            0x1c => skip_connection_close(plaintext, &mut offset)?,
+            _ => return Err(()),
+        }
+    }
+    Ok(())
+}
+
+fn skip_ack(bytes: &[u8], offset: &mut usize, ecn: bool) -> Result<(), ()> {
+    read_varint(bytes, offset)?;
+    read_varint(bytes, offset)?;
+    let ranges = read_varint(bytes, offset)?;
+    read_varint(bytes, offset)?;
+    for _ in 0..ranges {
+        read_varint(bytes, offset)?;
+        read_varint(bytes, offset)?;
+    }
+    if ecn {
+        read_varint(bytes, offset)?;
+        read_varint(bytes, offset)?;
+        read_varint(bytes, offset)?;
+    }
+    Ok(())
+}
+
+fn skip_connection_close(bytes: &[u8], offset: &mut usize) -> Result<(), ()> {
+    read_varint(bytes, offset)?;
+    read_varint(bytes, offset)?;
+    let reason_length = usize::try_from(read_varint(bytes, offset)?).map_err(|_| ())?;
+    *offset = (*offset).checked_add(reason_length).ok_or(())?;
+    if *offset > bytes.len() {
+        return Err(());
+    }
+    Ok(())
+}
+
+pub(super) fn read_varint(bytes: &[u8], offset: &mut usize) -> Result<u64, ()> {
+    let first = *bytes.get(*offset).ok_or(())?;
+    let length = 1_usize << (first >> 6);
+    let end = (*offset).checked_add(length).ok_or(())?;
+    let encoded = bytes.get(*offset..end).ok_or(())?;
+    let mut value = u64::from(first & 0x3f);
+    for byte in &encoded[1..] {
+        value = (value << 8) | u64::from(*byte);
+    }
+    *offset = end;
+    Ok(value)
+}

--- a/crates/transport/src/quic_initial/packet.rs
+++ b/crates/transport/src/quic_initial/packet.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+
+use super::crypto::InitialKeys;
+use super::frame::read_varint;
+
+pub(super) const QUIC_V1: u32 = 0x0000_0001;
+pub(super) const QUIC_V2: u32 = 0x6b33_43cf;
+
+struct InitialHeader<'a> {
+    version: u32,
+    destination_connection_id: &'a [u8],
+    packet_number_offset: usize,
+    packet_end: usize,
+}
+
+pub(super) fn decrypt_client_initial(
+    datagram: &[u8],
+    largest_packet_numbers: &mut HashMap<Vec<u8>, u64>,
+) -> Result<Option<Vec<Vec<u8>>>, ()> {
+    let mut offset = 0;
+    let mut plaintexts = Vec::new();
+    while offset < datagram.len() && super::looks_like_client_initial(&datagram[offset..]) {
+        let (plaintext, consumed) = decrypt_one(&datagram[offset..], largest_packet_numbers)?;
+        plaintexts.push(plaintext);
+        offset = offset.checked_add(consumed).ok_or(())?;
+    }
+    Ok((!plaintexts.is_empty()).then_some(plaintexts))
+}
+
+fn decrypt_one(
+    packet: &[u8],
+    largest_packet_numbers: &mut HashMap<Vec<u8>, u64>,
+) -> Result<(Vec<u8>, usize), ()> {
+    let header = parse_initial_header(packet)?;
+    let keys = InitialKeys::derive(header.version, header.destination_connection_id)?;
+    let sample_offset = header.packet_number_offset.checked_add(4).ok_or(())?;
+    let sample_end = sample_offset.checked_add(16).ok_or(())?;
+    let mask = keys.header_mask(packet.get(sample_offset..sample_end).ok_or(())?)?;
+
+    let first = packet[0] ^ (mask[0] & 0x0f);
+    let packet_number_length = usize::from((first & 0x03) + 1);
+    let packet_number_end = header
+        .packet_number_offset
+        .checked_add(packet_number_length)
+        .ok_or(())?;
+    if packet_number_end > header.packet_end {
+        return Err(());
+    }
+    let mut packet_number_bytes = [0_u8; 4];
+    for index in 0..packet_number_length {
+        packet_number_bytes[4 - packet_number_length + index] =
+            packet[header.packet_number_offset + index] ^ mask[index + 1];
+    }
+    let truncated = u64::from(u32::from_be_bytes(packet_number_bytes));
+    let connection_id = header.destination_connection_id.to_vec();
+    let expected = largest_packet_numbers
+        .get(&connection_id)
+        .copied()
+        .map_or(0, |largest| largest.saturating_add(1));
+    let packet_number = decode_packet_number(expected, truncated, packet_number_length);
+
+    let mut unprotected_header = packet[..packet_number_end].to_vec();
+    unprotected_header[0] = first;
+    unprotected_header[header.packet_number_offset..packet_number_end]
+        .copy_from_slice(&packet_number_bytes[4 - packet_number_length..]);
+    let mut ciphertext = packet[packet_number_end..header.packet_end].to_vec();
+    let plaintext = keys.decrypt(packet_number, &unprotected_header, &mut ciphertext)?;
+    largest_packet_numbers
+        .entry(connection_id)
+        .and_modify(|largest| *largest = (*largest).max(packet_number))
+        .or_insert(packet_number);
+    Ok((plaintext, header.packet_end))
+}
+
+fn parse_initial_header(datagram: &[u8]) -> Result<InitialHeader<'_>, ()> {
+    if datagram.len() < 7 || datagram[0] & 0xc0 != 0xc0 {
+        return Err(());
+    }
+    let version = u32::from_be_bytes([datagram[1], datagram[2], datagram[3], datagram[4]]);
+    let initial_type = match version {
+        QUIC_V1 => 0,
+        QUIC_V2 => 1,
+        _ => return Err(()),
+    };
+    if (datagram[0] >> 4) & 0x03 != initial_type {
+        return Err(());
+    }
+    let mut offset = 5;
+    let destination_length = usize::from(*datagram.get(offset).ok_or(())?);
+    offset += 1;
+    let destination_end = offset.checked_add(destination_length).ok_or(())?;
+    let destination_connection_id = datagram.get(offset..destination_end).ok_or(())?;
+    offset = destination_end;
+    let source_length = usize::from(*datagram.get(offset).ok_or(())?);
+    offset += 1;
+    offset = offset.checked_add(source_length).ok_or(())?;
+    if offset > datagram.len() {
+        return Err(());
+    }
+    let token_length = usize::try_from(read_varint(datagram, &mut offset)?).map_err(|_| ())?;
+    offset = offset.checked_add(token_length).ok_or(())?;
+    if offset > datagram.len() {
+        return Err(());
+    }
+    let protected_length = usize::try_from(read_varint(datagram, &mut offset)?).map_err(|_| ())?;
+    let packet_end = offset.checked_add(protected_length).ok_or(())?;
+    if packet_end > datagram.len() || protected_length < 17 {
+        return Err(());
+    }
+    Ok(InitialHeader {
+        version,
+        destination_connection_id,
+        packet_number_offset: offset,
+        packet_end,
+    })
+}
+
+fn decode_packet_number(expected: u64, truncated: u64, encoded_length: usize) -> u64 {
+    let bits = encoded_length * 8;
+    let window = 1_u64 << bits;
+    let half_window = window / 2;
+    let mask = window - 1;
+    let candidate = (expected & !mask) | truncated;
+    if candidate.saturating_add(half_window) <= expected
+        && candidate < (1_u64 << 62).saturating_sub(window)
+    {
+        candidate + window
+    } else if candidate > expected.saturating_add(half_window) && candidate >= window {
+        candidate - window
+    } else {
+        candidate
+    }
+}

--- a/crates/transport/src/quic_initial/tests.rs
+++ b/crates/transport/src/quic_initial/tests.rs
@@ -1,0 +1,94 @@
+use super::crypto::vector_keys;
+use super::{QuicInitialOutcome, QuicInitialSniffer};
+
+#[test]
+fn rfc_9001_client_keys_and_header_mask_match() {
+    let destination_connection_id = decode("8394c8f03e515708");
+    let keys = vector_keys(&destination_connection_id).expect("derive RFC keys");
+    let (key, iv, hp) = keys.parts();
+    assert_eq!(key, decode("1f369613dd76d5467730efcbe3b1a22d"));
+    assert_eq!(iv, decode("fa044b2f42a3fd3b46fb255c"));
+    assert_eq!(hp, decode("9f50449e04a0e810283a1e9933adedd2"));
+    assert_eq!(
+        keys.header_mask(&decode("d1b1c98dd7689fb8ec11d242b123dc9b"))
+            .expect("derive header mask"),
+        [0x43, 0x7b, 0x9a, 0xec, 0x36]
+    );
+}
+
+#[test]
+fn decrypts_rfc_9001_client_initial_and_reassembles_client_hello() {
+    let packet = decode(concat!(
+        "c000000001088394c8f03e5157080000449e7b9aec34d1b1c98dd7689fb8ec11",
+        "d242b123dc9bd8bab936b47d92ec356c0bab7df5976d27cd449f63300099f399",
+        "1c260ec4c60d17b31f8429157bb35a1282a643a8d2262cad67500cadb8e7378c",
+        "8eb7539ec4d4905fed1bee1fc8aafba17c750e2c7ace01e6005f80fcb7df6212",
+        "30c83711b39343fa028cea7f7fb5ff89eac2308249a02252155e2347b63d58c5",
+        "457afd84d05dfffdb20392844ae812154682e9cf012f9021a6f0be17ddd0c208",
+        "4dce25ff9b06cde535d0f920a2db1bf362c23e596d11a4f5a6cf3948838a3aec",
+        "4e15daf8500a6ef69ec4e3feb6b1d98e610ac8b7ec3faf6ad760b7bad1db4ba3",
+        "485e8a94dc250ae3fdb41ed15fb6a8e5eba0fc3dd60bc8e30c5c4287e53805db",
+        "059ae0648db2f64264ed5e39be2e20d82df566da8dd5998ccabdae053060ae6c",
+        "7b4378e846d29f37ed7b4ea9ec5d82e7961b7f25a9323851f681d582363aa5f8",
+        "9937f5a67258bf63ad6f1a0b1d96dbd4faddfcefc5266ba6611722395c906556",
+        "be52afe3f565636ad1b17d508b73d8743eeb524be22b3dcbc2c7468d54119c74",
+        "68449a13d8e3b95811a198f3491de3e7fe942b330407abf82a4ed7c1b311663a",
+        "c69890f4157015853d91e923037c227a33cdd5ec281ca3f79c44546b9d90ca00",
+        "f064c99e3dd97911d39fe9c5d0b23a229a234cb36186c4819e8b9c5927726632",
+        "291d6a418211cc2962e20fe47feb3edf330f2c603a9d48c0fcb5699dbfe58964",
+        "25c5bac4aee82e57a85aaf4e2513e4f05796b07ba2ee47d80506f8d2c25e50fd",
+        "14de71e6c418559302f939b0e1abd576f279c4b2e0feb85c1f28ff18f58891ff",
+        "ef132eef2fa09346aee33c28eb130ff28f5b766953334113211996d20011a198",
+        "e3fc433f9f2541010ae17c1bf202580f6047472fb36857fe843b19f5984009dd",
+        "c324044e847a4f4a0ab34f719595de37252d6235365e9b84392b061085349d73",
+        "203a4a13e96f5432ec0fd4a1ee65accdd5e3904df54c1da510b0ff20dcc0c77f",
+        "cb2c0e0eb605cb0504db87632cf3d8b4dae6e705769d1de354270123cb11450e",
+        "fc60ac47683d7b8d0f811365565fd98c4c8eb936bcab8d069fc33bd801b03ade",
+        "a2e1fbc5aa463d08ca19896d2bf59a071b851e6c239052172f296bfb5e724047",
+        "90a2181014f3b94a4e97d117b438130368cc39dbb2d198065ae3986547926cd2",
+        "162f40a29f0c3c8745c0f50fba3852e566d44575c29d39a03f0cda721984b6f4",
+        "40591f355e12d439ff150aab7613499dbd49adabc8676eef023b15b65bfc5ca0",
+        "6948109f23f350db82123535eb8a7433bdabcb909271a6ecbcb58b936a88cd4e",
+        "8f2e6ff5800175f113253d8fa9ca8885c2f552e657dc603f252e1a8e308f76f0",
+        "be79e2fb8f5d5fbbe2e30ecadd220723c8c0aea8078cdfcb3868263ff8f09400",
+        "54da48781893a7e49ad5aff4af300cd804a6b6279ab3ff3afb64491c85194aab",
+        "760d58a606654f9f4400e8b38591356fbf6425aca26dc85244259ff2b19c41b9",
+        "f96f3ca9ec1dde434da7d2d392b905ddf3d1f9af93d1af5950bd493f5aa731b4",
+        "056df31bd267b6b90a079831aaf579be0a39013137aac6d404f518cfd4684064",
+        "7e78bfe706ca4cf5e9c5453e9f7cfd2b8b4c8d169a44e55c88d4a9a7f9474241",
+        "e221af44860018ab0856972e194cd934"
+    ));
+    assert_eq!(packet.len(), 1_200);
+
+    let mut sniffer = QuicInitialSniffer::new();
+    let QuicInitialOutcome::ClientHello(client_hello) = sniffer.ingest(&packet) else {
+        panic!("RFC client Initial did not produce a ClientHello");
+    };
+    assert_eq!(client_hello.len(), 241);
+    assert!(client_hello
+        .windows(b"example.com".len())
+        .any(|window| window == b"example.com"));
+}
+
+fn decode(input: &str) -> Vec<u8> {
+    assert_eq!(input.len() % 2, 0);
+    input
+        .as_bytes()
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|pair| {
+            let high = digit(pair[0]);
+            let low = digit(pair[1]);
+            (high << 4) | low
+        })
+        .collect()
+}
+
+fn digit(value: u8) -> u8 {
+    match value {
+        b'0'..=b'9' => value - b'0',
+        b'a'..=b'f' => value - b'a' + 10,
+        _ => panic!("invalid hex digit"),
+    }
+}

--- a/crates/tun/src/route/journal.rs
+++ b/crates/tun/src/route/journal.rs
@@ -33,11 +33,21 @@ pub(super) struct RouteLease {
 impl RouteLease {
     pub(super) fn acquire(recovery_key: &str, ipv6: bool) -> io::Result<Self> {
         let journal_path = route_journal_path(recovery_key, ipv6)?;
-        Self::acquire_at(journal_path, recovery_key)
+        let lock_path = route_family_lock_path(ipv6)?;
+        Self::acquire_paths(journal_path, lock_path, recovery_key)
     }
 
+    #[cfg(test)]
     pub(super) fn acquire_at(journal_path: PathBuf, tun_name: &str) -> io::Result<Self> {
         let lock_path = journal_path.with_extension("lock");
+        Self::acquire_paths(journal_path, lock_path, tun_name)
+    }
+
+    pub(super) fn acquire_paths(
+        journal_path: PathBuf,
+        lock_path: PathBuf,
+        owner: &str,
+    ) -> io::Result<Self> {
         let lock = std::fs::OpenOptions::new()
             .create(true)
             .truncate(false)
@@ -45,14 +55,20 @@ impl RouteLease {
             .write(true)
             .open(&lock_path)?;
         fs2::FileExt::try_lock_exclusive(&lock).map_err(|error| {
+            let active_owner = std::fs::read_to_string(&lock_path)
+                .ok()
+                .map(|owner| owner.trim().to_owned())
+                .filter(|owner| !owner.is_empty())
+                .unwrap_or_else(|| "unknown".to_owned());
             io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!(
-                    "TUN route transaction for `{tun_name}` is already active (`{}`): {error}",
+                    "TUN route transaction for `{owner}` conflicts with active owner `{active_owner}` (`{}`): {error}",
                     lock_path.display()
                 ),
             )
         })?;
+        persist_lock_owner(&lock, owner)?;
         Ok(Self {
             journal_path,
             _lock: lock,
@@ -224,6 +240,21 @@ impl RouteJournal {
 
 fn route_journal_path(recovery_key: &str, ipv6: bool) -> io::Result<PathBuf> {
     let root = route_state_root()?;
+    let safe_name = safe_recovery_key(recovery_key);
+    Ok(root.join(format!(
+        "routes-{safe_name}-{}.json",
+        if ipv6 { "v6" } else { "v4" }
+    )))
+}
+
+fn route_family_lock_path(ipv6: bool) -> io::Result<PathBuf> {
+    Ok(route_state_root()?.join(format!(
+        "routes-{}.owner.lock",
+        if ipv6 { "v6" } else { "v4" }
+    )))
+}
+
+fn safe_recovery_key(recovery_key: &str) -> String {
     let safe_name: String = recovery_key
         .chars()
         .map(|character| {
@@ -235,15 +266,21 @@ fn route_journal_path(recovery_key: &str, ipv6: bool) -> io::Result<PathBuf> {
         })
         .take(64)
         .collect();
-    Ok(root.join(format!(
-        "routes-{}-{}.json",
-        if safe_name.is_empty() {
-            "tun"
-        } else {
-            &safe_name
-        },
-        if ipv6 { "v6" } else { "v4" }
-    )))
+    if safe_name.is_empty() {
+        "tun".to_owned()
+    } else {
+        safe_name
+    }
+}
+
+fn persist_lock_owner(lock: &std::fs::File, owner: &str) -> io::Result<()> {
+    use std::io::{Seek, Write};
+
+    let mut lock = lock;
+    lock.set_len(0)?;
+    lock.rewind()?;
+    lock.write_all(safe_recovery_key(owner).as_bytes())?;
+    lock.sync_data()
 }
 
 pub(super) fn route_state_root() -> io::Result<PathBuf> {

--- a/crates/tun/src/route/tests.rs
+++ b/crates/tun/src/route/tests.rs
@@ -126,6 +126,35 @@ fn route_lease_serializes_same_device_transactions() {
 }
 
 #[test]
+fn route_lease_serializes_different_instances_per_address_family() {
+    let directory = tempfile::tempdir().expect("temporary lease directory");
+    let lock_path = directory.path().join("routes-v4.owner.lock");
+    let first = RouteLease::acquire_paths(
+        directory.path().join("routes-first-v4.json"),
+        lock_path.clone(),
+        "first-instance",
+    )
+    .expect("first instance lease");
+
+    let error = RouteLease::acquire_paths(
+        directory.path().join("routes-second-v4.json"),
+        lock_path.clone(),
+        "second-instance",
+    )
+    .expect_err("a different tag must not own the same family concurrently");
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert!(error.to_string().contains("active owner `first-instance`"));
+
+    drop(first);
+    RouteLease::acquire_paths(
+        directory.path().join("routes-second-v4.json"),
+        lock_path,
+        "second-instance",
+    )
+    .expect("next instance takes ownership after release");
+}
+
+#[test]
 fn recovery_key_can_load_a_journal_from_a_renumbered_dynamic_device() {
     let directory = tempfile::tempdir().expect("temporary journal directory");
     let path = directory.path().join("routes-stable-tag-v4.json");

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -321,7 +321,7 @@ UDP 数据包路径通过 `UdpPacketPath`、`DatagramCodec` 等中性接口组�
 
 ### `zero-tun`
 
-`zero-tun` 定义平台无关的 TUN 设备抽象、Linux/macOS/Windows 设备实现和事务化系统路由。平台驱动的部署仍由最终应用或安装器负责。自动路由默认同时用两组 `/1` 接管 IPv4/IPv6，并按地址族记录和绑定各自的物理出口（例如 Windows 的 IPv4 以太网与 IPv6 Teredo 可以不同）；macOS 还为绑定物理接口的 socket 维护 interface-scoped 默认路由，避免 `/1` 接管后物理出口查询直接返回不可达。路由事务持有跨进程 lease，并持久记录 Zero 安装的半默认路由、显式目的网络排除项和 scoped 绕行项；异常退出后的同名设备启动先恢复残留项。
+`zero-tun` 定义平台无关的 TUN 设备抽象、Linux/macOS/Windows 设备实现和事务化系统路由。平台驱动的部署仍由最终应用或安装器负责。自动路由默认同时用两组 `/1` 接管 IPv4/IPv6，并按地址族记录和绑定各自的物理出口（例如 Windows 的 IPv4 以太网与 IPv6 Teredo 可以不同）；macOS 还为绑定物理接口的 socket 维护 interface-scoped 默认路由，避免 `/1` 接管后物理出口查询直接返回不可达。路由事务按地址族持有主机级跨进程 lease，而不是按可配置 tag 隔离；因此两个实例不能同时改写同一地址族的捕获路由。恢复日志仍按稳定 tag 寻址，并持久记录 Zero 安装的半默认路由、显式目的网络排除项和 scoped 绕行项；异常退出后的同名设备启动先恢复残留项。
 
 TUN 反环路由两类互不替代的机制组成：捕获路由只负责让应用流量进入 Zero；运行时拥有的 TCP/UDP/QUIC socket 工厂负责在系统路由仍指向 Zero TUN 时把自身流量绑定到 underlay 出口。socket 工厂必须先以无发包的本地路由探测取得内核选择的源地址；命中 TUN 地址才强制物理出口，命中 LAN、企业 VPN 或其他更具体路由时必须保留系统选择。启动时必须先解析并发布 IPv4/IPv6 underlay，再安装对应 `/1` 捕获路由。代理节点地址不属于目的网络排除，不能在 TUN 启动或协调期间被枚举、解析或安装为 `/32`/`/128` host route；当前仅为尚未完全出口感知的 DNS bootstrap 保留显式排除。额外 carrier socket（例如 QUIC、split-HTTP 第二连接和 UDP packet path）必须复用同一出口工厂。
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -327,6 +327,12 @@ TUN 反环路由两类互不替代的机制组成：捕获路由只负责让应�
 
 TUN UDP association 以原始客户端源 IP/端口为身份，同一源关联内再按目标复用 UDP flow；不同源端口不能仅因目标相同而合并，否则响应会写回错误客户端。关联建立有并发硬上限和滚动速率限制，单关联队列使用非阻塞投递，关闭的关联和失败的目标 flow 都应用有界指数退避。这样自捕获或 `WSAENOBUFS` 只能造成受控丢包，不能演化为无界 association/session 重建。TUN 会话必须记录原始源 IP/端口，不能用 loopback 占位地址代替。
 
+QUIC 透明嗅探不终止 QUIC 连接。通用 Initial v1/v2 密钥派生、包保护验证和
+CRYPTO 帧重组属于 `zero-transport`；TUN UDP 只维护按关联/目标有界且带期限的
+暂存状态，并把恢复出的逻辑域名、原始 IP 与 `quic_sni` 来源交给统一 Session。
+ECH、未知版本、认证失败、超时和容量压力都回退到 DNS reverse 或原始 IP，
+不得使用密文字符串扫描或外层 SNI 猜测隐藏域名。
+
 TCP 入站身份包含完整源 IP/端口；平台 listener 不得把 peer 降级成只有 IP 的值。TUN 用户态 TCP 栈对排队待 accept 的连接附加单调代际，并在交付前确认同一四元组仍指向该代连接且处于 established 状态，避免 RST 后同四元组快速重连时交付过期连接。目标地址相同本身不构成重复连接，不能按目标合并独立 TCP stream。
 
 本机进程归属属于 `zero-platform-tokio`：Linux、Windows 和 macOS 分别使用平台连接表与进程接口，proxy 只消费中性的 PID/name/path 结果。TCP 与 UDP 都以完整本地源端点查询；查询是尽力而为的观测补充，套接字竞态、权限或平台错误只产生空元数据，不得改变路由或使会话失败。系统表读取在阻塞任务池执行，不能阻塞异步转发工作线程。

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -145,7 +145,8 @@ encrypted-DNS endpoints when deployment policy requires it.
 Flow records expose `target.original_ip`, `target.host_source`, and
 `target.fake_ip_reverse_status`. Together with `target.host`, `resolved_ip`, and
 `sniffed_host`, these distinguish Fake-IP restoration, DNS reverse recovery
-(`host_source=dns_reverse`), TLS sniffing, a missing
+(`host_source=dns_reverse`), TLS/HTTP/QUIC sniffing (`tls_sni`, `http_host`,
+`quic_sni`), a missing
 reverse mapping, and the final direct endpoint without changing existing API
 fields.
 

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -20,7 +20,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
 - 代理节点不再获得自动 host route；Zero 创建的 TCP/UDP/QUIC socket 按 IPv4/IPv6 分别绑定各自 underlay 接口，避免代理自环。DNS UDP 与 DoT socket 使用同一出口权威；DoH/系统 bootstrap 仍由显式 DNS 排除或操作系统解析路径保护。
 - 物理出口或受管 TUN 地址集合每次实际变化都会发布单调递增的出口 generation。direct UDP 在下一次发送前发现旧 generation 时重建双栈 socket；重建期间若拓扑持续抖动则 fail closed，不使用旧出口继续发送。新建域名 UDP flow 在解析器首选的可用地址族内采用稳定候选，DNS 答案重排不会把所有流量重新固定到第一条记录。
 - macOS 会为每个受管地址族维护物理出口的 interface-scoped 默认路由，使绑定接口的 direct、代理节点和 DNS socket 在全局 `/1` 路由生效后仍可达；该路由参与出口切换、回滚和崩溃恢复。
-- 路由恢复日志按稳定的 TUN 入站 `tag` 与地址族寻址，并记录当次真实设备名；因此 macOS 在崩溃重启后即使 `utunN` 编号变化，也能清理旧设备留下的路由。
+- 路由恢复日志按稳定的 TUN 入站 `tag` 与地址族寻址，并记录当次真实设备名；因此 macOS 在崩溃重启后即使 `utunN` 编号变化，也能清理旧设备留下的路由。系统路由 lease 则按地址族全局持有，第二个进程即使使用不同 tag，也必须明确失败且报告当前 owner，不能同时改写同一组捕获路由。
 
 调试时可分别使用 `--no-auto-route`、`--single-stack`、`--no-strict-route` 或 `--no-dns-hijack`。生产防泄露验证不应关闭这些选项。
 
@@ -184,6 +184,7 @@ sudo tcpdump -i physical0 -nn 'udp port 3478 or udp port 5349'
 6. 制造短暂的无默认路由窗口或排除路由安装失败；TUN 应保持运行、`healthy=false` 且显示 `last_error`，恢复后自动协调并回到 `healthy=true`，期间不得出现忙重试。
 7. Windows 连续执行两轮 start/stop，确认阻塞 reader 被唤醒且同名 Wintun adapter 可复用。
 8. 严格模式下删除一条受管 `/1` 路由或制造协调失败，并确认平台保护仍阻止非 TUN 物理出站：Linux 检查 `zero_killswitch_*` nftables 表，macOS 检查 `com.apple/zero_*` pf anchor，Windows 检查 `ZeroKillSwitch-*` Firewall rule group 与各 profile 的 outbound block 状态。
+9. 保持一个实例持有 IPv4/IPv6 自动路由，再以不同 TUN tag 启动第二个实例；第二个实例必须在安装任何路由或 kill switch 前以 `AlreadyExists` 失败。停止第一个实例后，第二个实例应能取得 lease 并正常启动。
 
 路由事务会写入恢复日志。默认位置为 Windows 的 `%LOCALAPPDATA%\\Zero\\run`、Unix 的 `$XDG_RUNTIME_DIR/zero` 或 `/run/zero`，不可用时回退到系统临时目录的 `zero` 子目录；可用 `ZERO_TUN_STATE_DIR` 指定隔离目录。进程被强杀后，kill switch 保持 fail-closed；下一次以相同 TUN 入站 `tag` 启动会接管原保护并消费路由日志。Windows 额外保存启用前各 Firewall profile 的 outbound policy，只有正常停止且规则清理成功后才恢复；Linux nftables table 与 macOS pf anchor 使用稳定资源名原位替换，热更新失败保留旧规则。
 

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -197,7 +197,9 @@ sudo tcpdump -i physical0 -nn 'udp port 3478 or udp port 5349'
 
 透明 TCP 嗅探覆盖 TLS SNI 与 HTTP/1.x Host。所有已读取前缀必须原样回放；
 ECH 连接不得把 outer public name 猜作真实目标，先尝试无歧义 DNS 反向映射，
-否则继续使用原始 IP。QUIC Initial/SNI 属于独立 UDP 状态机能力，不能用
+否则继续使用原始 IP。QUIC Initial/SNI 使用 `zero-transport` 中的 RFC 9001/9369
+Initial 解密与 CRYPTO 帧有界重组，TUN UDP 仅负责 200ms/容量受限的暂存和
+Session 元数据桥接；不能用
 TCP ClientHello 解析器或单包字符串扫描替代。
 
 真实路由和设备操作需要管理员权限，不能由普通单元测试模拟。仓库中的 `tun_privileged_e2e` 会直接读取系统网络状态，校验接口 MTU、地址、拆分默认路由、TCP、DNS 劫持、STUN 基线与 block、强杀后的恢复日志，以及配置移除后的设备和日志清理。IPv4/IPv6 STUN 用例分别以单栈配置运行，需要对应地址族的原生网络和可达 STUN 服务。独立的离线双栈用例通过本地模拟 DNS 和 SOCKS5 出站，验证同一设备的 IPv4/IPv6 地址、四条 `/1` 路由、双族 TCP/DNS 流量和两份恢复日志；它也覆盖物理出口仅有 IPv4 时 IPv6 经代理载荷出站的情形。为公网 STUN 用例提供可达服务并运行：


### PR DESCRIPTION
## Summary

- serialize automatic TUN route ownership per address family across processes, independent of the configurable inbound tag
- retain tag-scoped recovery journals while recording a bounded owner identity in the host-level lease for actionable conflict errors
- document and unit-test deterministic rejection and handoff between differently tagged instances

## Architecture

This stays in `zero-tun`: the platform route transaction owns the cross-process lease, while `zero-proxy` remains responsible only for TUN lifecycle orchestration. IPv4 and IPv6 have independent leases so a dual-stack instance may own both without coupling their platform transactions.

The lease is acquired before stale-route recovery, capture route mutation, egress publication, or strict-route leak-guard installation. A competing instance therefore fails closed with `AlreadyExists` and cannot partially modify system state.

## Validation

GitHub Actions is the available Rust environment for this workspace. CI covers:

- `cargo fmt --all --check`
- workspace/all-feature Clippy
- workspace check, tests, and architecture boundaries
- optional/proxy feature combinations
- musl compatibility
- Linux, macOS, and Windows TUN backend/E2E harness compilation