### PR TITLE
feat(tun): return ICMP for rejected UDP

### DIFF
--- a/crates/proxy/src/inbound/tun/udp.rs
+++ b/crates/proxy/src/inbound/tun/udp.rs
@@ -205,21 +205,33 @@ pub(super) async fn run(
                             &mut associations,
                             now,
                             source,
-                            destination,
+                            datagram.destination,
                             reason,
+                            stack.send_unreachable(&datagram.payload, source, datagram.destination),
                         ),
                     },
-                    Delivery::Full => {
+                    Delivery::Full(datagram) => {
+                        let feedback_sent = stack.send_unreachable(
+                            &datagram.payload,
+                            source,
+                            datagram.destination,
+                        );
                         if associations.should_log_pressure(now) {
                             tracing::warn!(
                                 ?source,
                                 ?destination,
+                                feedback_sent,
                                 active_associations = associations.active_count(),
                                 "dropping TUN UDP datagram because its association queue is full"
                             );
                         }
                     }
-                    Delivery::Closed(_datagram) => {
+                    Delivery::Closed(datagram) => {
+                        let feedback_sent = stack.send_unreachable(
+                            &datagram.payload,
+                            source,
+                            datagram.destination,
+                        );
                         if associations.remove(source) {
                             associations.record_failure(source, now);
                         }
@@ -227,6 +239,7 @@ pub(super) async fn run(
                             tracing::warn!(
                                 ?source,
                                 ?destination,
+                                feedback_sent,
                                 active_associations = associations.active_count(),
                                 "TUN UDP association closed; applying recreate backoff"
                             );
@@ -309,12 +322,14 @@ fn log_pressure_drop(
     source: SocketAddress,
     destination: SocketAddress,
     reason: AdmissionRejection,
+    feedback_sent: bool,
 ) {
     if associations.should_log_pressure(now) {
         tracing::warn!(
             ?source,
             ?destination,
             ?reason,
+            feedback_sent,
             active_associations = associations.active_count(),
             "dropping new TUN UDP association under admission pressure"
         );

--- a/crates/proxy/src/inbound/tun/udp/association.rs
+++ b/crates/proxy/src/inbound/tun/udp/association.rs
@@ -34,7 +34,7 @@ pub(super) struct AssociationRegistry {
 pub(super) enum Delivery {
     Delivered,
     Missing(TunDatagram),
-    Full,
+    Full(TunDatagram),
     Closed(TunDatagram),
 }
 
@@ -61,7 +61,7 @@ impl AssociationRegistry {
         };
         match association.sender.try_send(datagram) {
             Ok(()) => Delivery::Delivered,
-            Err(mpsc::error::TrySendError::Full(_)) => Delivery::Full,
+            Err(mpsc::error::TrySendError::Full(datagram)) => Delivery::Full(datagram),
             Err(mpsc::error::TrySendError::Closed(datagram)) => Delivery::Closed(datagram),
         }
     }
@@ -208,7 +208,7 @@ mod tests {
 
         assert!(matches!(
             registry.deliver(source(50_000), datagram()),
-            Delivery::Full
+            Delivery::Full(_)
         ));
         assert!(matches!(
             registry.deliver(source(50_001), datagram()),

--- a/crates/stack/src/packet.rs
+++ b/crates/stack/src/packet.rs
@@ -10,7 +10,7 @@ mod icmp;
 pub use fragment::{
     fragment_ip_packet, parse_ip_fragment, rebuild_fragmented_packet, FragmentKey, ParsedIpFragment,
 };
-pub use icmp::build_icmp_response;
+pub use icmp::{build_icmp_response, build_udp_unreachable_response};
 
 // ── Protocol numbers ──────────────────────────────────────────────────
 

--- a/crates/stack/src/packet/icmp.rs
+++ b/crates/stack/src/packet/icmp.rs
@@ -6,16 +6,30 @@ use super::{checksum, transport_header, IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_TC
 /// TCP/UDP within the configured MTU return `None` and continue normally.
 pub fn build_icmp_response(packet: &[u8], mtu: usize) -> Option<Vec<u8>> {
     match packet.first().map(|byte| byte >> 4) {
-        Some(4) => build_ipv4_response(packet, mtu),
-        Some(6) => build_ipv6_response(packet, mtu),
+        Some(4) => build_ipv4_response(packet, mtu, false),
+        Some(6) => build_ipv6_response(packet, mtu, false),
         _ => None,
     }
 }
 
-fn build_ipv4_response(packet: &[u8], mtu: usize) -> Option<Vec<u8>> {
+/// Build an administrative-prohibited response for a UDP datagram rejected
+/// by the local TUN policy. The response remains bounded to the configured
+/// MTU and quotes the original IP/UDP headers for kernel error correlation.
+pub fn build_udp_unreachable_response(packet: &[u8], mtu: usize) -> Option<Vec<u8>> {
+    if super::transport_header(packet)?.protocol != IPPROTO_UDP {
+        return None;
+    }
+    match packet.first().map(|byte| byte >> 4) {
+        Some(4) => build_ipv4_response(packet, mtu, true),
+        Some(6) => build_ipv6_response(packet, mtu, true),
+        _ => None,
+    }
+}
+
+fn build_ipv4_response(packet: &[u8], mtu: usize, reject_udp: bool) -> Option<Vec<u8>> {
     let transport = transport_header(packet)?;
     let oversized = packet.len() > mtu;
-    if !oversized && matches!(transport.protocol, IPPROTO_TCP | IPPROTO_UDP) {
+    if !oversized && matches!(transport.protocol, IPPROTO_TCP | IPPROTO_UDP) && !reject_udp {
         return None;
     }
     if transport.protocol == IPPROTO_ICMP
@@ -66,10 +80,10 @@ fn build_ipv4_response(packet: &[u8], mtu: usize) -> Option<Vec<u8>> {
     Some(response)
 }
 
-fn build_ipv6_response(packet: &[u8], mtu: usize) -> Option<Vec<u8>> {
+fn build_ipv6_response(packet: &[u8], mtu: usize, reject_udp: bool) -> Option<Vec<u8>> {
     let transport = transport_header(packet)?;
     let oversized = packet.len() > mtu;
-    if !oversized && matches!(transport.protocol, IPPROTO_TCP | IPPROTO_UDP) {
+    if !oversized && matches!(transport.protocol, IPPROTO_TCP | IPPROTO_UDP) && !reject_udp {
         return None;
     }
     if transport.protocol == IPPROTO_ICMPV6
@@ -121,4 +135,40 @@ fn icmpv6_checksum(source: Ipv6Addr, destination: Ipv6Addr, icmp: &[u8]) -> u16 
     pseudo.extend_from_slice(&[0, 0, 0, IPPROTO_ICMPV6]);
     pseudo.extend_from_slice(icmp);
     checksum(&pseudo)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    #[test]
+    fn rejected_udp_builds_bounded_ipv4_and_ipv6_errors() {
+        let ipv4 = crate::packet::build_udp(
+            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+            IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+            50_000,
+            443,
+            b"rejected-v4",
+        );
+        let response = build_udp_unreachable_response(&ipv4, 1500).unwrap();
+        assert_eq!(response[9], IPPROTO_ICMP);
+        assert_eq!(&response[12..16], &[203, 0, 113, 7]);
+        assert_eq!(&response[16..20], &[10, 0, 0, 2]);
+        assert_eq!(&response[20..22], &[3, 13]);
+        assert!(response.len() <= 1500);
+
+        let ipv6 = crate::packet::build_udp(
+            IpAddr::V6("fd00::2".parse::<Ipv6Addr>().unwrap()),
+            IpAddr::V6("2001:db8::7".parse::<Ipv6Addr>().unwrap()),
+            50_001,
+            443,
+            b"rejected-v6",
+        );
+        let response = build_udp_unreachable_response(&ipv6, 1500).unwrap();
+        assert_eq!(response[6], IPPROTO_ICMPV6);
+        assert_eq!(&response[40..42], &[1, 1]);
+        assert!(response.len() <= 1500);
+    }
 }

--- a/crates/stack/src/udp.rs
+++ b/crates/stack/src/udp.rs
@@ -69,6 +69,27 @@ impl UserUdpStack {
             next_fragment_id: AtomicU32::new(1),
         }
     }
+
+    /// Best-effort, non-blocking feedback for a UDP datagram rejected before
+    /// an association can accept it.
+    pub fn send_unreachable(
+        &self,
+        payload: &[u8],
+        source: SocketAddress,
+        destination: SocketAddress,
+    ) -> bool {
+        let original = packet::build_udp(
+            sockaddr_to_ipaddr(&source),
+            sockaddr_to_ipaddr(&destination),
+            source.port,
+            destination.port,
+            payload,
+        );
+        let Some(response) = packet::build_udp_unreachable_response(&original, self.mtu) else {
+            return false;
+        };
+        self.outbound.try_send(response).is_ok()
+    }
 }
 
 impl UdpStack for UserUdpStack {

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -325,13 +325,7 @@ UDP 数据包路径通过 `UdpPacketPath`、`DatagramCodec` 等中性接口组�
 
 TUN 反环路由两类互不替代的机制组成：捕获路由只负责让应用流量进入 Zero；运行时拥有的 TCP/UDP/QUIC socket 工厂负责在系统路由仍指向 Zero TUN 时把自身流量绑定到 underlay 出口。socket 工厂必须先以无发包的本地路由探测取得内核选择的源地址；命中 TUN 地址才强制物理出口，命中 LAN、企业 VPN 或其他更具体路由时必须保留系统选择。启动时必须先解析并发布 IPv4/IPv6 underlay，再安装对应 `/1` 捕获路由。代理节点地址不属于目的网络排除，不能在 TUN 启动或协调期间被枚举、解析或安装为 `/32`/`/128` host route；当前仅为尚未完全出口感知的 DNS bootstrap 保留显式排除。额外 carrier socket（例如 QUIC、split-HTTP 第二连接和 UDP packet path）必须复用同一出口工厂。
 
-TUN UDP association 以原始客户端源 IP/端口为身份，同一源关联内再按目标复用 UDP flow；不同源端口不能仅因目标相同而合并，否则响应会写回错误客户端。direct 路径采用 endpoint-independent mapping：同一客户端源端点的不同目标复用同一族 outbound socket；创建 socket 时尽力保留客户端源端口，端口已占用或不可绑定时回退到临时端口。过滤采用 endpoint-dependent filtering，只有已建立 flow 的精确远端 IP/端口可以回包，不允许“当前只有一条 flow”成为接受任意 sender 的隐式例外。出口 generation 变化时以相同端口策略重建 socket。关联建立有并发硬上限和滚动速率限制，单关联队列使用非阻塞投递，关闭的关联和失败的目标 flow 都应用有界指数退避。这样自捕获或 `WSAENOBUFS` 只能造成受控丢包，不能演化为无界 association/session 重建。TUN 会话必须记录原始源 IP/端口，不能用 loopback 占位地址代替。
-
-QUIC 透明嗅探不终止 QUIC 连接。通用 Initial v1/v2 密钥派生、包保护验证和
-CRYPTO 帧重组属于 `zero-transport`；TUN UDP 只维护按关联/目标有界且带期限的
-暂存状态，并把恢复出的逻辑域名、原始 IP 与 `quic_sni` 来源交给统一 Session。
-ECH、未知版本、认证失败、超时和容量压力都回退到 DNS reverse 或原始 IP，
-不得使用密文字符串扫描或外层 SNI 猜测隐藏域名。
+TUN UDP association 以原始客户端源 IP/端口为身份，同一源关联内再按目标复用 UDP flow；不同源端口不能仅因目标相同而合并，否则响应会写回错误客户端。direct 路径采用 endpoint-independent mapping：同一客户端源端点的不同目标复用同一族 outbound socket；创建 socket 时尽力保留客户端源端口，端口已占用或不可绑定时回退到临时端口。过滤采用 endpoint-dependent filtering，只有已建立 flow 的精确远端 IP/端口可以回包，不允许“当前只有一条 flow”成为接受任意 sender 的隐式例外。出口 generation 变化时以相同端口策略重建 socket。关联建立有并发硬上限和滚动速率限制，单关联队列使用非阻塞投递，关闭的关联和失败的目标 flow 都应用有界指数退避。容量、速率、退避或关闭队列造成的本地显式拒绝，会尽力向客户端回送引用原 UDP 首部的 IPv4/IPv6 administratively prohibited；反馈也使用非阻塞有界队列，不能为报告拥塞而反向阻塞收包循环。这样自捕获或 `WSAENOBUFS` 只能造成受控丢包，不能演化为无界 association/session 重建。TUN 会话必须记录原始源 IP/端口，不能用 loopback 占位地址代替。
 
 QUIC 透明嗅探不终止 QUIC 连接。通用 Initial v1/v2 密钥派生、包保护验证和
 CRYPTO 帧重组属于 `zero-transport`；TUN UDP 只维护按关联/目标有界且带期限的

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -137,7 +137,7 @@ dig @8.8.8.8 example.com A
 
 `dig` 的目标地址可以是任意 DNS 地址；启用 DNS 劫持时 UDP/TCP 53 查询不会发往该目标，而是由 Zero DNS 返回。启用 Fake-IP 后，A 响应应位于配置的 Fake-IP 网段，后续到该地址的 TCP/UDP 会在路由决策前恢复为原域名。
 
-持续向同一 UDP 目标发送请求时，会话 API 应只保留同一源 tuple 对应的一条活动 flow，并显示应用的真实 TUN 源 IP/端口，而不是 `127.0.0.1:0`。同一 TUN 源端口访问多个 direct 目标时，目标观测到的 outbound 源端口应保持一致，并在端口可用时等于客户端源端口；预先占用该端口后应回退到稳定的临时端口而不是使 association 失败。向该映射端口注入来自未建立远端 IP/端口的 datagram 必须被丢弃，不能写回 TUN 客户端。制造大量不同源端口或让目标持续发送失败时，活动 association 数必须保持有界；日志可以出现限速丢包或退避，但不能出现单个目标每包创建一个新 session 的单调增长，也不能演化为 `WSAENOBUFS` 紧密循环。
+持续向同一 UDP 目标发送请求时，会话 API 应只保留同一源 tuple 对应的一条活动 flow，并显示应用的真实 TUN 源 IP/端口，而不是 `127.0.0.1:0`。同一 TUN 源端口访问多个 direct 目标时，目标观测到的 outbound 源端口应保持一致，并在端口可用时等于客户端源端口；预先占用该端口后应回退到稳定的临时端口而不是使 association 失败。向该映射端口注入来自未建立远端 IP/端口的 datagram 必须被丢弃，不能写回 TUN 客户端。制造大量不同源端口或让目标持续发送失败时，活动 association 数必须保持有界；容量、速率、重建退避或关闭队列导致的新 datagram 被明确拒绝时，IPv4 客户端应收到 type 3/code 13，IPv6 客户端应收到 type 1/code 1，且 quoted packet 对应原 UDP tuple。ICMP 反馈通道饱和时允许丢弃反馈，不能阻塞 TUN 收包。日志可以出现限速丢包或退避，但不能出现单个目标每包创建一个新 session 的单调增长，也不能演化为 `WSAENOBUFS` 紧密循环。
 
 ### macOS
 


### PR DESCRIPTION
## Summary

- add pure IPv4/IPv6 administrative-prohibited packet construction in `zero-stack`
- quote the rejected original IP/UDP headers so host kernels can correlate the error to the sending socket
- emit best-effort feedback when TUN UDP admission is rejected by capacity, rate, recreate backoff, full queue, or closed queue
- use a non-blocking response enqueue so overload feedback cannot stall the TUN receive loop
- cover both address families and document acceptance behavior

## Architecture

Raw packet construction remains pure in `zero-stack`. The concrete user UDP stack owns bounded packet enqueue. `zero-proxy` only decides when an association rejection warrants feedback and records whether it could be queued; protocol adapters and platform route code are unchanged.

## Stack position

This PR is based on #41 and completes its UDP NAT failure-feedback surface without coupling it to mapping or socket mechanics.

## Validation

GitHub Actions is the platform acceptance environment for Linux, macOS, and Windows.