### PR TITLE
feat(tun): audit routes across network lifecycle

### DIFF
--- a/crates/proxy/src/inbound/tun/routes.rs
+++ b/crates/proxy/src/inbound/tun/routes.rs
@@ -13,12 +13,26 @@ mod state;
 use state::{publish_error, publish_state, publish_unavailable};
 
 const ROUTE_EVENT_DEBOUNCE: Duration = Duration::from_millis(400);
+const ROUTE_WATCHDOG_INTERVAL: Duration = Duration::from_secs(30);
 const ROUTE_RETRY_DELAYS: [Duration; 4] = [
     Duration::from_millis(250),
     Duration::from_secs(1),
     Duration::from_secs(3),
     Duration::from_secs(10),
 ];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileTrigger {
+    PlatformEvent,
+    Retry,
+    Watchdog,
+}
+
+impl ReconcileTrigger {
+    fn should_debounce(self) -> bool {
+        matches!(self, Self::PlatformEvent)
+    }
+}
 
 pub(super) struct InstalledRoutes {
     pub guards: Vec<SystemRouteGuard>,
@@ -191,7 +205,7 @@ async fn run(
     // between initial route installation and monitor creation.
     let mut retry_index = Some(0_usize);
     loop {
-        let triggered_by_event = if let Some(index) = retry_index {
+        let trigger = if let Some(index) = retry_index {
             let delay = ROUTE_RETRY_DELAYS[index.min(ROUTE_RETRY_DELAYS.len() - 1)];
             tokio::select! {
                 changed = shutdown.changed() => {
@@ -203,9 +217,9 @@ async fn run(
                         monitor = None;
                         publish_runtime_error(&proxy, &spec, error.to_string());
                     }
-                    true
+                    ReconcileTrigger::PlatformEvent
                 }
-                _ = tokio::time::sleep(delay) => false,
+                _ = tokio::time::sleep(delay) => ReconcileTrigger::Retry,
             }
         } else {
             tokio::select! {
@@ -219,15 +233,16 @@ async fn run(
                         publish_runtime_error(&proxy, &spec, error.to_string());
                         retry_index = Some(0);
                     }
-                    true
+                    ReconcileTrigger::PlatformEvent
                 }
+                _ = tokio::time::sleep(ROUTE_WATCHDOG_INTERVAL) => ReconcileTrigger::Watchdog,
             }
         };
         if *shutdown.borrow() {
             break;
         }
 
-        if triggered_by_event {
+        if trigger.should_debounce() {
             tokio::select! {
                 changed = shutdown.changed() => {
                     let _ = changed;
@@ -241,6 +256,12 @@ async fn run(
                     monitor = None;
                 }
             }
+        }
+        if trigger == ReconcileTrigger::Watchdog {
+            tracing::debug!(
+                tun = %spec.tun_name,
+                "auditing TUN routes after the network lifecycle watchdog interval"
+            );
         }
         if monitor.is_none() {
             match RouteChangeMonitor::new() {
@@ -436,7 +457,9 @@ pub(super) fn route_names(guards: &[SystemRouteGuard]) -> (Option<String>, Optio
 
 #[cfg(test)]
 mod tests {
-    use super::{next_retry, RouteRuntimeSpec, ROUTE_RETRY_DELAYS};
+    use super::{
+        next_retry, ReconcileTrigger, RouteRuntimeSpec, ROUTE_RETRY_DELAYS, ROUTE_WATCHDOG_INTERVAL,
+    };
 
     #[test]
     fn route_retry_backoff_starts_small_and_is_bounded() {
@@ -446,6 +469,14 @@ mod tests {
             next_retry(Some(ROUTE_RETRY_DELAYS.len() - 1)),
             ROUTE_RETRY_DELAYS.len() - 1
         );
+    }
+
+    #[test]
+    fn only_platform_events_are_debounced() {
+        assert!(ReconcileTrigger::PlatformEvent.should_debounce());
+        assert!(!ReconcileTrigger::Retry.should_debounce());
+        assert!(!ReconcileTrigger::Watchdog.should_debounce());
+        assert!(ROUTE_WATCHDOG_INTERVAL > ROUTE_RETRY_DELAYS[0]);
     }
 
     #[test]

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -325,6 +325,8 @@ UDP 数据包路径通过 `UdpPacketPath`、`DatagramCodec` 等中性接口组�
 
 TUN 反环路由两类互不替代的机制组成：捕获路由只负责让应用流量进入 Zero；运行时拥有的 TCP/UDP/QUIC socket 工厂负责在系统路由仍指向 Zero TUN 时把自身流量绑定到 underlay 出口。socket 工厂必须先以无发包的本地路由探测取得内核选择的源地址；命中 TUN 地址才强制物理出口，命中 LAN、企业 VPN 或其他更具体路由时必须保留系统选择。启动时必须先解析并发布 IPv4/IPv6 underlay，再安装对应 `/1` 捕获路由。代理节点地址不属于目的网络排除，不能在 TUN 启动或协调期间被枚举、解析或安装为 `/32`/`/128` host route；当前仅为尚未完全出口感知的 DNS bootstrap 保留显式排除。额外 carrier socket（例如 QUIC、split-HTTP 第二连接和 UDP packet path）必须复用同一出口工厂。
 
+路由变化通知只作为失效提示，不能作为网络生命周期的唯一事实源。TUN 路由协调器除响应 Linux netlink、macOS routing socket 和 Windows IP Helper 通知外，还必须低频重新读取期望状态；这样休眠恢复、DHCP/IPv6 前缀变更、VPN 叠加或平台漏报事件仍会收敛。周期审计复用同一幂等 reconcile 与事务回滚路径，不创建第二套路由状态；严格模式审计失败时撤回受管出口并按既有退避重试，从而保持 fail closed。
+
 TUN UDP association 以原始客户端源 IP/端口为身份，同一源关联内再按目标复用 UDP flow；不同源端口不能仅因目标相同而合并，否则响应会写回错误客户端。direct 路径采用 endpoint-independent mapping：同一客户端源端点的不同目标复用同一族 outbound socket；创建 socket 时尽力保留客户端源端口，端口已占用或不可绑定时回退到临时端口。过滤采用 endpoint-dependent filtering，只有已建立 flow 的精确远端 IP/端口可以回包，不允许“当前只有一条 flow”成为接受任意 sender 的隐式例外。出口 generation 变化时以相同端口策略重建 socket。关联建立有并发硬上限和滚动速率限制，单关联队列使用非阻塞投递，关闭的关联和失败的目标 flow 都应用有界指数退避。容量、速率、退避或关闭队列造成的本地显式拒绝，会尽力向客户端回送引用原 UDP 首部的 IPv4/IPv6 administratively prohibited；反馈也使用非阻塞有界队列，不能为报告拥塞而反向阻塞收包循环。这样自捕获或 `WSAENOBUFS` 只能造成受控丢包，不能演化为无界 association/session 重建。TUN 会话必须记录原始源 IP/端口，不能用 loopback 占位地址代替。
 
 QUIC 透明嗅探不终止 QUIC 连接。通用 Initial v1/v2 密钥派生、包保护验证和

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -159,6 +159,12 @@ Resolve-DnsName example.com
 
 strict route 启动必须显式读取 Domain、Private、Public 三个 Windows Firewall profile，并把带 schema 的 UTF-8 JSON 快照持久化后才能修改默认出站策略。PowerShell 成功退出但未输出快照、缺少任一 profile 或包含未知动作时都必须在安装规则前 fail closed；错误不得退化为无上下文的 JSON EOF。
 
+## 网络生命周期验证
+
+在保持 TUN 运行的情况下依次执行休眠/唤醒、DHCP 续租、IPv6 前缀变化，以及连接和断开企业 VPN。每次变化后立即检查 `tun status` 和默认路由；平台事件正常时应在防抖窗口后收敛，即使平台未投递通知，也必须在 30 秒周期审计窗口内更新物理出口、DNS bootstrap 排除路由和严格模式防泄露规则。旧出口与新出口相同时不得递增出口 generation 或重建 UDP socket。
+
+临时移除所有可用物理默认路由时，`strict_route` 必须撤回对应受管出口并报告 unhealthy；恢复网络后应按有界退避自动回到 healthy，不需要重启 TUN。模拟协调失败时必须保留上一份可用路由/防泄露事务，不能留下部分更新。
+
 ## WebRTC/STUN 防泄露验证
 
 TUN 能接管浏览器发出的 STUN UDP，但最终是否暴露真实公网出口仍由 Zero 路由策略决定：


### PR DESCRIPTION
## Summary

- add a low-frequency route reconciliation watchdog alongside platform change notifications
- re-read underlay routes, DNS bootstrap exclusions, and leak protection state after missed events or suspended runtimes
- preserve the existing idempotent transaction, rollback, strict fail-closed, and bounded retry paths
- keep unchanged route audits from advancing egress generation or rebuilding UDP sockets
- document sleep/wake, DHCP, IPv6 prefix, VPN, and missing-default-route acceptance behavior

## Architecture

Linux netlink, macOS routing sockets, and Windows IP Helper remain invalidation hints in `zero-tun`. Lifecycle orchestration stays in the TUN ingress facade in `zero-proxy`, and periodic audits reuse the same platform-neutral desired-state reconciliation. No protocol adapter or alternative route state is introduced.

## Stack position

This PR is based on #42 and is one independently reversible P1 network-lifecycle capability.

## Validation

GitHub Actions is the platform acceptance environment for Linux, macOS, and Windows.