### PR TITLE
feat(tun): compile excluded capture CIDRs

### DIFF
--- a/crates/api/src/command.rs
+++ b/crates/api/src/command.rs
@@ -223,6 +223,9 @@ pub struct TunStartCommand {
     /// Destination CIDRs captured by automatic TUN routes. Empty means full tunnel.
     #[serde(default)]
     pub include_cidrs: Vec<String>,
+    /// Destination CIDRs removed from the automatic capture plan.
+    #[serde(default)]
+    pub exclude_cidrs: Vec<String>,
     /// Install split-default routes for both IPv4 and IPv6.
     #[serde(default = "default_true")]
     pub dual_stack: bool,
@@ -245,6 +248,7 @@ impl Default for TunStartCommand {
             tag: String::new(),
             auto_route: true,
             include_cidrs: Vec::new(),
+            exclude_cidrs: Vec::new(),
             dual_stack: true,
             strict_route: true,
             dns_hijack: true,

--- a/crates/api/src/query.rs
+++ b/crates/api/src/query.rs
@@ -314,6 +314,8 @@ pub struct TunStatusSnapshot {
     pub auto_route: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub include_cidrs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_cidrs: Vec<String>,
     #[serde(default)]
     pub dual_stack: bool,
     #[serde(default)]

--- a/crates/api/tests/api_model.rs
+++ b/crates/api/tests/api_model.rs
@@ -17,6 +17,7 @@ fn tun_start_defaults_to_transactional_automatic_routes() {
 
     assert!(command.auto_route);
     assert!(command.include_cidrs.is_empty());
+    assert!(command.exclude_cidrs.is_empty());
     assert!(command.dual_stack);
     assert!(command.strict_route);
     assert!(command.dns_hijack);

--- a/crates/config/src/model/tun.rs
+++ b/crates/config/src/model/tun.rs
@@ -29,6 +29,9 @@ pub struct TunConfig {
     /// the full-tunnel split-default behavior.
     #[serde(default)]
     pub include_cidrs: Vec<IpNet>,
+    /// Destination networks removed from the automatic capture plan.
+    #[serde(default)]
+    pub exclude_cidrs: Vec<IpNet>,
     /// Install both IPv4 and IPv6 split-default routes. Disable only on a
     /// deliberately single-stack host.
     #[serde(default = "default_true")]

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -362,9 +362,9 @@ fn validate_tun_config(
             "`runtime.tun.mtu` must be at least 576".to_owned(),
         ));
     }
-    if !tun.include_cidrs.is_empty() && !tun.auto_route {
+    if (!tun.include_cidrs.is_empty() || !tun.exclude_cidrs.is_empty()) && !tun.auto_route {
         return Err(ConfigError::InvalidRuntime(
-            "`runtime.tun.include_cidrs` requires `runtime.tun.auto_route=true`".to_owned(),
+            "`runtime.tun.include_cidrs` and `runtime.tun.exclude_cidrs` require `runtime.tun.auto_route=true`".to_owned(),
         ));
     }
     if tun.include_cidrs.len() > 128 {
@@ -382,6 +382,24 @@ fn validate_tun_config(
         if !tun.dual_stack && cidr.addr().is_ipv4() != address.is_ipv4() {
             return Err(ConfigError::InvalidRuntime(format!(
                 "`runtime.tun.include_cidrs` entry `{cidr}` has no configured TUN address family"
+            )));
+        }
+    }
+    if tun.exclude_cidrs.len() > 128 {
+        return Err(ConfigError::InvalidRuntime(
+            "`runtime.tun.exclude_cidrs` supports at most 128 entries".to_owned(),
+        ));
+    }
+    let mut seen_cidrs = HashSet::new();
+    for cidr in &tun.exclude_cidrs {
+        if !seen_cidrs.insert(*cidr) {
+            return Err(ConfigError::InvalidRuntime(format!(
+                "duplicate `runtime.tun.exclude_cidrs` entry `{cidr}`"
+            )));
+        }
+        if !tun.dual_stack && cidr.addr().is_ipv4() != address.is_ipv4() {
+            return Err(ConfigError::InvalidRuntime(format!(
+                "`runtime.tun.exclude_cidrs` entry `{cidr}` has no configured TUN address family"
             )));
         }
     }

--- a/crates/config/tests/config_parse.rs
+++ b/crates/config/tests/config_parse.rs
@@ -1784,6 +1784,7 @@ fn parses_declarative_tun_runtime_with_safe_defaults() {
     assert_eq!(tun.effective_mtu(config.runtime.network.mtu), 1400);
     assert!(tun.auto_route);
     assert!(tun.include_cidrs.is_empty());
+    assert!(tun.exclude_cidrs.is_empty());
     assert!(tun.dual_stack);
     assert!(tun.strict_route);
     assert!(tun.dns_hijack);
@@ -1795,6 +1796,9 @@ fn validates_declarative_tun_capture_cidrs() {
         r#"{ "addr": "10.0.0.1/24", "auto_route": false, "include_cidrs": ["10.0.0.0/8"] }"#,
         r#"{ "addr": "10.0.0.1/24", "dual_stack": false, "include_cidrs": ["2001:db8::/32"] }"#,
         r#"{ "addr": "10.0.0.1/24", "include_cidrs": ["10.0.0.0/8", "10.0.0.0/8"] }"#,
+        r#"{ "addr": "10.0.0.1/24", "auto_route": false, "exclude_cidrs": ["192.168.0.0/16"] }"#,
+        r#"{ "addr": "10.0.0.1/24", "dual_stack": false, "exclude_cidrs": ["2001:db8::/32"] }"#,
+        r#"{ "addr": "10.0.0.1/24", "exclude_cidrs": ["192.168.0.0/16", "192.168.0.0/16"] }"#,
     ] {
         let raw = format!(
             r#"{{

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -21,11 +21,13 @@ use crate::runtime::{Proxy, TunControl, TunInfo};
 use config::{configured_dns_endpoint_addresses, parse_interface_addresses};
 
 static NEXT_TUN_ID: AtomicU64 = AtomicU64::new(1);
+const MAX_CAPTURE_ROUTE_PREFIXES: usize = 512;
 
 #[derive(Clone, Debug)]
 pub struct TunRuntimeOptions {
     pub auto_route: bool,
     pub include_cidrs: Vec<ipnet::IpNet>,
+    pub exclude_cidrs: Vec<ipnet::IpNet>,
     pub dual_stack: bool,
     pub strict_route: bool,
     pub dns_hijack: bool,
@@ -130,20 +132,27 @@ impl Proxy {
         let TunRuntimeOptions {
             auto_route,
             include_cidrs,
+            exclude_cidrs,
             dual_stack,
             strict_route,
             dns_hijack,
         } = options;
-        if !include_cidrs.is_empty() && !auto_route {
+        if (!include_cidrs.is_empty() || !exclude_cidrs.is_empty()) && !auto_route {
             return Err(EngineError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "TUN include CIDRs require automatic routes",
+                "TUN include/exclude CIDRs require automatic routes",
             )));
         }
         if include_cidrs.len() > 128 {
             return Err(EngineError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "TUN include CIDRs support at most 128 entries",
+            )));
+        }
+        if exclude_cidrs.len() > 128 {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TUN exclude CIDRs support at most 128 entries",
             )));
         }
         let unique_include_cidrs = include_cidrs
@@ -153,6 +162,15 @@ impl Proxy {
             return Err(EngineError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "TUN include CIDRs must not contain duplicates",
+            )));
+        }
+        let unique_exclude_cidrs = exclude_cidrs
+            .iter()
+            .collect::<std::collections::HashSet<_>>();
+        if unique_exclude_cidrs.len() != exclude_cidrs.len() {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TUN exclude CIDRs must not contain duplicates",
             )));
         }
         let _operation = self.tun_operation_lock.lock().await;
@@ -176,17 +194,51 @@ impl Proxy {
         }
         let interface_addresses =
             parse_interface_addresses(addr, mask, secondary_addr, dual_stack)?;
+        if let Some(cidr) = include_cidrs.iter().chain(&exclude_cidrs).find(|cidr| {
+            !interface_addresses
+                .iter()
+                .any(|address| address.address.is_ipv6() == cidr.addr().is_ipv6())
+        }) {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("TUN capture CIDR `{cidr}` has no configured interface address family"),
+            )));
+        }
+        let compiled_route_count = interface_addresses
+            .iter()
+            .map(|address| {
+                zero_tun::capture_route_prefixes_with_exclusions(
+                    address.address,
+                    &include_cidrs,
+                    &exclude_cidrs,
+                )
+                .len()
+            })
+            .sum::<usize>();
+        if compiled_route_count > MAX_CAPTURE_ROUTE_PREFIXES {
+            return Err(EngineError::Io(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "TUN capture plan expands to {compiled_route_count} routes; maximum is {MAX_CAPTURE_ROUTE_PREFIXES}"
+                ),
+            )));
+        }
         let route_addresses = interface_addresses
             .iter()
             .filter(|address| {
-                !zero_tun::capture_route_prefixes(address.address, &include_cidrs).is_empty()
+                !zero_tun::capture_route_prefixes_with_exclusions(
+                    address.address,
+                    &include_cidrs,
+                    &exclude_cidrs,
+                )
+                .is_empty()
             })
             .map(|address| (address.address, address.netmask))
             .collect::<Vec<_>>();
         if auto_route && route_addresses.is_empty() {
             return Err(EngineError::Io(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "TUN include CIDRs do not match any configured interface address family",
+                "TUN include/exclude CIDRs leave no captured route for a configured interface family",
             )));
         }
         let mut tun_owned_addresses = interface_addresses
@@ -235,12 +287,15 @@ impl Proxy {
         let route_exclusions = prepared_network.route_exclusions;
         let installed = if auto_route {
             routes::install(
-                device_name.clone(),
-                tag.to_owned(),
-                route_addresses.clone(),
-                include_cidrs.clone(),
-                route_exclusions.clone(),
-                strict_route,
+                routes::RouteInstallSpec {
+                    tun_name: device_name.clone(),
+                    recovery_key: tag.to_owned(),
+                    addresses: route_addresses.clone(),
+                    include_cidrs: include_cidrs.clone(),
+                    exclude_cidrs: exclude_cidrs.clone(),
+                    excluded: route_exclusions.clone(),
+                    strict: strict_route,
+                },
                 self.egress_interface.clone(),
             )
             .await?
@@ -318,6 +373,7 @@ impl Proxy {
                     primary_ipv6: address.is_ipv6(),
                     addresses: route_addresses,
                     include_cidrs: include_cidrs.clone(),
+                    exclude_cidrs: exclude_cidrs.clone(),
                     dns_hijack,
                     strict_route,
                 },
@@ -339,6 +395,7 @@ impl Proxy {
             tag: tag.to_owned(),
             auto_route,
             include_cidrs,
+            exclude_cidrs,
             dual_stack,
             strict_route,
             dns_hijack,
@@ -455,6 +512,7 @@ impl Proxy {
             options: TunRuntimeOptions {
                 auto_route: desired.auto_route,
                 include_cidrs: desired.include_cidrs.clone(),
+                exclude_cidrs: desired.exclude_cidrs.clone(),
                 dual_stack: desired.dual_stack,
                 strict_route: desired.strict_route,
                 dns_hijack: desired.dns_hijack,

--- a/crates/proxy/src/inbound/tun/routes.rs
+++ b/crates/proxy/src/inbound/tun/routes.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use ipnet::IpNet;
 use tokio::sync::{oneshot, watch};
 use zero_engine::EngineError;
-use zero_tun::{capture_route_prefixes, RouteChangeMonitor, SystemLeakGuard, SystemRouteGuard};
+use zero_tun::{
+    capture_route_prefixes_with_exclusions, RouteChangeMonitor, SystemLeakGuard, SystemRouteGuard,
+};
 
 use crate::runtime::Proxy;
 
@@ -40,15 +42,29 @@ pub(super) struct InstalledRoutes {
     pub last_error: Option<String>,
 }
 
+pub(super) struct RouteInstallSpec {
+    pub tun_name: String,
+    pub recovery_key: String,
+    pub addresses: Vec<(IpAddr, IpAddr)>,
+    pub include_cidrs: Vec<IpNet>,
+    pub exclude_cidrs: Vec<IpNet>,
+    pub excluded: Vec<IpAddr>,
+    pub strict: bool,
+}
+
 pub(super) async fn install(
-    tun_name: String,
-    recovery_key: String,
-    addresses: Vec<(IpAddr, IpAddr)>,
-    include_cidrs: Vec<IpNet>,
-    excluded: Vec<IpAddr>,
-    strict: bool,
+    spec: RouteInstallSpec,
     egress_control: zero_platform_tokio::EgressInterfaceControl,
 ) -> Result<InstalledRoutes, EngineError> {
+    let RouteInstallSpec {
+        tun_name,
+        recovery_key,
+        addresses,
+        include_cidrs,
+        exclude_cidrs,
+        excluded,
+        strict,
+    } = spec;
     tokio::task::spawn_blocking(move || {
         let mut guards = Vec::new();
         let mut last_error = None;
@@ -56,7 +72,9 @@ pub(super) async fn install(
         let previous_v6 = egress_control.current_for(true);
         let protected = addresses
             .iter()
-            .flat_map(|(address, _)| capture_route_prefixes(*address, &include_cidrs))
+            .flat_map(|(address, _)| {
+                capture_route_prefixes_with_exclusions(*address, &include_cidrs, &exclude_cidrs)
+            })
             .collect::<Vec<_>>();
         for (address, netmask) in addresses {
             let ipv6 = address.is_ipv6();
@@ -71,7 +89,7 @@ pub(super) async fn install(
                 &recovery_key,
                 address,
                 netmask,
-                &capture_route_prefixes(address, &include_cidrs),
+                &capture_route_prefixes_with_exclusions(address, &include_cidrs, &exclude_cidrs),
                 &excluded,
                 move |route| {
                     let interface = zero_platform_tokio::EgressInterface::new(
@@ -165,6 +183,7 @@ pub(super) struct RouteRuntimeSpec {
     pub primary_ipv6: bool,
     pub addresses: Vec<(IpAddr, IpAddr)>,
     pub include_cidrs: Vec<IpNet>,
+    pub exclude_cidrs: Vec<IpNet>,
     pub dns_hijack: bool,
     pub strict_route: bool,
 }
@@ -301,9 +320,12 @@ async fn run(
         let recovery_key = spec.recovery_key.clone();
         let addresses = spec.addresses.clone();
         let include_cidrs = spec.include_cidrs.clone();
+        let exclude_cidrs = spec.exclude_cidrs.clone();
         let protected = addresses
             .iter()
-            .flat_map(|(address, _)| capture_route_prefixes(*address, &include_cidrs))
+            .flat_map(|(address, _)| {
+                capture_route_prefixes_with_exclusions(*address, &include_cidrs, &exclude_cidrs)
+            })
             .collect::<Vec<_>>();
         let reconcile_exclusions = exclusions.clone();
         let reconciled = tokio::task::spawn_blocking(move || {
@@ -313,6 +335,7 @@ async fn run(
                 &recovery_key,
                 &addresses,
                 &include_cidrs,
+                &exclude_cidrs,
                 &reconcile_exclusions,
             )
             .and_then(|changed| {
@@ -403,6 +426,7 @@ fn reconcile_guards(
     recovery_key: &str,
     addresses: &[(IpAddr, IpAddr)],
     include_cidrs: &[IpNet],
+    exclude_cidrs: &[IpNet],
     excluded: &[IpAddr],
 ) -> io::Result<bool> {
     let mut changed = false;
@@ -418,7 +442,7 @@ fn reconcile_guards(
                 recovery_key,
                 address,
                 netmask,
-                &capture_route_prefixes(address, include_cidrs),
+                &capture_route_prefixes_with_exclusions(address, include_cidrs, exclude_cidrs),
                 excluded,
             )?);
             changed = true;
@@ -491,6 +515,7 @@ mod tests {
                 "255.255.255.0".parse().unwrap(),
             )],
             include_cidrs: Vec::new(),
+            exclude_cidrs: Vec::new(),
             dns_hijack: true,
             strict_route: true,
         };

--- a/crates/proxy/src/inbound/tun/tests.rs
+++ b/crates/proxy/src/inbound/tun/tests.rs
@@ -36,6 +36,7 @@ async fn command_tun_start_rejects_fake_ip_pool_collision_before_device_creation
             super::TunRuntimeOptions {
                 auto_route: false,
                 include_cidrs: Vec::new(),
+                exclude_cidrs: Vec::new(),
                 dual_stack: false,
                 strict_route: true,
                 dns_hijack: true,
@@ -57,6 +58,7 @@ fn configured_tun_fixture() -> (zero_config::TunConfig, TunInfo) {
         tag: "tun-in".to_owned(),
         auto_route: true,
         include_cidrs: Vec::new(),
+        exclude_cidrs: Vec::new(),
         dual_stack: false,
         strict_route: true,
         dns_hijack: true,
@@ -71,6 +73,7 @@ fn configured_tun_fixture() -> (zero_config::TunConfig, TunInfo) {
         tag: config.tag.clone(),
         auto_route: true,
         include_cidrs: Vec::new(),
+        exclude_cidrs: Vec::new(),
         dual_stack: false,
         strict_route: true,
         dns_hijack: true,

--- a/crates/proxy/src/runtime.rs
+++ b/crates/proxy/src/runtime.rs
@@ -105,6 +105,7 @@ pub(crate) struct TunInfo {
     pub tag: String,
     pub auto_route: bool,
     pub include_cidrs: Vec<ipnet::IpNet>,
+    pub exclude_cidrs: Vec<ipnet::IpNet>,
     pub dual_stack: bool,
     pub strict_route: bool,
     pub dns_hijack: bool,

--- a/crates/proxy/src/runtime/handle/command/tun.rs
+++ b/crates/proxy/src/runtime/handle/command/tun.rs
@@ -34,10 +34,21 @@ pub(super) fn execute_tun_start(
                 format!("invalid TUN include CIDR: {error}"),
             )
         })?;
-    if !include_cidrs.is_empty() && !auto_route {
+    let exclude_cidrs = cmd
+        .exclude_cidrs
+        .iter()
+        .map(|cidr| cidr.parse::<ipnet::IpNet>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            zero_api::ApiError::new(
+                zero_api::ApiErrorCode::InvalidArgument,
+                format!("invalid TUN exclude CIDR: {error}"),
+            )
+        })?;
+    if (!include_cidrs.is_empty() || !exclude_cidrs.is_empty()) && !auto_route {
         return Err(zero_api::ApiError::new(
             zero_api::ApiErrorCode::InvalidArgument,
-            "TUN include CIDRs require `auto_route=true`",
+            "TUN include/exclude CIDRs require `auto_route=true`",
         ));
     }
     if include_cidrs.len() > 128 {
@@ -53,6 +64,21 @@ pub(super) fn execute_tun_start(
         return Err(zero_api::ApiError::new(
             zero_api::ApiErrorCode::InvalidArgument,
             "TUN include CIDRs must not contain duplicates",
+        ));
+    }
+    if exclude_cidrs.len() > 128 {
+        return Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::InvalidArgument,
+            "TUN exclude CIDRs support at most 128 entries",
+        ));
+    }
+    let unique = exclude_cidrs
+        .iter()
+        .collect::<std::collections::HashSet<_>>();
+    if unique.len() != exclude_cidrs.len() {
+        return Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::InvalidArgument,
+            "TUN exclude CIDRs must not contain duplicates",
         ));
     }
     let dual_stack = cmd.dual_stack;
@@ -74,6 +100,7 @@ pub(super) fn execute_tun_start(
                     TunRuntimeOptions {
                         auto_route,
                         include_cidrs,
+                        exclude_cidrs,
                         dual_stack,
                         strict_route,
                         dns_hijack,

--- a/crates/proxy/src/runtime/handle/query.rs
+++ b/crates/proxy/src/runtime/handle/query.rs
@@ -27,6 +27,7 @@ impl zero_api::QueryService for ProxyHandle {
                     healthy: tun.healthy,
                     auto_route: tun.auto_route,
                     include_cidrs: tun.include_cidrs.iter().map(ToString::to_string).collect(),
+                    exclude_cidrs: tun.exclude_cidrs.iter().map(ToString::to_string).collect(),
                     dual_stack: tun.dual_stack,
                     strict_route: tun.strict_route,
                     dns_hijack: tun.dns_hijack,

--- a/crates/proxy/src/runtime/handle/query/tests.rs
+++ b/crates/proxy/src/runtime/handle/query/tests.rs
@@ -24,6 +24,7 @@ fn running_tun_status_exposes_route_health_and_error() {
         tag: "tun-in".to_owned(),
         auto_route: true,
         include_cidrs: Vec::new(),
+        exclude_cidrs: Vec::new(),
         dual_stack: false,
         strict_route: true,
         dns_hijack: true,

--- a/crates/tun/src/lib.rs
+++ b/crates/tun/src/lib.rs
@@ -14,8 +14,8 @@ type TunPacketReceiver = tokio::sync::mpsc::Receiver<Vec<u8>>;
 
 mod route;
 pub use route::{
-    capture_route_prefixes, split_default_route_prefixes, RouteChangeMonitor, RouteInterface,
-    SystemLeakGuard, SystemRouteGuard,
+    capture_route_prefixes, capture_route_prefixes_with_exclusions, split_default_route_prefixes,
+    RouteChangeMonitor, RouteInterface, SystemLeakGuard, SystemRouteGuard,
 };
 
 // ── Address helpers ───────────────────────────────────────────────────

--- a/crates/tun/src/route.rs
+++ b/crates/tun/src/route.rs
@@ -116,6 +116,18 @@ pub fn split_default_route_prefixes(address: IpAddr) -> [&'static str; 2] {
 }
 
 pub fn capture_route_prefixes(address: IpAddr, included: &[IpNet]) -> Vec<IpNet> {
+    capture_route_prefixes_with_exclusions(address, included, &[])
+}
+
+/// Compile one address family's automatic capture routes from positive and
+/// negative destination CIDRs. Exclusions are represented by splitting the
+/// captured prefixes, so excluded traffic keeps the system route without a
+/// second platform-specific bypass state.
+pub fn capture_route_prefixes_with_exclusions(
+    address: IpAddr,
+    included: &[IpNet],
+    excluded: &[IpNet],
+) -> Vec<IpNet> {
     let mut prefixes: Vec<IpNet> = if included.is_empty() {
         split_default_route_prefixes(address)
             .into_iter()
@@ -128,9 +140,60 @@ pub fn capture_route_prefixes(address: IpAddr, included: &[IpNet]) -> Vec<IpNet>
             .filter(|prefix| prefix.addr().is_ipv6() == address.is_ipv6())
             .collect()
     };
+    for excluded in excluded
+        .iter()
+        .copied()
+        .filter(|prefix| prefix.addr().is_ipv6() == address.is_ipv6())
+    {
+        prefixes = prefixes
+            .into_iter()
+            .flat_map(|prefix| subtract_prefix(prefix, excluded))
+            .collect();
+    }
     prefixes.sort_unstable();
     prefixes.dedup();
     prefixes
+}
+
+fn subtract_prefix(captured: IpNet, excluded: IpNet) -> Vec<IpNet> {
+    if captured.addr().is_ipv6() != excluded.addr().is_ipv6()
+        || !captured.contains(&excluded.network())
+    {
+        return if excluded.contains(&captured.network()) {
+            Vec::new()
+        } else {
+            vec![captured]
+        };
+    }
+    if excluded.contains(&captured.network()) {
+        return Vec::new();
+    }
+    split_prefix(captured)
+        .into_iter()
+        .flat_map(|child| subtract_prefix(child, excluded))
+        .collect()
+}
+
+fn split_prefix(prefix: IpNet) -> [IpNet; 2] {
+    let next = prefix.prefix_len() + 1;
+    match prefix {
+        IpNet::V4(prefix) => {
+            let first = u32::from(prefix.network());
+            let second = first | (1_u32 << (32 - next));
+            [
+                IpNet::new(IpAddr::V4(first.into()), next).expect("IPv4 child prefix is valid"),
+                IpNet::new(IpAddr::V4(second.into()), next).expect("IPv4 child prefix is valid"),
+            ]
+        }
+        IpNet::V6(prefix) => {
+            let first = u128::from(prefix.network());
+            let second = first | (1_u128 << (128 - next));
+            [
+                IpNet::new(IpAddr::V6(first.into()), next).expect("IPv6 child prefix is valid"),
+                IpNet::new(IpAddr::V6(second.into()), next).expect("IPv6 child prefix is valid"),
+            ]
+        }
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/tun/src/route/tests.rs
+++ b/crates/tun/src/route/tests.rs
@@ -1,6 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr};
 
-use super::{capture_route_prefixes, RouteInterface, RouteJournal, RouteLease};
+use super::{
+    capture_route_prefixes, capture_route_prefixes_with_exclusions, RouteInterface, RouteJournal,
+    RouteLease,
+};
 
 #[test]
 fn capture_plan_defaults_to_split_routes_and_filters_explicit_families() {
@@ -17,6 +20,47 @@ fn capture_plan_defaults_to_split_routes_and_filters_explicit_families() {
             ],
         ),
         vec!["2001:db8::/32".parse().unwrap()]
+    );
+}
+
+#[test]
+fn capture_plan_subtracts_exclusions_for_both_address_families() {
+    let ipv4 = capture_route_prefixes_with_exclusions(
+        "10.66.0.1".parse().unwrap(),
+        &["10.0.0.0/8".parse().unwrap()],
+        &["10.64.0.0/10".parse().unwrap()],
+    );
+    assert_eq!(
+        ipv4,
+        vec![
+            "10.0.0.0/10".parse().unwrap(),
+            "10.128.0.0/9".parse().unwrap()
+        ]
+    );
+
+    let ipv6 = capture_route_prefixes_with_exclusions(
+        "fd66::1".parse().unwrap(),
+        &["2001:db8::/32".parse().unwrap()],
+        &["2001:db8:8000::/33".parse().unwrap()],
+    );
+    assert_eq!(ipv6, vec!["2001:db8::/33".parse().unwrap()]);
+}
+
+#[test]
+fn broader_and_unrelated_exclusions_are_deterministic() {
+    assert!(capture_route_prefixes_with_exclusions(
+        "10.66.0.1".parse().unwrap(),
+        &["10.0.0.0/8".parse().unwrap()],
+        &["0.0.0.0/0".parse().unwrap()],
+    )
+    .is_empty());
+    assert_eq!(
+        capture_route_prefixes_with_exclusions(
+            "10.66.0.1".parse().unwrap(),
+            &["10.0.0.0/8".parse().unwrap()],
+            &["192.0.2.0/24".parse().unwrap()],
+        ),
+        vec!["10.0.0.0/8".parse().unwrap()]
     );
 }
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -321,7 +321,7 @@ UDP 数据包路径通过 `UdpPacketPath`、`DatagramCodec` 等中性接口组�
 
 ### `zero-tun`
 
-`zero-tun` 定义平台无关的 TUN 设备抽象、Linux/macOS/Windows 设备实现和事务化系统路由。平台驱动的部署仍由最终应用或安装器负责。自动路由默认同时用两组 `/1` 接管 IPv4/IPv6；配置 `include_cidrs` 后则只为匹配已配置 TUN 地址族的目的前缀安装捕获路由，未列出的地址族和目的网络保持系统原路径。两种模式都按地址族记录和绑定各自的物理出口（例如 Windows 的 IPv4 以太网与 IPv6 Teredo 可以不同）；macOS 还为绑定物理接口的 socket 维护 interface-scoped 默认路由，避免捕获路由生效后物理出口查询直接返回不可达。路由事务按地址族持有主机级跨进程 lease，而不是按可配置 tag 隔离；因此两个实例不能同时改写同一地址族的捕获路由。恢复日志仍按稳定 tag 寻址，并持久记录 Zero 安装的捕获路由、显式目的网络排除项和 scoped 绕行项；异常退出后的同名设备启动先恢复残留项。
+`zero-tun` 定义平台无关的 TUN 设备抽象、Linux/macOS/Windows 设备实现和事务化系统路由。平台驱动的部署仍由最终应用或安装器负责。自动路由默认同时用两组 `/1` 接管 IPv4/IPv6；配置 `include_cidrs` 后则只从匹配已配置 TUN 地址族的目的前缀开始编译，`exclude_cidrs` 再从该集合中执行平台无关的 CIDR 差集，未被最终计划覆盖的地址族和目的网络保持系统原路径。差集通过拆分捕获前缀表达，不创建第二套平台旁路状态；编译后的计划最多 512 条路由，避免细粒度排除无界放大路由表。自动路由和 strict kill switch 必须消费同一最终计划。两种模式都按地址族记录和绑定各自的物理出口（例如 Windows 的 IPv4 以太网与 IPv6 Teredo 可以不同）；macOS 还为绑定物理接口的 socket 维护 interface-scoped 默认路由，避免捕获路由生效后物理出口查询直接返回不可达。路由事务按地址族持有主机级跨进程 lease，而不是按可配置 tag 隔离；因此两个实例不能同时改写同一地址族的捕获路由。恢复日志仍按稳定 tag 寻址，并持久记录 Zero 安装的捕获路由、显式目的网络排除项和 scoped 绕行项；异常退出后的同名设备启动先恢复残留项。
 
 TUN 反环路由两类互不替代的机制组成：捕获路由只负责让应用流量进入 Zero；运行时拥有的 TCP/UDP/QUIC socket 工厂负责在系统路由仍指向 Zero TUN 时把自身流量绑定到 underlay 出口。socket 工厂必须先以无发包的本地路由探测取得内核选择的源地址；命中 TUN 地址才强制物理出口，命中 LAN、企业 VPN 或其他更具体路由时必须保留系统选择。启动时必须先解析并发布 IPv4/IPv6 underlay，再安装对应 `/1` 捕获路由。代理节点地址不属于目的网络排除，不能在 TUN 启动或协调期间被枚举、解析或安装为 `/32`/`/128` host route；当前仅为尚未完全出口感知的 DNS bootstrap 保留显式排除。额外 carrier socket（例如 QUIC、split-HTTP 第二连接和 UDP packet path）必须复用同一出口工厂。
 

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -13,7 +13,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
 默认行为：
 
 - `auto_route=true`：通过两条 `/1` 路由接管默认流量，不覆盖原默认路由；
-- `include_cidrs=[]` 保持上述全隧道行为；非空时只安装列出的目的 CIDR，并按地址族忽略没有对应接管前缀的 TUN 地址。`include_cidrs` 最多 128 项、不得重复，并要求 `auto_route=true`；
+- `include_cidrs=[]` 保持上述全隧道起点；非空时只从列出的目的 CIDR 开始。`exclude_cidrs` 从这个集合中排除通用目的网络，两者最多各 128 项、不得重复，并要求 `auto_route=true`；编译结果最多 512 条路由且至少保留一个已配置地址族；
 - `auto_route=true` 会继续监听系统默认路由和接口变化；Wi-Fi/有线切换、VPN 上下线或 metric 变化后，内核在不重启 TUN 的情况下更新新建 socket 使用的物理出口和仍需保留的 DNS bootstrap 排除路由。事件会合并处理；协调失败时非严格模式保留上一份可用状态，严格模式进入 fail-closed，两者都会在 `tun status` 中报告错误；
 - `dual_stack=true`：在同一设备上配置 IPv4/IPv6 两个地址，并同时安装两组拆分默认路由；`secondary_addr` 可显式指定另一族 CIDR，省略时按主地址族使用 `10.66.0.1/24` 或 `fd66::1/64`；只有明确的单栈主机才应关闭，否则另一地址族仍可能绕过 TUN；
 - `strict_route=true`：underlay 出口、仍需保留的 DNS bootstrap 排除、任一半默认路由或平台 kill switch 失败时，启动整体失败并回滚已安装项；运行期 route monitor、bootstrap 重算或路由/防火墙协调失败时撤销受影响地址族的出口发布，使新建 TCP、UDP 与 DNS socket fail closed，协调恢复后再发布新出口；未选中的坏代理节点不影响 TUN 启动；
@@ -23,7 +23,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
 - macOS 会为每个受管地址族维护物理出口的 interface-scoped 默认路由，使绑定接口的 direct、代理节点和 DNS socket 在全局 `/1` 路由生效后仍可达；该路由参与出口切换、回滚和崩溃恢复。
 - 路由恢复日志按稳定的 TUN 入站 `tag` 与地址族寻址，并记录当次真实设备名；因此 macOS 在崩溃重启后即使 `utunN` 编号变化，也能清理旧设备留下的路由。系统路由 lease 则按地址族全局持有，第二个进程即使使用不同 tag，也必须明确失败且报告当前 owner，不能同时改写同一组捕获路由。
 
-调试时可分别使用 `--no-auto-route`、`--single-stack`、`--no-strict-route` 或 `--no-dns-hijack`。`--include-cidr CIDR` 可重复传入以验证选择性接管。生产防泄露验证不应关闭 strict route。
+调试时可分别使用 `--no-auto-route`、`--single-stack`、`--no-strict-route` 或 `--no-dns-hijack`。`--include-cidr CIDR` 与 `--exclude-cidr CIDR` 均可重复传入以验证选择性接管。生产防泄露验证不应关闭 strict route。
 
 ## DNS 前置约束
 
@@ -41,6 +41,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
       "tag": "tun-in",
       "auto_route": true,
       "include_cidrs": [],
+      "exclude_cidrs": [],
       "dual_stack": true,
       "strict_route": true,
       "dns_hijack": true
@@ -111,7 +112,7 @@ cargo run -- tun status
 状态应包含：
 
 ```text
-tun: running, healthy=true, managed_by_config=true, name=..., addr=10.66.0.1/24, addresses=10.66.0.1/24,fd66::1/64, mtu=1500, tag=tun-in, auto_route=true, include_cidrs=full-tunnel, dual_stack=true, strict_route=true, dns_hijack=true, egress=..., egress_v4=..., egress_v6=...
+tun: running, healthy=true, managed_by_config=true, name=..., addr=10.66.0.1/24, addresses=10.66.0.1/24,fd66::1/64, mtu=1500, tag=tun-in, auto_route=true, include_cidrs=full-tunnel, exclude_cidrs=-, dual_stack=true, strict_route=true, dns_hijack=true, egress=..., egress_v4=..., egress_v6=...
 ```
 
 停止并确认清理：

--- a/src/application/tun.rs
+++ b/src/application/tun.rs
@@ -17,6 +17,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
             tag,
             auto_route,
             include_cidrs,
+            exclude_cidrs,
             dual_stack,
             strict_route,
             dns_hijack,
@@ -34,6 +35,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
                     "tag": tag,
                     "auto_route": auto_route,
                     "include_cidrs": include_cidrs,
+                    "exclude_cidrs": exclude_cidrs,
                     "dual_stack": dual_stack,
                     "strict_route": strict_route,
                     "dns_hijack": dns_hijack,
@@ -69,7 +71,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
             let status = decode_tun_status(response.result.unwrap_or_default())?;
             if status.running {
                 println!(
-                    "tun: running, healthy={}, managed_by_config={}, name={}, addr={}, addresses={}, mtu={}, tag={}, auto_route={}, include_cidrs={}, dual_stack={}, strict_route={}, dns_hijack={}, egress={}, egress_v4={}, egress_v6={}",
+                    "tun: running, healthy={}, managed_by_config={}, name={}, addr={}, addresses={}, mtu={}, tag={}, auto_route={}, include_cidrs={}, exclude_cidrs={}, dual_stack={}, strict_route={}, dns_hijack={}, egress={}, egress_v4={}, egress_v6={}",
                     status.healthy,
                     status.managed_by_config,
                     status.name.as_deref().unwrap_or("-"),
@@ -90,6 +92,11 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
                         "full-tunnel".to_owned()
                     } else {
                         status.include_cidrs.join(",")
+                    },
+                    if status.exclude_cidrs.is_empty() {
+                        "-".to_owned()
+                    } else {
+                        status.exclude_cidrs.join(",")
                     },
                     status.dual_stack,
                     status.strict_route,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,7 @@ pub enum Command {
         tag: String,
         auto_route: bool,
         include_cidrs: Vec<String>,
+        exclude_cidrs: Vec<String>,
         dual_stack: bool,
         strict_route: bool,
         dns_hijack: bool,
@@ -206,7 +207,7 @@ pub fn usage() -> &'static str {
   zero validate CONFIG
   zero connector state [--json] CONFIG
   zero mode <rule|direct|global> [outbound] [--socket PATH]
-  zero tun start --addr IP --tag TAG [--name NAME] [--mask MASK] [--secondary-addr CIDR] [--mtu MTU] [--include-cidr CIDR]... [--no-auto-route] [--single-stack] [--no-strict-route] [--no-dns-hijack] [--socket PATH]
+  zero tun start --addr IP --tag TAG [--name NAME] [--mask MASK] [--secondary-addr CIDR] [--mtu MTU] [--include-cidr CIDR]... [--exclude-cidr CIDR]... [--no-auto-route] [--single-stack] [--no-strict-route] [--no-dns-hijack] [--socket PATH]
   zero tun stop [--socket PATH]
   zero tun status [--socket PATH]
   zero build-info
@@ -429,6 +430,7 @@ fn parse_tun_start(args: Vec<String>) -> Result<Command, CliError> {
     let mut tag: Option<String> = None;
     let mut auto_route = true;
     let mut include_cidrs = Vec::new();
+    let mut exclude_cidrs = Vec::new();
     let mut dual_stack = true;
     let mut strict_route = true;
     let mut dns_hijack = true;
@@ -459,6 +461,10 @@ fn parse_tun_start(args: Vec<String>) -> Result<Command, CliError> {
                 iter.next()
                     .ok_or(CliError::new("--include-cidr requires value"))?,
             ),
+            "--exclude-cidr" => exclude_cidrs.push(
+                iter.next()
+                    .ok_or(CliError::new("--exclude-cidr requires value"))?,
+            ),
             "--no-auto-route" => auto_route = false,
             "--single-stack" => dual_stack = false,
             "--no-strict-route" => strict_route = false,
@@ -484,6 +490,7 @@ fn parse_tun_start(args: Vec<String>) -> Result<Command, CliError> {
         tag,
         auto_route,
         include_cidrs,
+        exclude_cidrs,
         dual_stack,
         strict_route,
         dns_hijack,


### PR DESCRIPTION
## Summary

- add `exclude_cidrs` to declarative config, control API, CLI, status, and runtime state
- compile exclusions as a platform-neutral CIDR difference in `zero-tun`
- make automatic routes and strict leak protection consume the same final capture plan
- reject duplicates, unsupported families, empty plans, and plans expanding beyond 512 routes
- cover IPv4/IPv6 subtraction plus broader and unrelated exclusions

## Architecture

CIDR set algebra remains pure in `zero-tun`; `zero-proxy` owns bounded lifecycle validation and passes the compiled plan to the existing transactional route and leak-guard facades. Linux, macOS, and Windows do not gain a second bypass state, and protocol adapters remain unchanged.

## Stack position

This PR is based on #43 and extends #40's positive CIDR capture with a separate, independently reversible negative selection capability.

## Validation

GitHub Actions is the platform acceptance environment for Linux, macOS, and Windows.