### PR TITLE
feat(tun): add selective CIDR capture

### DIFF
--- a/crates/api/src/command.rs
+++ b/crates/api/src/command.rs
@@ -220,6 +220,9 @@ pub struct TunStartCommand {
     /// Install split default routes through the TUN device.
     #[serde(default = "default_true")]
     pub auto_route: bool,
+    /// Destination CIDRs captured by automatic TUN routes. Empty means full tunnel.
+    #[serde(default)]
+    pub include_cidrs: Vec<String>,
     /// Install split-default routes for both IPv4 and IPv6.
     #[serde(default = "default_true")]
     pub dual_stack: bool,
@@ -241,6 +244,7 @@ impl Default for TunStartCommand {
             secondary_addr: None,
             tag: String::new(),
             auto_route: true,
+            include_cidrs: Vec::new(),
             dual_stack: true,
             strict_route: true,
             dns_hijack: true,

--- a/crates/api/src/query.rs
+++ b/crates/api/src/query.rs
@@ -312,6 +312,8 @@ pub struct TunStatusSnapshot {
     pub healthy: bool,
     #[serde(default)]
     pub auto_route: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include_cidrs: Vec<String>,
     #[serde(default)]
     pub dual_stack: bool,
     #[serde(default)]

--- a/crates/api/tests/api_model.rs
+++ b/crates/api/tests/api_model.rs
@@ -16,6 +16,7 @@ fn tun_start_defaults_to_transactional_automatic_routes() {
     .expect("deserialize TUN command");
 
     assert!(command.auto_route);
+    assert!(command.include_cidrs.is_empty());
     assert!(command.dual_stack);
     assert!(command.strict_route);
     assert!(command.dns_hijack);

--- a/crates/config/src/model/tun.rs
+++ b/crates/config/src/model/tun.rs
@@ -1,3 +1,4 @@
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 
 /// Declarative TUN runtime configuration.
@@ -24,6 +25,10 @@ pub struct TunConfig {
     pub tag: String,
     #[serde(default = "default_true")]
     pub auto_route: bool,
+    /// Destination networks captured by automatic routes. An empty list keeps
+    /// the full-tunnel split-default behavior.
+    #[serde(default)]
+    pub include_cidrs: Vec<IpNet>,
     /// Install both IPv4 and IPv6 split-default routes. Disable only on a
     /// deliberately single-stack host.
     #[serde(default = "default_true")]

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -362,6 +362,29 @@ fn validate_tun_config(
             "`runtime.tun.mtu` must be at least 576".to_owned(),
         ));
     }
+    if !tun.include_cidrs.is_empty() && !tun.auto_route {
+        return Err(ConfigError::InvalidRuntime(
+            "`runtime.tun.include_cidrs` requires `runtime.tun.auto_route=true`".to_owned(),
+        ));
+    }
+    if tun.include_cidrs.len() > 128 {
+        return Err(ConfigError::InvalidRuntime(
+            "`runtime.tun.include_cidrs` supports at most 128 entries".to_owned(),
+        ));
+    }
+    let mut seen_cidrs = HashSet::new();
+    for cidr in &tun.include_cidrs {
+        if !seen_cidrs.insert(*cidr) {
+            return Err(ConfigError::InvalidRuntime(format!(
+                "duplicate `runtime.tun.include_cidrs` entry `{cidr}`"
+            )));
+        }
+        if !tun.dual_stack && cidr.addr().is_ipv4() != address.is_ipv4() {
+            return Err(ConfigError::InvalidRuntime(format!(
+                "`runtime.tun.include_cidrs` entry `{cidr}` has no configured TUN address family"
+            )));
+        }
+    }
     if tun.dns_hijack && tun.strict_route {
         runtime
             .dns

--- a/crates/config/tests/config_parse.rs
+++ b/crates/config/tests/config_parse.rs
@@ -1783,9 +1783,36 @@ fn parses_declarative_tun_runtime_with_safe_defaults() {
     assert_eq!(tun.tag, "tun");
     assert_eq!(tun.effective_mtu(config.runtime.network.mtu), 1400);
     assert!(tun.auto_route);
+    assert!(tun.include_cidrs.is_empty());
     assert!(tun.dual_stack);
     assert!(tun.strict_route);
     assert!(tun.dns_hijack);
+}
+
+#[test]
+fn validates_declarative_tun_capture_cidrs() {
+    for tun in [
+        r#"{ "addr": "10.0.0.1/24", "auto_route": false, "include_cidrs": ["10.0.0.0/8"] }"#,
+        r#"{ "addr": "10.0.0.1/24", "dual_stack": false, "include_cidrs": ["2001:db8::/32"] }"#,
+        r#"{ "addr": "10.0.0.1/24", "include_cidrs": ["10.0.0.0/8", "10.0.0.0/8"] }"#,
+    ] {
+        let raw = format!(
+            r#"{{
+                "runtime": {{
+                    "dns": {{
+                        "servers": {{ "global": {{ "type": "udp", "host": "1.1.1.1" }} }},
+                        "default_server": "global"
+                    }},
+                    "tun": {tun}
+                }},
+                "route": {{ "final": {{ "type": "direct" }} }}
+            }}"#
+        );
+        assert!(matches!(
+            RuntimeConfig::parse(&raw),
+            Err(zero_config::ConfigError::InvalidRuntime(_))
+        ));
+    }
 }
 
 #[test]

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -79,6 +79,7 @@ dns = ["zero-dns/udp", "zero-dns/doh", "zero-dns/dot", "zero-dns/doq"]
 [dependencies]
 async-trait = "0.1"
 futures-util = "0.3"
+ipnet.workspace = true
 regex = "1"
 quinn = { version = "0.11", default-features = false, features = ["rustls-ring"], optional = true }
 ring = { version = "0.17", optional = true }

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -22,9 +22,10 @@ use config::{configured_dns_endpoint_addresses, parse_interface_addresses};
 
 static NEXT_TUN_ID: AtomicU64 = AtomicU64::new(1);
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct TunRuntimeOptions {
     pub auto_route: bool,
+    pub include_cidrs: Vec<ipnet::IpNet>,
     pub dual_stack: bool,
     pub strict_route: bool,
     pub dns_hijack: bool,
@@ -128,10 +129,32 @@ impl Proxy {
         } = spec;
         let TunRuntimeOptions {
             auto_route,
+            include_cidrs,
             dual_stack,
             strict_route,
             dns_hijack,
         } = options;
+        if !include_cidrs.is_empty() && !auto_route {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TUN include CIDRs require automatic routes",
+            )));
+        }
+        if include_cidrs.len() > 128 {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TUN include CIDRs support at most 128 entries",
+            )));
+        }
+        let unique_include_cidrs = include_cidrs
+            .iter()
+            .collect::<std::collections::HashSet<_>>();
+        if unique_include_cidrs.len() != include_cidrs.len() {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TUN include CIDRs must not contain duplicates",
+            )));
+        }
         let _operation = self.tun_operation_lock.lock().await;
         if !cfg!(feature = "udp-runtime") {
             return Err(EngineError::Io(io::Error::new(
@@ -153,6 +176,19 @@ impl Proxy {
         }
         let interface_addresses =
             parse_interface_addresses(addr, mask, secondary_addr, dual_stack)?;
+        let route_addresses = interface_addresses
+            .iter()
+            .filter(|address| {
+                !zero_tun::capture_route_prefixes(address.address, &include_cidrs).is_empty()
+            })
+            .map(|address| (address.address, address.netmask))
+            .collect::<Vec<_>>();
+        if auto_route && route_addresses.is_empty() {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TUN include CIDRs do not match any configured interface address family",
+            )));
+        }
         let mut tun_owned_addresses = interface_addresses
             .iter()
             .map(|address| address.address)
@@ -197,15 +233,12 @@ impl Proxy {
         let (tcp, udp) = stack.into_parts();
 
         let route_exclusions = prepared_network.route_exclusions;
-        let route_addresses = interface_addresses
-            .iter()
-            .map(|address| (address.address, address.netmask))
-            .collect::<Vec<_>>();
         let installed = if auto_route {
             routes::install(
                 device_name.clone(),
                 tag.to_owned(),
                 route_addresses.clone(),
+                include_cidrs.clone(),
                 route_exclusions.clone(),
                 strict_route,
                 self.egress_interface.clone(),
@@ -219,9 +252,9 @@ impl Proxy {
             }
         };
         if auto_route {
-            let missing_family = interface_addresses.iter().find(|address| {
+            let missing_family = route_addresses.iter().find(|(address, _)| {
                 self.egress_interface
-                    .current_for(address.address.is_ipv6())
+                    .current_for(address.is_ipv6())
                     .is_none()
             });
             if let Some(missing) = missing_family {
@@ -232,11 +265,7 @@ impl Proxy {
                     io::ErrorKind::NotConnected,
                     format!(
                         "TUN physical egress was not published for {} before route activation",
-                        if missing.address.is_ipv6() {
-                            "IPv6"
-                        } else {
-                            "IPv4"
-                        }
+                        if missing.0.is_ipv6() { "IPv6" } else { "IPv4" }
                     ),
                 )));
             }
@@ -266,9 +295,13 @@ impl Proxy {
         let (egress_interface_v4, egress_interface_v6) = routes::route_names(&installed.guards);
         debug!("TUN physical egress bindings selected");
         let egress_interface = if address.is_ipv6() {
-            egress_interface_v6.clone()
+            egress_interface_v6
+                .clone()
+                .or_else(|| egress_interface_v4.clone())
         } else {
-            egress_interface_v4.clone()
+            egress_interface_v4
+                .clone()
+                .or_else(|| egress_interface_v6.clone())
         };
         let managed_by_config = managed_config.is_some();
 
@@ -284,6 +317,7 @@ impl Proxy {
                     recovery_key: tag.to_owned(),
                     primary_ipv6: address.is_ipv6(),
                     addresses: route_addresses,
+                    include_cidrs: include_cidrs.clone(),
                     dns_hijack,
                     strict_route,
                 },
@@ -304,6 +338,7 @@ impl Proxy {
             mtu,
             tag: tag.to_owned(),
             auto_route,
+            include_cidrs,
             dual_stack,
             strict_route,
             dns_hijack,
@@ -419,6 +454,7 @@ impl Proxy {
             tag: &desired.tag,
             options: TunRuntimeOptions {
                 auto_route: desired.auto_route,
+                include_cidrs: desired.include_cidrs.clone(),
                 dual_stack: desired.dual_stack,
                 strict_route: desired.strict_route,
                 dns_hijack: desired.dns_hijack,

--- a/crates/proxy/src/inbound/tun/routes.rs
+++ b/crates/proxy/src/inbound/tun/routes.rs
@@ -2,9 +2,10 @@ use std::io;
 use std::net::IpAddr;
 use std::time::Duration;
 
+use ipnet::IpNet;
 use tokio::sync::{oneshot, watch};
 use zero_engine::EngineError;
-use zero_tun::{RouteChangeMonitor, SystemLeakGuard, SystemRouteGuard};
+use zero_tun::{capture_route_prefixes, RouteChangeMonitor, SystemLeakGuard, SystemRouteGuard};
 
 use crate::runtime::Proxy;
 
@@ -29,6 +30,7 @@ pub(super) async fn install(
     tun_name: String,
     recovery_key: String,
     addresses: Vec<(IpAddr, IpAddr)>,
+    include_cidrs: Vec<IpNet>,
     excluded: Vec<IpAddr>,
     strict: bool,
     egress_control: zero_platform_tokio::EgressInterfaceControl,
@@ -38,6 +40,10 @@ pub(super) async fn install(
         let mut last_error = None;
         let previous_v4 = egress_control.current_for(false);
         let previous_v6 = egress_control.current_for(true);
+        let protected = addresses
+            .iter()
+            .flat_map(|(address, _)| capture_route_prefixes(*address, &include_cidrs))
+            .collect::<Vec<_>>();
         for (address, netmask) in addresses {
             let ipv6 = address.is_ipv6();
             let previous = if ipv6 {
@@ -51,6 +57,7 @@ pub(super) async fn install(
                 &recovery_key,
                 address,
                 netmask,
+                &capture_route_prefixes(address, &include_cidrs),
                 &excluded,
                 move |route| {
                     let interface = zero_platform_tokio::EgressInterface::new(
@@ -99,7 +106,7 @@ pub(super) async fn install(
             }
         }
         let leak_guard = if strict {
-            match SystemLeakGuard::install(&tun_name, &recovery_key, &excluded) {
+            match SystemLeakGuard::install(&tun_name, &recovery_key, &protected, &excluded) {
                 Ok(guard) => Some(guard),
                 Err(error) => {
                     let mut rollback_error = None;
@@ -143,6 +150,7 @@ pub(super) struct RouteRuntimeSpec {
     pub recovery_key: String,
     pub primary_ipv6: bool,
     pub addresses: Vec<(IpAddr, IpAddr)>,
+    pub include_cidrs: Vec<IpNet>,
     pub dns_hijack: bool,
     pub strict_route: bool,
 }
@@ -271,6 +279,11 @@ async fn run(
         let tun_name = spec.tun_name.clone();
         let recovery_key = spec.recovery_key.clone();
         let addresses = spec.addresses.clone();
+        let include_cidrs = spec.include_cidrs.clone();
+        let protected = addresses
+            .iter()
+            .flat_map(|(address, _)| capture_route_prefixes(*address, &include_cidrs))
+            .collect::<Vec<_>>();
         let reconcile_exclusions = exclusions.clone();
         let reconciled = tokio::task::spawn_blocking(move || {
             let result = reconcile_guards(
@@ -278,12 +291,13 @@ async fn run(
                 &tun_name,
                 &recovery_key,
                 &addresses,
+                &include_cidrs,
                 &reconcile_exclusions,
             )
             .and_then(|changed| {
                 let leak_changed = leak_guard
                     .as_mut()
-                    .map(|guard| guard.reconcile(&reconcile_exclusions))
+                    .map(|guard| guard.reconcile(&protected, &reconcile_exclusions))
                     .transpose()?
                     .unwrap_or(false);
                 Ok(changed || leak_changed)
@@ -367,6 +381,7 @@ fn reconcile_guards(
     tun_name: &str,
     recovery_key: &str,
     addresses: &[(IpAddr, IpAddr)],
+    include_cidrs: &[IpNet],
     excluded: &[IpAddr],
 ) -> io::Result<bool> {
     let mut changed = false;
@@ -382,6 +397,7 @@ fn reconcile_guards(
                 recovery_key,
                 address,
                 netmask,
+                &capture_route_prefixes(address, include_cidrs),
                 excluded,
             )?);
             changed = true;
@@ -443,6 +459,7 @@ mod tests {
                 "10.66.0.1".parse().unwrap(),
                 "255.255.255.0".parse().unwrap(),
             )],
+            include_cidrs: Vec::new(),
             dns_hijack: true,
             strict_route: true,
         };

--- a/crates/proxy/src/inbound/tun/routes/state.rs
+++ b/crates/proxy/src/inbound/tun/routes/state.rs
@@ -36,9 +36,13 @@ pub(super) fn publish_state(
     info.egress_interface_v4 = egress_v4.map(|egress| egress.name().to_owned());
     info.egress_interface_v6 = egress_v6.map(|egress| egress.name().to_owned());
     info.egress_interface = if spec.primary_ipv6 {
-        info.egress_interface_v6.clone()
+        info.egress_interface_v6
+            .clone()
+            .or_else(|| info.egress_interface_v4.clone())
     } else {
-        info.egress_interface_v4.clone()
+        info.egress_interface_v4
+            .clone()
+            .or_else(|| info.egress_interface_v6.clone())
     };
     if let Some(exclusions) = exclusions {
         info.route_exclusions = exclusions;
@@ -71,9 +75,13 @@ pub(super) fn publish_unavailable(proxy: &Proxy, spec: &RouteRuntimeSpec, error:
         info.egress_interface_v6 = None;
     }
     info.egress_interface = if spec.primary_ipv6 {
-        info.egress_interface_v6.clone()
+        info.egress_interface_v6
+            .clone()
+            .or_else(|| info.egress_interface_v4.clone())
     } else {
-        info.egress_interface_v4.clone()
+        info.egress_interface_v4
+            .clone()
+            .or_else(|| info.egress_interface_v6.clone())
     };
     info.healthy = false;
     info.last_error = Some(error);

--- a/crates/proxy/src/inbound/tun/tests.rs
+++ b/crates/proxy/src/inbound/tun/tests.rs
@@ -35,6 +35,7 @@ async fn command_tun_start_rejects_fake_ip_pool_collision_before_device_creation
             "tun-test",
             super::TunRuntimeOptions {
                 auto_route: false,
+                include_cidrs: Vec::new(),
                 dual_stack: false,
                 strict_route: true,
                 dns_hijack: true,
@@ -55,6 +56,7 @@ fn configured_tun_fixture() -> (zero_config::TunConfig, TunInfo) {
         mtu: None,
         tag: "tun-in".to_owned(),
         auto_route: true,
+        include_cidrs: Vec::new(),
         dual_stack: false,
         strict_route: true,
         dns_hijack: true,
@@ -68,6 +70,7 @@ fn configured_tun_fixture() -> (zero_config::TunConfig, TunInfo) {
         mtu: 1500,
         tag: config.tag.clone(),
         auto_route: true,
+        include_cidrs: Vec::new(),
         dual_stack: false,
         strict_route: true,
         dns_hijack: true,

--- a/crates/proxy/src/runtime.rs
+++ b/crates/proxy/src/runtime.rs
@@ -104,6 +104,7 @@ pub(crate) struct TunInfo {
     pub mtu: u16,
     pub tag: String,
     pub auto_route: bool,
+    pub include_cidrs: Vec<ipnet::IpNet>,
     pub dual_stack: bool,
     pub strict_route: bool,
     pub dns_hijack: bool,

--- a/crates/proxy/src/runtime/handle/command/tun.rs
+++ b/crates/proxy/src/runtime/handle/command/tun.rs
@@ -23,6 +23,38 @@ pub(super) fn execute_tun_start(
         .unwrap_or_else(|| proxy.engine().config().runtime.network.mtu);
     let tag = cmd.tag.clone();
     let auto_route = cmd.auto_route;
+    let include_cidrs = cmd
+        .include_cidrs
+        .iter()
+        .map(|cidr| cidr.parse::<ipnet::IpNet>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            zero_api::ApiError::new(
+                zero_api::ApiErrorCode::InvalidArgument,
+                format!("invalid TUN include CIDR: {error}"),
+            )
+        })?;
+    if !include_cidrs.is_empty() && !auto_route {
+        return Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::InvalidArgument,
+            "TUN include CIDRs require `auto_route=true`",
+        ));
+    }
+    if include_cidrs.len() > 128 {
+        return Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::InvalidArgument,
+            "TUN include CIDRs support at most 128 entries",
+        ));
+    }
+    let unique = include_cidrs
+        .iter()
+        .collect::<std::collections::HashSet<_>>();
+    if unique.len() != include_cidrs.len() {
+        return Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::InvalidArgument,
+            "TUN include CIDRs must not contain duplicates",
+        ));
+    }
     let dual_stack = cmd.dual_stack;
     let strict_route = cmd.strict_route;
     let dns_hijack = cmd.dns_hijack;
@@ -41,6 +73,7 @@ pub(super) fn execute_tun_start(
                     &tag,
                     TunRuntimeOptions {
                         auto_route,
+                        include_cidrs,
                         dual_stack,
                         strict_route,
                         dns_hijack,
@@ -63,6 +96,9 @@ pub(super) fn map_tun_start_error(error: EngineError) -> zero_api::ApiError {
             cause: Some(error.to_string()),
             details: Vec::new(),
         };
+    }
+    if matches!(&error, EngineError::Io(source) if source.kind() == io::ErrorKind::InvalidInput) {
+        return zero_api::ApiError::new(zero_api::ApiErrorCode::InvalidArgument, error.to_string());
     }
     zero_api::ApiError::new(zero_api::ApiErrorCode::Internal, error.to_string())
 }

--- a/crates/proxy/src/runtime/handle/query.rs
+++ b/crates/proxy/src/runtime/handle/query.rs
@@ -26,6 +26,7 @@ impl zero_api::QueryService for ProxyHandle {
                     tag: Some(tun.tag.clone()),
                     healthy: tun.healthy,
                     auto_route: tun.auto_route,
+                    include_cidrs: tun.include_cidrs.iter().map(ToString::to_string).collect(),
                     dual_stack: tun.dual_stack,
                     strict_route: tun.strict_route,
                     dns_hijack: tun.dns_hijack,

--- a/crates/proxy/src/runtime/handle/query/tests.rs
+++ b/crates/proxy/src/runtime/handle/query/tests.rs
@@ -23,6 +23,7 @@ fn running_tun_status_exposes_route_health_and_error() {
         mtu: 1500,
         tag: "tun-in".to_owned(),
         auto_route: true,
+        include_cidrs: Vec::new(),
         dual_stack: false,
         strict_route: true,
         dns_hijack: true,

--- a/crates/tun/Cargo.toml
+++ b/crates/tun/Cargo.toml
@@ -20,6 +20,7 @@ windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Network
 
 [dependencies]
 fs2.workspace = true
+ipnet.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/tun/src/lib.rs
+++ b/crates/tun/src/lib.rs
@@ -14,8 +14,8 @@ type TunPacketReceiver = tokio::sync::mpsc::Receiver<Vec<u8>>;
 
 mod route;
 pub use route::{
-    split_default_route_prefixes, RouteChangeMonitor, RouteInterface, SystemLeakGuard,
-    SystemRouteGuard,
+    capture_route_prefixes, split_default_route_prefixes, RouteChangeMonitor, RouteInterface,
+    SystemLeakGuard, SystemRouteGuard,
 };
 
 // ── Address helpers ───────────────────────────────────────────────────

--- a/crates/tun/src/route.rs
+++ b/crates/tun/src/route.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::net::IpAddr;
 
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 
 mod journal;
@@ -62,6 +63,7 @@ impl SystemRouteGuard {
         _recovery_key: &str,
         _address: IpAddr,
         _netmask: IpAddr,
+        _captured: &[IpNet],
         _excluded: &[IpAddr],
     ) -> io::Result<Self> {
         Err(io::Error::new(
@@ -75,6 +77,7 @@ impl SystemRouteGuard {
         _recovery_key: &str,
         _address: IpAddr,
         _netmask: IpAddr,
+        _captured: &[IpNet],
         _excluded: &[IpAddr],
         _publish_egress: impl FnOnce(&RouteInterface) -> io::Result<()>,
     ) -> io::Result<Self> {
@@ -110,6 +113,24 @@ pub fn split_default_route_prefixes(address: IpAddr) -> [&'static str; 2] {
     } else {
         ["::/1", "8000::/1"]
     }
+}
+
+pub fn capture_route_prefixes(address: IpAddr, included: &[IpNet]) -> Vec<IpNet> {
+    let mut prefixes: Vec<IpNet> = if included.is_empty() {
+        split_default_route_prefixes(address)
+            .into_iter()
+            .map(|prefix| prefix.parse().expect("split-default CIDR is valid"))
+            .collect()
+    } else {
+        included
+            .iter()
+            .copied()
+            .filter(|prefix| prefix.addr().is_ipv6() == address.is_ipv6())
+            .collect()
+    };
+    prefixes.sort_unstable();
+    prefixes.dedup();
+    prefixes
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/tun/src/route/leak.rs
+++ b/crates/tun/src/route/leak.rs
@@ -7,6 +7,8 @@
 use std::io;
 use std::net::IpAddr;
 
+use ipnet::IpNet;
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "macos")]
@@ -27,14 +29,19 @@ pub struct SystemLeakGuard;
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 impl SystemLeakGuard {
-    pub fn install(_tun_name: &str, _recovery_key: &str, _excluded: &[IpAddr]) -> io::Result<Self> {
+    pub fn install(
+        _tun_name: &str,
+        _recovery_key: &str,
+        _protected: &[IpNet],
+        _excluded: &[IpAddr],
+    ) -> io::Result<Self> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "strict-route leak protection is unsupported on this platform",
         ))
     }
 
-    pub fn reconcile(&mut self, _excluded: &[IpAddr]) -> io::Result<bool> {
+    pub fn reconcile(&mut self, _protected: &[IpNet], _excluded: &[IpAddr]) -> io::Result<bool> {
         Ok(false)
     }
 
@@ -61,6 +68,13 @@ fn normalized_exclusions(excluded: &[IpAddr]) -> Vec<IpAddr> {
     excluded.sort_unstable();
     excluded.dedup();
     excluded
+}
+
+fn normalized_prefixes(prefixes: &[IpNet]) -> Vec<IpNet> {
+    let mut prefixes = prefixes.to_vec();
+    prefixes.sort_unstable();
+    prefixes.dedup();
+    prefixes
 }
 
 fn validate_interface_name(name: &str) -> io::Result<()> {

--- a/crates/tun/src/route/leak/linux.rs
+++ b/crates/tun/src/route/leak/linux.rs
@@ -3,37 +3,51 @@ use std::io::Write;
 use std::net::IpAddr;
 use std::process::{Command, Stdio};
 
-use super::{normalized_exclusions, safe_resource_name, validate_interface_name};
+use ipnet::IpNet;
+
+use super::{
+    normalized_exclusions, normalized_prefixes, safe_resource_name, validate_interface_name,
+};
 
 #[derive(Debug)]
 pub struct SystemLeakGuard {
     table: String,
     tun_name: String,
+    protected: Vec<IpNet>,
     excluded: Vec<IpAddr>,
     active: bool,
 }
 
 impl SystemLeakGuard {
-    pub fn install(tun_name: &str, recovery_key: &str, excluded: &[IpAddr]) -> io::Result<Self> {
+    pub fn install(
+        tun_name: &str,
+        recovery_key: &str,
+        protected: &[IpNet],
+        excluded: &[IpAddr],
+    ) -> io::Result<Self> {
         validate_interface_name(tun_name)?;
         let table = format!("zero_killswitch_{}", safe_resource_name(recovery_key));
+        let protected = normalized_prefixes(protected);
         let excluded = normalized_exclusions(excluded);
         let exists = table_exists(&table)?;
-        apply_policy(&table, tun_name, &excluded, exists)?;
+        apply_policy(&table, tun_name, &protected, &excluded, exists)?;
         Ok(Self {
             table,
             tun_name: tun_name.to_owned(),
+            protected,
             excluded,
             active: true,
         })
     }
 
-    pub fn reconcile(&mut self, excluded: &[IpAddr]) -> io::Result<bool> {
+    pub fn reconcile(&mut self, protected: &[IpNet], excluded: &[IpAddr]) -> io::Result<bool> {
+        let protected = normalized_prefixes(protected);
         let excluded = normalized_exclusions(excluded);
-        if excluded == self.excluded {
+        if protected == self.protected && excluded == self.excluded {
             return Ok(false);
         }
-        apply_policy(&self.table, &self.tun_name, &excluded, true)?;
+        apply_policy(&self.table, &self.tun_name, &protected, &excluded, true)?;
+        self.protected = protected;
         self.excluded = excluded;
         Ok(true)
     }
@@ -73,8 +87,14 @@ fn table_exists(table: &str) -> io::Result<bool> {
     Ok(output.status.success())
 }
 
-fn apply_policy(table: &str, tun_name: &str, excluded: &[IpAddr], exists: bool) -> io::Result<()> {
-    let script = policy_script(table, tun_name, excluded, exists);
+fn apply_policy(
+    table: &str,
+    tun_name: &str,
+    protected: &[IpNet],
+    excluded: &[IpAddr],
+    exists: bool,
+) -> io::Result<()> {
+    let script = policy_script(table, tun_name, protected, excluded, exists);
     let mut child = Command::new("nft")
         .args(["-f", "-"])
         .stdin(Stdio::piped())
@@ -97,7 +117,13 @@ fn apply_policy(table: &str, tun_name: &str, excluded: &[IpAddr], exists: bool) 
     }
 }
 
-fn policy_script(table: &str, tun_name: &str, excluded: &[IpAddr], exists: bool) -> String {
+fn policy_script(
+    table: &str,
+    tun_name: &str,
+    protected: &[IpNet],
+    excluded: &[IpAddr],
+    exists: bool,
+) -> String {
     let mut script = String::new();
     if exists {
         script.push_str(&format!("delete table inet {table}\n"));
@@ -122,7 +148,12 @@ fn policy_script(table: &str, tun_name: &str, excluded: &[IpAddr], exists: bool)
             "add rule inet {table} output {family} daddr {address} accept\n"
         ));
     }
-    script.push_str(&format!("add rule inet {table} output reject\n"));
+    for prefix in protected {
+        let family = if prefix.addr().is_ipv4() { "ip" } else { "ip6" };
+        script.push_str(&format!(
+            "add rule inet {table} output {family} daddr {prefix} reject\n"
+        ));
+    }
     script
 }
 
@@ -142,6 +173,7 @@ mod tests {
         let script = policy_script(
             "zero_killswitch_test",
             "tun0",
+            &["0.0.0.0/1".parse().unwrap(), "8000::/1".parse().unwrap()],
             &["192.0.2.1".parse().unwrap(), "2001:db8::1".parse().unwrap()],
             true,
         );
@@ -150,6 +182,7 @@ mod tests {
         assert!(script.contains("oifname \"tun0\" accept"));
         assert!(script.contains("ip daddr 192.0.2.1 accept"));
         assert!(script.contains("ip6 daddr 2001:db8::1 accept"));
-        assert!(script.ends_with("output reject\n"));
+        assert!(script.contains("ip daddr 0.0.0.0/1 reject"));
+        assert!(script.ends_with("ip6 daddr 8000::/1 reject\n"));
     }
 }

--- a/crates/tun/src/route/leak/macos.rs
+++ b/crates/tun/src/route/leak/macos.rs
@@ -3,24 +3,35 @@ use std::io::Write;
 use std::net::IpAddr;
 use std::process::{Command, Stdio};
 
-use super::{normalized_exclusions, safe_resource_name, validate_interface_name};
+use ipnet::IpNet;
+
+use super::{
+    normalized_exclusions, normalized_prefixes, safe_resource_name, validate_interface_name,
+};
 
 #[derive(Debug)]
 pub struct SystemLeakGuard {
     anchor: String,
     tun_name: String,
+    protected: Vec<IpNet>,
     excluded: Vec<IpAddr>,
     enable_token: Option<String>,
     active: bool,
 }
 
 impl SystemLeakGuard {
-    pub fn install(tun_name: &str, recovery_key: &str, excluded: &[IpAddr]) -> io::Result<Self> {
+    pub fn install(
+        tun_name: &str,
+        recovery_key: &str,
+        protected: &[IpNet],
+        excluded: &[IpAddr],
+    ) -> io::Result<Self> {
         validate_interface_name(tun_name)?;
         verify_anchor_namespace()?;
         let anchor = format!("com.apple/zero_{}", safe_resource_name(recovery_key));
+        let protected = normalized_prefixes(protected);
         let excluded = normalized_exclusions(excluded);
-        apply_policy(&anchor, tun_name, &excluded)?;
+        apply_policy(&anchor, tun_name, &protected, &excluded)?;
         let enable_token = if pf_enabled()? {
             None
         } else {
@@ -35,18 +46,21 @@ impl SystemLeakGuard {
         Ok(Self {
             anchor,
             tun_name: tun_name.to_owned(),
+            protected,
             excluded,
             enable_token,
             active: true,
         })
     }
 
-    pub fn reconcile(&mut self, excluded: &[IpAddr]) -> io::Result<bool> {
+    pub fn reconcile(&mut self, protected: &[IpNet], excluded: &[IpAddr]) -> io::Result<bool> {
+        let protected = normalized_prefixes(protected);
         let excluded = normalized_exclusions(excluded);
-        if excluded == self.excluded {
+        if protected == self.protected && excluded == self.excluded {
             return Ok(false);
         }
-        apply_policy(&self.anchor, &self.tun_name, &excluded)?;
+        apply_policy(&self.anchor, &self.tun_name, &protected, &excluded)?;
+        self.protected = protected;
         self.excluded = excluded;
         Ok(true)
     }
@@ -118,8 +132,13 @@ fn enable_pf() -> io::Result<Option<String>> {
         .map(str::to_owned))
 }
 
-fn apply_policy(anchor: &str, tun_name: &str, excluded: &[IpAddr]) -> io::Result<()> {
-    let rules = policy_rules(tun_name, excluded);
+fn apply_policy(
+    anchor: &str,
+    tun_name: &str,
+    protected: &[IpNet],
+    excluded: &[IpAddr],
+) -> io::Result<()> {
+    let rules = policy_rules(tun_name, protected, excluded);
     let mut child = Command::new("pfctl")
         .args(["-a", anchor, "-f", "-"])
         .stdin(Stdio::piped())
@@ -150,7 +169,7 @@ fn flush_anchor(anchor: &str) -> io::Result<()> {
     }
 }
 
-fn policy_rules(tun_name: &str, excluded: &[IpAddr]) -> String {
+fn policy_rules(tun_name: &str, protected: &[IpNet], excluded: &[IpAddr]) -> String {
     let uid = unsafe { libc::geteuid() };
     let mut rules = format!(
         "pass out quick on lo0 all\npass out quick on {tun_name} all\npass out quick user {uid} all\n"
@@ -158,7 +177,9 @@ fn policy_rules(tun_name: &str, excluded: &[IpAddr]) -> String {
     for address in excluded {
         rules.push_str(&format!("pass out quick to {address}\n"));
     }
-    rules.push_str("block drop out quick all\n");
+    for prefix in protected {
+        rules.push_str(&format!("block drop out quick to {prefix}\n"));
+    }
     rules
 }
 
@@ -175,9 +196,13 @@ mod tests {
 
     #[test]
     fn pf_policy_ends_in_a_quick_block() {
-        let rules = policy_rules("utun8", &["192.0.2.1".parse().unwrap()]);
+        let rules = policy_rules(
+            "utun8",
+            &["203.0.113.0/24".parse().unwrap()],
+            &["192.0.2.1".parse().unwrap()],
+        );
         assert!(rules.contains("pass out quick on utun8 all"));
         assert!(rules.contains("pass out quick to 192.0.2.1"));
-        assert!(rules.ends_with("block drop out quick all\n"));
+        assert!(rules.ends_with("block drop out quick to 203.0.113.0/24\n"));
     }
 }

--- a/crates/tun/src/route/leak/windows.rs
+++ b/crates/tun/src/route/leak/windows.rs
@@ -1,11 +1,15 @@
 use std::io;
-use std::net::IpAddr;
+use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use serde::{Deserialize, Serialize};
 
-use super::{normalized_exclusions, safe_resource_name, validate_interface_name};
+use super::{
+    normalized_exclusions, normalized_prefixes, safe_resource_name, validate_interface_name,
+};
 use crate::route::journal::route_state_root;
 
 #[derive(Debug)]
@@ -13,6 +17,8 @@ pub struct SystemLeakGuard {
     group: String,
     journal_path: PathBuf,
     journal: FirewallJournal,
+    tun_name: String,
+    protected: Vec<IpNet>,
     excluded: Vec<IpAddr>,
     active: bool,
 }
@@ -30,7 +36,12 @@ struct ProfilePolicy {
 }
 
 impl SystemLeakGuard {
-    pub fn install(tun_name: &str, recovery_key: &str, excluded: &[IpAddr]) -> io::Result<Self> {
+    pub fn install(
+        tun_name: &str,
+        recovery_key: &str,
+        protected: &[IpNet],
+        excluded: &[IpAddr],
+    ) -> io::Result<Self> {
         validate_interface_name(tun_name)?;
         let safe_name = safe_resource_name(recovery_key);
         let group = format!("ZeroKillSwitch-{safe_name}");
@@ -43,7 +54,8 @@ impl SystemLeakGuard {
                 journal
             }
         };
-        if let Err(error) = install_rules(&group, tun_name) {
+        let protected = normalized_prefixes(protected);
+        if let Err(error) = install_rules(&group, tun_name, &complement_prefixes(&protected)) {
             let rollback = restore_profiles(&group, &journal);
             return Err(with_rollback_error(error, rollback));
         }
@@ -51,16 +63,27 @@ impl SystemLeakGuard {
             group,
             journal_path,
             journal,
+            tun_name: tun_name.to_owned(),
+            protected,
             excluded: normalized_exclusions(excluded),
             active: true,
         })
     }
 
-    pub fn reconcile(&mut self, excluded: &[IpAddr]) -> io::Result<bool> {
+    pub fn reconcile(&mut self, protected: &[IpNet], excluded: &[IpAddr]) -> io::Result<bool> {
+        let protected = normalized_prefixes(protected);
         let excluded = normalized_exclusions(excluded);
-        let changed = excluded != self.excluded;
+        if protected == self.protected && excluded == self.excluded {
+            return Ok(false);
+        }
+        install_rules(
+            &self.group,
+            &self.tun_name,
+            &complement_prefixes(&protected),
+        )?;
+        self.protected = protected;
         self.excluded = excluded;
-        Ok(changed)
+        Ok(true)
     }
 
     pub fn close(mut self) -> io::Result<()> {
@@ -145,7 +168,7 @@ fn validate_journal(journal: &FirewallJournal) -> io::Result<()> {
     Ok(())
 }
 
-fn install_rules(group: &str, tun_name: &str) -> io::Result<()> {
+fn install_rules(group: &str, tun_name: &str, allowed: &[IpNet]) -> io::Result<()> {
     let executable = std::env::current_exe()?;
     let executable = executable.to_str().ok_or_else(|| {
         io::Error::new(
@@ -156,14 +179,123 @@ fn install_rules(group: &str, tun_name: &str) -> io::Result<()> {
     let group = quote_powershell(group);
     let tun_name = quote_powershell(tun_name);
     let executable = quote_powershell(executable);
-    let script = format!(
+    let mut script = format!(
         "$ErrorActionPreference='Stop'; \
          Get-NetFirewallRule -Group '{group}' -ErrorAction SilentlyContinue | Remove-NetFirewallRule; \
          New-NetFirewallRule -DisplayName '{group}-Core' -Group '{group}' -Direction Outbound -Action Allow -Program '{executable}' -Profile Any | Out-Null; \
-         New-NetFirewallRule -DisplayName '{group}-Tun' -Group '{group}' -Direction Outbound -Action Allow -InterfaceAlias '{tun_name}' -Profile Any | Out-Null; \
-         Set-NetFirewallProfile -Name Domain,Private,Public -DefaultOutboundAction Block"
+         New-NetFirewallRule -DisplayName '{group}-Tun' -Group '{group}' -Direction Outbound -Action Allow -InterfaceAlias '{tun_name}' -Profile Any | Out-Null; "
+    );
+    for (index, prefixes) in allowed.chunks(64).enumerate() {
+        let addresses = prefixes
+            .iter()
+            .map(|prefix| format!("'{}'", quote_powershell(&prefix.to_string())))
+            .collect::<Vec<_>>()
+            .join(",");
+        script.push_str(&format!(
+            "New-NetFirewallRule -DisplayName '{group}-Bypass-{index}' -Group '{group}' -Direction Outbound -Action Allow -RemoteAddress {addresses} -Profile Any | Out-Null; "
+        ));
+    }
+    script.push_str(
+        "Set-NetFirewallProfile -Name Domain,Private,Public -DefaultOutboundAction Block",
     );
     run_powershell(&script).map(|_| ())
+}
+
+fn complement_prefixes(protected: &[IpNet]) -> Vec<IpNet> {
+    let mut complement = Vec::new();
+    for (ipv6, width) in [(false, 32_u8), (true, 128_u8)] {
+        let mut ranges = protected
+            .iter()
+            .filter(|prefix| prefix.addr().is_ipv6() == ipv6)
+            .map(prefix_range)
+            .collect::<Vec<_>>();
+        ranges.sort_unstable();
+        let mut merged: Vec<(u128, u128)> = Vec::new();
+        for (start, end) in ranges {
+            if let Some(last) = merged.last_mut() {
+                if start <= last.1.saturating_add(1) {
+                    last.1 = last.1.max(end);
+                    continue;
+                }
+            }
+            merged.push((start, end));
+        }
+
+        let maximum = if ipv6 { u128::MAX } else { u32::MAX as u128 };
+        let mut start = 0_u128;
+        for (blocked_start, blocked_end) in merged {
+            if start < blocked_start {
+                append_range_prefixes(&mut complement, start, blocked_start - 1, width);
+            }
+            if blocked_end == maximum {
+                start = maximum;
+                break;
+            }
+            start = blocked_end + 1;
+        }
+        if start < maximum
+            || (start == maximum
+                && !protected.iter().any(|prefix| {
+                    prefix.addr().is_ipv6() == ipv6 && prefix.contains(&ip(maximum, width))
+                }))
+        {
+            append_range_prefixes(&mut complement, start, maximum, width);
+        }
+    }
+    complement
+}
+
+fn prefix_range(prefix: &IpNet) -> (u128, u128) {
+    let (start, width, prefix_len) = match prefix {
+        IpNet::V4(prefix) => (
+            u32::from(prefix.network()) as u128,
+            32_u8,
+            prefix.prefix_len(),
+        ),
+        IpNet::V6(prefix) => (u128::from(prefix.network()), 128_u8, prefix.prefix_len()),
+    };
+    let host_bits = width - prefix_len;
+    let end = if host_bits == 128 {
+        u128::MAX
+    } else {
+        start | ((1_u128 << host_bits) - 1)
+    };
+    (start, end)
+}
+
+fn append_range_prefixes(output: &mut Vec<IpNet>, mut start: u128, end: u128, width: u8) {
+    if start == 0 && end == u128::MAX && width == 128 {
+        output.push(IpNet::V6(Ipv6Net::new(Ipv6Addr::UNSPECIFIED, 0).unwrap()));
+        return;
+    }
+    while start <= end {
+        let aligned_bits = (start.trailing_zeros() as u8).min(width);
+        let remaining = end - start + 1;
+        let fitting_bits = (127 - remaining.leading_zeros()) as u8;
+        let host_bits = aligned_bits.min(fitting_bits).min(width);
+        let prefix_len = width - host_bits;
+        output.push(if width == 32 {
+            IpNet::V4(Ipv4Net::new(Ipv4Addr::from(start as u32), prefix_len).unwrap())
+        } else {
+            IpNet::V6(Ipv6Net::new(Ipv6Addr::from(start), prefix_len).unwrap())
+        });
+        if host_bits == 128 {
+            break;
+        }
+        let block_size = 1_u128 << host_bits;
+        if block_size > end - start {
+            break;
+        }
+        start += block_size;
+    }
+}
+
+fn ip(value: u128, width: u8) -> IpAddr {
+    if width == 32 {
+        IpAddr::V4(Ipv4Addr::from(value as u32))
+    } else {
+        IpAddr::V6(Ipv6Addr::from(value))
+    }
 }
 
 fn restore_profiles(group: &str, journal: &FirewallJournal) -> io::Result<()> {
@@ -216,9 +348,18 @@ fn persist_journal(path: &Path, journal: &FirewallJournal) -> io::Result<()> {
 }
 
 fn run_powershell(script: &str) -> io::Result<Vec<u8>> {
-    let output = Command::new("powershell.exe")
-        .args(["-NoProfile", "-NonInteractive", "-Command", script])
-        .output()?;
+    let mut child = Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "PowerShell stdin unavailable"))?
+        .write_all(script.as_bytes())?;
+    let output = child.wait_with_output()?;
     if output.status.success() {
         Ok(output.stdout)
     } else {
@@ -271,5 +412,36 @@ mod tests {
         )
         .expect_err("partial snapshot must fail closed");
         assert!(error.to_string().contains("incomplete"));
+    }
+
+    #[test]
+    fn complement_preserves_only_non_captured_destinations() {
+        let allowed = complement_prefixes(&[
+            "10.0.0.0/8".parse().unwrap(),
+            "2001:db8::/32".parse().unwrap(),
+        ]);
+        assert!(!allowed
+            .iter()
+            .any(|prefix| prefix.contains(&"10.1.2.3".parse().unwrap())));
+        assert!(!allowed
+            .iter()
+            .any(|prefix| prefix.contains(&"2001:db8::1".parse().unwrap())));
+        assert!(allowed
+            .iter()
+            .any(|prefix| prefix.contains(&"192.0.2.1".parse().unwrap())));
+        assert!(allowed
+            .iter()
+            .any(|prefix| prefix.contains(&"2001:db9::1".parse().unwrap())));
+    }
+
+    #[test]
+    fn split_defaults_have_an_empty_complement() {
+        let allowed = complement_prefixes(&[
+            "0.0.0.0/1".parse().unwrap(),
+            "128.0.0.0/1".parse().unwrap(),
+            "::/1".parse().unwrap(),
+            "8000::/1".parse().unwrap(),
+        ]);
+        assert!(allowed.is_empty());
     }
 }

--- a/crates/tun/src/route/linux.rs
+++ b/crates/tun/src/route/linux.rs
@@ -2,10 +2,11 @@ use std::io;
 use std::net::IpAddr;
 use std::process::Command;
 
+use ipnet::IpNet;
+
 use super::reconcile::{reconcile_route_state, with_rollback_error, RouteReconcileState};
 use super::{
-    command_error, family_exclusions, host_prefix, split_default_route_prefixes, RouteInterface,
-    RouteJournal, RouteLease,
+    command_error, family_exclusions, host_prefix, RouteInterface, RouteJournal, RouteLease,
 };
 
 #[derive(Debug)]
@@ -31,11 +32,18 @@ impl SystemRouteGuard {
         recovery_key: &str,
         address: IpAddr,
         netmask: IpAddr,
+        captured: &[IpNet],
         excluded: &[IpAddr],
     ) -> io::Result<Self> {
-        Self::install_with_egress(tun_name, recovery_key, address, netmask, excluded, |_| {
-            Ok(())
-        })
+        Self::install_with_egress(
+            tun_name,
+            recovery_key,
+            address,
+            netmask,
+            captured,
+            excluded,
+            |_| Ok(()),
+        )
     }
 
     pub fn install_with_egress(
@@ -43,6 +51,7 @@ impl SystemRouteGuard {
         recovery_key: &str,
         address: IpAddr,
         _netmask: IpAddr,
+        captured: &[IpNet],
         excluded: &[IpAddr],
         publish_egress: impl FnOnce(&RouteInterface) -> io::Result<()>,
     ) -> io::Result<Self> {
@@ -78,10 +87,11 @@ impl SystemRouteGuard {
         for peer in desired_exclusions {
             guard.install_exclusion(peer)?;
         }
-        for prefix in split_default_route_prefixes(address) {
-            let _ = guard.remove(prefix);
-            guard.add(prefix)?;
-            guard.journal.record_route(prefix)?;
+        for prefix in captured {
+            let prefix = prefix.to_string();
+            let _ = guard.remove(&prefix);
+            guard.add(&prefix)?;
+            guard.journal.record_route(&prefix)?;
         }
         Ok(guard)
     }

--- a/crates/tun/src/route/macos.rs
+++ b/crates/tun/src/route/macos.rs
@@ -2,11 +2,10 @@ use std::io;
 use std::net::IpAddr;
 use std::process::Command;
 
+use ipnet::IpNet;
+
 use super::reconcile::{reconcile_route_state, with_rollback_error, RouteReconcileState};
-use super::{
-    command_error, family_exclusions, split_default_route_prefixes, RouteInterface, RouteJournal,
-    RouteLease,
-};
+use super::{command_error, family_exclusions, RouteInterface, RouteJournal, RouteLease};
 
 mod scoped;
 
@@ -31,11 +30,18 @@ impl SystemRouteGuard {
         recovery_key: &str,
         address: IpAddr,
         netmask: IpAddr,
+        captured: &[IpNet],
         excluded: &[IpAddr],
     ) -> io::Result<Self> {
-        Self::install_with_egress(tun_name, recovery_key, address, netmask, excluded, |_| {
-            Ok(())
-        })
+        Self::install_with_egress(
+            tun_name,
+            recovery_key,
+            address,
+            netmask,
+            captured,
+            excluded,
+            |_| Ok(()),
+        )
     }
 
     pub fn install_with_egress(
@@ -43,6 +49,7 @@ impl SystemRouteGuard {
         recovery_key: &str,
         address: IpAddr,
         netmask: IpAddr,
+        captured: &[IpNet],
         excluded: &[IpAddr],
         publish_egress: impl FnOnce(&RouteInterface) -> io::Result<()>,
     ) -> io::Result<Self> {
@@ -84,10 +91,11 @@ impl SystemRouteGuard {
         for peer in desired_exclusions {
             guard.install_exclusion(peer)?;
         }
-        for prefix in split_default_route_prefixes(address) {
-            let _ = guard.remove(prefix);
-            guard.add(prefix)?;
-            guard.journal.record_route(prefix)?;
+        for prefix in captured {
+            let prefix = prefix.to_string();
+            let _ = guard.remove(&prefix);
+            guard.add(&prefix)?;
+            guard.journal.record_route(&prefix)?;
         }
         Ok(guard)
     }

--- a/crates/tun/src/route/tests.rs
+++ b/crates/tun/src/route/tests.rs
@@ -1,6 +1,24 @@
 use std::net::{IpAddr, Ipv4Addr};
 
-use super::{RouteInterface, RouteJournal, RouteLease};
+use super::{capture_route_prefixes, RouteInterface, RouteJournal, RouteLease};
+
+#[test]
+fn capture_plan_defaults_to_split_routes_and_filters_explicit_families() {
+    assert_eq!(
+        capture_route_prefixes("10.66.0.1".parse().unwrap(), &[]),
+        vec!["0.0.0.0/1".parse().unwrap(), "128.0.0.0/1".parse().unwrap()]
+    );
+    assert_eq!(
+        capture_route_prefixes(
+            "fd66::1".parse().unwrap(),
+            &[
+                "203.0.113.0/24".parse().unwrap(),
+                "2001:db8::/32".parse().unwrap(),
+            ],
+        ),
+        vec!["2001:db8::/32".parse().unwrap()]
+    );
+}
 
 fn journal(path: std::path::PathBuf) -> RouteJournal {
     RouteJournal {

--- a/crates/tun/src/route/windows.rs
+++ b/crates/tun/src/route/windows.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use ipnet::IpNet;
 use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
 use windows_sys::Win32::NetworkManagement::IpHelper::{
     ConvertInterfaceAliasToLuid, ConvertInterfaceLuidToAlias, ConvertInterfaceLuidToIndex,
@@ -15,10 +16,7 @@ use windows_sys::Win32::Networking::WinSock::{
 };
 
 use super::reconcile::{reconcile_route_state, with_rollback_error, RouteReconcileState};
-use super::{
-    family_exclusions, host_prefix, split_default_route_prefixes, RouteInterface, RouteJournal,
-    RouteLease,
-};
+use super::{family_exclusions, host_prefix, RouteInterface, RouteJournal, RouteLease};
 
 #[derive(Debug)]
 pub struct SystemRouteGuard {
@@ -43,11 +41,18 @@ impl SystemRouteGuard {
         recovery_key: &str,
         address: IpAddr,
         netmask: IpAddr,
+        captured: &[IpNet],
         excluded: &[IpAddr],
     ) -> io::Result<Self> {
-        Self::install_with_egress(tun_name, recovery_key, address, netmask, excluded, |_| {
-            Ok(())
-        })
+        Self::install_with_egress(
+            tun_name,
+            recovery_key,
+            address,
+            netmask,
+            captured,
+            excluded,
+            |_| Ok(()),
+        )
     }
 
     pub fn install_with_egress(
@@ -55,6 +60,7 @@ impl SystemRouteGuard {
         recovery_key: &str,
         address: IpAddr,
         _netmask: IpAddr,
+        captured: &[IpNet],
         excluded: &[IpAddr],
         publish_egress: impl FnOnce(&RouteInterface) -> io::Result<()>,
     ) -> io::Result<Self> {
@@ -101,10 +107,11 @@ impl SystemRouteGuard {
         for peer in desired_exclusions {
             guard.install_exclusion(peer)?;
         }
-        for prefix in split_default_route_prefixes(address) {
-            guard.remove(prefix)?;
-            guard.add(prefix)?;
-            guard.journal.record_route(prefix)?;
+        for prefix in captured {
+            let prefix = prefix.to_string();
+            guard.remove(&prefix)?;
+            guard.add(&prefix)?;
+            guard.journal.record_route(&prefix)?;
         }
         Ok(guard)
     }

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -321,7 +321,7 @@ UDP 数据包路径通过 `UdpPacketPath`、`DatagramCodec` 等中性接口组�
 
 ### `zero-tun`
 
-`zero-tun` 定义平台无关的 TUN 设备抽象、Linux/macOS/Windows 设备实现和事务化系统路由。平台驱动的部署仍由最终应用或安装器负责。自动路由默认同时用两组 `/1` 接管 IPv4/IPv6，并按地址族记录和绑定各自的物理出口（例如 Windows 的 IPv4 以太网与 IPv6 Teredo 可以不同）；macOS 还为绑定物理接口的 socket 维护 interface-scoped 默认路由，避免 `/1` 接管后物理出口查询直接返回不可达。路由事务按地址族持有主机级跨进程 lease，而不是按可配置 tag 隔离；因此两个实例不能同时改写同一地址族的捕获路由。恢复日志仍按稳定 tag 寻址，并持久记录 Zero 安装的半默认路由、显式目的网络排除项和 scoped 绕行项；异常退出后的同名设备启动先恢复残留项。
+`zero-tun` 定义平台无关的 TUN 设备抽象、Linux/macOS/Windows 设备实现和事务化系统路由。平台驱动的部署仍由最终应用或安装器负责。自动路由默认同时用两组 `/1` 接管 IPv4/IPv6；配置 `include_cidrs` 后则只为匹配已配置 TUN 地址族的目的前缀安装捕获路由，未列出的地址族和目的网络保持系统原路径。两种模式都按地址族记录和绑定各自的物理出口（例如 Windows 的 IPv4 以太网与 IPv6 Teredo 可以不同）；macOS 还为绑定物理接口的 socket 维护 interface-scoped 默认路由，避免捕获路由生效后物理出口查询直接返回不可达。路由事务按地址族持有主机级跨进程 lease，而不是按可配置 tag 隔离；因此两个实例不能同时改写同一地址族的捕获路由。恢复日志仍按稳定 tag 寻址，并持久记录 Zero 安装的捕获路由、显式目的网络排除项和 scoped 绕行项；异常退出后的同名设备启动先恢复残留项。
 
 TUN 反环路由两类互不替代的机制组成：捕获路由只负责让应用流量进入 Zero；运行时拥有的 TCP/UDP/QUIC socket 工厂负责在系统路由仍指向 Zero TUN 时把自身流量绑定到 underlay 出口。socket 工厂必须先以无发包的本地路由探测取得内核选择的源地址；命中 TUN 地址才强制物理出口，命中 LAN、企业 VPN 或其他更具体路由时必须保留系统选择。启动时必须先解析并发布 IPv4/IPv6 underlay，再安装对应 `/1` 捕获路由。代理节点地址不属于目的网络排除，不能在 TUN 启动或协调期间被枚举、解析或安装为 `/32`/`/128` host route；当前仅为尚未完全出口感知的 DNS bootstrap 保留显式排除。额外 carrier socket（例如 QUIC、split-HTTP 第二连接和 UDP packet path）必须复用同一出口工厂。
 
@@ -339,7 +339,7 @@ TCP 入站身份包含完整源 IP/端口；平台 listener 不得把 peer 降�
 
 `auto_route=true` 还会通过平台原生通知持续观察主机路由拓扑：Windows 使用 IP Helper 路由/接口回调，Linux 使用 `NETLINK_ROUTE`，macOS 使用 `PF_ROUTE`。通知只是有界的失效信号；`zero-proxy` 中单一的 TUN route reconciler 对突发事件防抖，重新解析非 TUN 默认出口和仍需保留的显式 DNS/bootstrap 排除集合，再调用 `zero-tun` 的事务化 guard 原地协调。同步平台命令在阻塞线程池执行，失败保留上一份可用状态并退避重试。提交成功后只替换新建 socket 读取的物理出口，既有连接和 TUN/用户态网络栈不重启；`auto_route=false` 不创建监听任务。这一运行期协调属于 #21；代理端点 host route 不得重新进入该流程。
 
-`strict_route=true` 还要求 `zero-tun` 在捕获路由提交后安装平台泄露保护：Linux 使用独立 nftables table，macOS 使用 `com.apple/*` 下的独立 pf anchor，Windows 使用 Windows Firewall（WFP 执行层）的稳定 rule group 与 profile outbound policy。保护只允许 loopback、受管 TUN 接口、Zero 自身的 underlay 出站以及显式 bootstrap/端点地址；最后规则必须 fail closed。资源名由 TUN 入站 tag 稳定派生，热协调以原子替换或先放行后收紧的事务更新；更新失败继续保留旧保护。正常停止先恢复防火墙状态再删除路由，异常退出则保留保护并由同 tag 的下一实例接管。平台权限、工具或恢复日志不可用时严格模式启动失败，不能降级为仅安装路由。
+`strict_route=true` 还要求 `zero-tun` 在捕获路由提交后安装平台泄露保护：Linux 使用独立 nftables table，macOS 使用 `com.apple/*` 下的独立 pf anchor，Windows 使用 Windows Firewall（WFP 执行层）的稳定 rule group 与 profile outbound policy。保护范围与同一份捕获前缀计划一致：全隧道阻断受管地址族的全部非 TUN 出口，选择性接管只阻断所列目的前缀，未接管目的网络保持正常直连。Linux/macOS 直接为捕获前缀生成拒绝规则；Windows 在恢复日志保护的默认 outbound block 下放行捕获集合的 CIDR 补集，不能用与 allow 冲突的显式 block 规则。loopback、受管 TUN 接口、Zero 自身的 underlay 出站以及显式 bootstrap/端点地址继续放行。资源名由 TUN 入站 tag 稳定派生，热协调以原子替换或先放行后收紧的事务更新；更新失败继续保留旧保护。正常停止先恢复防火墙状态再删除路由，异常退出则保留保护并由同 tag 的下一实例接管。平台权限、工具或恢复日志不可用时严格模式启动失败，不能降级为仅安装路由。
 
 TUN 入站的基本路径为：
 

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -13,6 +13,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
 默认行为：
 
 - `auto_route=true`：通过两条 `/1` 路由接管默认流量，不覆盖原默认路由；
+- `include_cidrs=[]` 保持上述全隧道行为；非空时只安装列出的目的 CIDR，并按地址族忽略没有对应接管前缀的 TUN 地址。`include_cidrs` 最多 128 项、不得重复，并要求 `auto_route=true`；
 - `auto_route=true` 会继续监听系统默认路由和接口变化；Wi-Fi/有线切换、VPN 上下线或 metric 变化后，内核在不重启 TUN 的情况下更新新建 socket 使用的物理出口和仍需保留的 DNS bootstrap 排除路由。事件会合并处理；协调失败时非严格模式保留上一份可用状态，严格模式进入 fail-closed，两者都会在 `tun status` 中报告错误；
 - `dual_stack=true`：在同一设备上配置 IPv4/IPv6 两个地址，并同时安装两组拆分默认路由；`secondary_addr` 可显式指定另一族 CIDR，省略时按主地址族使用 `10.66.0.1/24` 或 `fd66::1/64`；只有明确的单栈主机才应关闭，否则另一地址族仍可能绕过 TUN；
 - `strict_route=true`：underlay 出口、仍需保留的 DNS bootstrap 排除、任一半默认路由或平台 kill switch 失败时，启动整体失败并回滚已安装项；运行期 route monitor、bootstrap 重算或路由/防火墙协调失败时撤销受影响地址族的出口发布，使新建 TCP、UDP 与 DNS socket fail closed，协调恢复后再发布新出口；未选中的坏代理节点不影响 TUN 启动；
@@ -22,7 +23,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
 - macOS 会为每个受管地址族维护物理出口的 interface-scoped 默认路由，使绑定接口的 direct、代理节点和 DNS socket 在全局 `/1` 路由生效后仍可达；该路由参与出口切换、回滚和崩溃恢复。
 - 路由恢复日志按稳定的 TUN 入站 `tag` 与地址族寻址，并记录当次真实设备名；因此 macOS 在崩溃重启后即使 `utunN` 编号变化，也能清理旧设备留下的路由。系统路由 lease 则按地址族全局持有，第二个进程即使使用不同 tag，也必须明确失败且报告当前 owner，不能同时改写同一组捕获路由。
 
-调试时可分别使用 `--no-auto-route`、`--single-stack`、`--no-strict-route` 或 `--no-dns-hijack`。生产防泄露验证不应关闭这些选项。
+调试时可分别使用 `--no-auto-route`、`--single-stack`、`--no-strict-route` 或 `--no-dns-hijack`。`--include-cidr CIDR` 可重复传入以验证选择性接管。生产防泄露验证不应关闭 strict route。
 
 ## DNS 前置约束
 
@@ -39,6 +40,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
       "secondary_addr": "fd66::1/64",
       "tag": "tun-in",
       "auto_route": true,
+      "include_cidrs": [],
       "dual_stack": true,
       "strict_route": true,
       "dns_hijack": true
@@ -109,7 +111,7 @@ cargo run -- tun status
 状态应包含：
 
 ```text
-tun: running, healthy=true, managed_by_config=true, name=..., addr=10.66.0.1/24, addresses=10.66.0.1/24,fd66::1/64, mtu=1500, tag=tun-in, auto_route=true, dual_stack=true, strict_route=true, dns_hijack=true, egress=..., egress_v4=..., egress_v6=...
+tun: running, healthy=true, managed_by_config=true, name=..., addr=10.66.0.1/24, addresses=10.66.0.1/24,fd66::1/64, mtu=1500, tag=tun-in, auto_route=true, include_cidrs=full-tunnel, dual_stack=true, strict_route=true, dns_hijack=true, egress=..., egress_v4=..., egress_v6=...
 ```
 
 停止并确认清理：

--- a/src/application/tun.rs
+++ b/src/application/tun.rs
@@ -16,6 +16,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
             mtu,
             tag,
             auto_route,
+            include_cidrs,
             dual_stack,
             strict_route,
             dns_hijack,
@@ -32,6 +33,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
                     "mtu": mtu,
                     "tag": tag,
                     "auto_route": auto_route,
+                    "include_cidrs": include_cidrs,
                     "dual_stack": dual_stack,
                     "strict_route": strict_route,
                     "dns_hijack": dns_hijack,
@@ -67,7 +69,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
             let status = decode_tun_status(response.result.unwrap_or_default())?;
             if status.running {
                 println!(
-                    "tun: running, healthy={}, managed_by_config={}, name={}, addr={}, addresses={}, mtu={}, tag={}, auto_route={}, dual_stack={}, strict_route={}, dns_hijack={}, egress={}, egress_v4={}, egress_v6={}",
+                    "tun: running, healthy={}, managed_by_config={}, name={}, addr={}, addresses={}, mtu={}, tag={}, auto_route={}, include_cidrs={}, dual_stack={}, strict_route={}, dns_hijack={}, egress={}, egress_v4={}, egress_v6={}",
                     status.healthy,
                     status.managed_by_config,
                     status.name.as_deref().unwrap_or("-"),
@@ -84,6 +86,11 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
                         .unwrap_or("-"),
                     status.tag.as_deref().unwrap_or("-"),
                     status.auto_route,
+                    if status.include_cidrs.is_empty() {
+                        "full-tunnel".to_owned()
+                    } else {
+                        status.include_cidrs.join(",")
+                    },
                     status.dual_stack,
                     status.strict_route,
                     status.dns_hijack,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,7 @@ pub enum Command {
         mtu: Option<u16>,
         tag: String,
         auto_route: bool,
+        include_cidrs: Vec<String>,
         dual_stack: bool,
         strict_route: bool,
         dns_hijack: bool,
@@ -205,7 +206,7 @@ pub fn usage() -> &'static str {
   zero validate CONFIG
   zero connector state [--json] CONFIG
   zero mode <rule|direct|global> [outbound] [--socket PATH]
-  zero tun start --addr IP --tag TAG [--name NAME] [--mask MASK] [--secondary-addr CIDR] [--mtu MTU] [--no-auto-route] [--single-stack] [--no-strict-route] [--no-dns-hijack] [--socket PATH]
+  zero tun start --addr IP --tag TAG [--name NAME] [--mask MASK] [--secondary-addr CIDR] [--mtu MTU] [--include-cidr CIDR]... [--no-auto-route] [--single-stack] [--no-strict-route] [--no-dns-hijack] [--socket PATH]
   zero tun stop [--socket PATH]
   zero tun status [--socket PATH]
   zero build-info
@@ -427,6 +428,7 @@ fn parse_tun_start(args: Vec<String>) -> Result<Command, CliError> {
     let mut mtu: Option<u16> = None;
     let mut tag: Option<String> = None;
     let mut auto_route = true;
+    let mut include_cidrs = Vec::new();
     let mut dual_stack = true;
     let mut strict_route = true;
     let mut dns_hijack = true;
@@ -453,6 +455,10 @@ fn parse_tun_start(args: Vec<String>) -> Result<Command, CliError> {
                 )
             }
             "--tag" => tag = Some(iter.next().ok_or(CliError::new("--tag requires value"))?),
+            "--include-cidr" => include_cidrs.push(
+                iter.next()
+                    .ok_or(CliError::new("--include-cidr requires value"))?,
+            ),
             "--no-auto-route" => auto_route = false,
             "--single-stack" => dual_stack = false,
             "--no-strict-route" => strict_route = false,
@@ -477,6 +483,7 @@ fn parse_tun_start(args: Vec<String>) -> Result<Command, CliError> {
         mtu,
         tag,
         auto_route,
+        include_cidrs,
         dual_stack,
         strict_route,
         dns_hijack,


### PR DESCRIPTION
## Summary

- add declarative, command, CLI, and status contracts for destination CIDR capture
- install and recover only the selected platform routes while preserving the existing split-default behavior when the list is empty
- scope strict leak protection to the same capture plan on Linux, macOS, and Windows
- preserve ordinary non-captured traffic on Windows through a bounded CIDR-complement allow policy under the existing recoverable default-deny transaction
- validate family coverage, duplicate entries, automatic-route dependency, and entry limits
- document the architecture and end-to-end acceptance surface

## Architecture

Configuration and validation stay in `zero-config`; control and status contracts stay in `zero-api`; TUN lifecycle and route reconciliation stay in `zero-proxy`; all OS route/firewall mechanics stay in `zero-tun`. The empty capture list is backward-compatible full tunnel. A non-empty list is the single source for both installed routes and fail-closed protection.

## Validation

GitHub Actions is the platform acceptance environment for Linux, macOS, and Windows.