### PR TITLE
feat(diagnostics): expose direct egress decision context

### DIFF
--- a/crates/api/src/command.rs
+++ b/crates/api/src/command.rs
@@ -27,6 +27,8 @@ pub enum CommandRequest {
     DiagnosticsDnsCache(DiagnosticsDnsCacheCommand),
     #[serde(rename = "diagnostics.fakeip_lookup")]
     DiagnosticsFakeipLookup(DiagnosticsFakeipLookupCommand),
+    #[serde(rename = "fakeip.clear")]
+    FakeIpClear(FakeIpClearCommand),
     #[serde(rename = "diagnostics.trace_route")]
     DiagnosticsTraceRoute(DiagnosticsTraceRouteCommand),
     #[serde(rename = "mode.set")]
@@ -51,6 +53,7 @@ impl CommandRequest {
             | Self::DiagnosticsDnsLookup(_)
             | Self::DiagnosticsDnsCache(_)
             | Self::DiagnosticsFakeipLookup(_)
+            | Self::FakeIpClear(_)
             | Self::DiagnosticsTraceRoute(_)
             | Self::ModeSet(_)
             | Self::TunStart(_)
@@ -182,6 +185,19 @@ pub struct DiagnosticsDnsCacheCommand {
 /// `ip` (reverse: fake IP → domain) should be set.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiagnosticsFakeipLookupCommand {
+    #[serde(default)]
+    pub domain: Option<String>,
+    #[serde(default)]
+    pub ip: Option<String>,
+}
+
+/// Clear fake-IP mappings (`fakeip.clear`).
+///
+/// Omit both selectors to clear every mapping. Set exactly one of `domain` or
+/// `ip` to remove one mapping in both directions. Persistent runtime state is
+/// compacted as part of the same operation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FakeIpClearCommand {
     #[serde(default)]
     pub domain: Option<String>,
     #[serde(default)]

--- a/crates/api/src/flow.rs
+++ b/crates/api/src/flow.rs
@@ -132,13 +132,30 @@ pub struct FlowNetworkContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub local_address: Option<TargetAddress>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_address: Option<TargetAddress>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolved_candidates: Vec<TargetAddress>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_interface: Option<FlowNetworkInterface>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub egress: Option<FlowEgressContext>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub route_lookup: Option<FlowRouteLookup>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub socket_binding: Option<FlowSocketBinding>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connect_stage: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FlowEgressContext {
+    pub generation: u64,
+    pub address_family: String,
+    pub tun_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub configured_interface: Option<FlowNetworkInterface>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -19,8 +19,8 @@ pub use command::{
     CommandRequest, CommandResponse, ConfigApplyCommand, ConfigValidateCommand,
     DiagnosticsDnsCacheCommand, DiagnosticsDnsLookupCommand, DiagnosticsFakeipLookupCommand,
     DiagnosticsProbeOutboundCommand, DiagnosticsProbeTargetCommand, DiagnosticsTraceRouteCommand,
-    FlowCloseCommand, ModeSetCommand, PolicyProbeCommand, PolicySelectCommand, TunStartCommand,
-    TunStopCommand,
+    FakeIpClearCommand, FlowCloseCommand, ModeSetCommand, PolicyProbeCommand, PolicySelectCommand,
+    TunStartCommand, TunStopCommand,
 };
 pub use error::{ApiError, ApiErrorCode, ErrorDetail};
 pub use event::{

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -28,9 +28,9 @@ pub use event::{
     PassiveRelayHealthState, PublishResult,
 };
 pub use flow::{
-    AuthInfo, EndpointRef, FlowEventPayload, FlowFailureInfo, FlowNetworkContext,
-    FlowNetworkInterface, FlowOutcome, FlowPath, FlowRecord, FlowRecordTiming, FlowResult,
-    FlowRoute, FlowRouteLookup, FlowSocketBinding, FlowSource, FlowState, FlowTarget,
+    AuthInfo, EndpointRef, FlowEgressContext, FlowEventPayload, FlowFailureInfo,
+    FlowNetworkContext, FlowNetworkInterface, FlowOutcome, FlowPath, FlowRecord, FlowRecordTiming,
+    FlowResult, FlowRoute, FlowRouteLookup, FlowSocketBinding, FlowSource, FlowState, FlowTarget,
     FlowThroughput, FlowTiming, MatchedRuleInfo, Network, PolicyDecision,
     PolicyProbeCompletedPayload, PolicyProbeMember, PolicySelectedPayload, RouteDecision,
     TargetAddress, TrafficStats, WarningPayload,

--- a/crates/api/tests/api_model.rs
+++ b/crates/api/tests/api_model.rs
@@ -3,8 +3,9 @@ use std::collections::BTreeMap;
 use serde_json::json;
 use zero_api::{
     event_type, ApiErrorCode, ApiEvent, AuthContext, AuthInfo, CommandRequest, ConfigApplyCommand,
-    ConfigValidateCommand, EndpointRef, FlowEventPayload, FlowOutcome, FlowTiming, Network,
-    Permission, PolicySelectCommand, RouteDecision, TargetAddress, TrafficStats, EVENT_SCHEMA_ID,
+    ConfigValidateCommand, EndpointRef, FakeIpClearCommand, FlowEventPayload, FlowOutcome,
+    FlowTiming, Network, Permission, PolicySelectCommand, RouteDecision, TargetAddress,
+    TrafficStats, EVENT_SCHEMA_ID,
 };
 
 #[test]
@@ -140,6 +141,16 @@ fn command_request_serializes_with_stable_method_name() {
     assert_eq!(value["method"], "policies.select");
     assert_eq!(value["params"]["policy_tag"], "proxy");
     assert_eq!(value["params"]["target_tag"], "direct");
+}
+
+#[test]
+fn fake_ip_clear_is_an_admin_command_with_optional_selectors() {
+    let command = CommandRequest::FakeIpClear(FakeIpClearCommand::default());
+
+    assert_eq!(command.required_permission(), Permission::Admin);
+    let value = serde_json::to_value(command).expect("serialize fake-IP clear command");
+    assert_eq!(value["method"], "fakeip.clear");
+    assert_eq!(value["params"], json!({ "domain": null, "ip": null }));
 }
 
 #[test]

--- a/crates/api/tests/api_model.rs
+++ b/crates/api/tests/api_model.rs
@@ -59,7 +59,19 @@ fn flow_path_network_context_is_additive_and_optional() {
         "relay_chain": [],
         "network": {
             "local_address": { "host": "192.0.2.10", "port": 49152 },
+            "remote_address": { "host": "198.51.100.8", "port": 443 },
+            "resolved_candidates": [
+                { "host": "198.51.100.8", "port": 443 },
+                { "host": "2001:db8::8", "port": 443 }
+            ],
             "selected_interface": { "name": "Ethernet", "index": 7 },
+            "egress": {
+                "generation": 12,
+                "address_family": "ipv4",
+                "tun_active": true,
+                "configured_interface": { "name": "Ethernet", "index": 7 },
+                "unavailable_reason": "default route reconciliation failed"
+            },
             "route_lookup": {
                 "status": "resolved",
                 "source_address": "10.0.0.2"
@@ -75,7 +87,17 @@ fn flow_path_network_context_is_additive_and_optional() {
     .expect("deserialize enhanced flow path");
     let network = path.network.expect("network context");
     assert_eq!(network.local_address.unwrap().port, 49152);
+    assert_eq!(network.remote_address.unwrap().host, "198.51.100.8");
+    assert_eq!(network.resolved_candidates.len(), 2);
     assert_eq!(network.selected_interface.unwrap().index, 7);
+    let egress = network.egress.unwrap();
+    assert_eq!(egress.generation, 12);
+    assert!(egress.tun_active);
+    assert_eq!(egress.address_family, "ipv4");
+    assert_eq!(
+        egress.unavailable_reason.as_deref(),
+        Some("default route reconciliation failed")
+    );
     assert_eq!(network.route_lookup.unwrap().status, "resolved");
     assert!(network.socket_binding.unwrap().interface_bound);
     assert_eq!(network.connect_stage.as_deref(), Some("connected"));

--- a/crates/dns/src/fake_ip.rs
+++ b/crates/dns/src/fake_ip.rs
@@ -1,6 +1,6 @@
 //! Bounded dual-stack Fake-IP mapping lifecycle for transparent proxying.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,6 +13,7 @@ use zero_traits::IpAddress;
 
 use crate::message::normalize_domain;
 
+mod management;
 mod persistence;
 mod state_path;
 
@@ -20,6 +21,7 @@ use persistence::{
     unix_time_ms, FakeIpPersistence, FakeIpStateLease, PersistedMapping, PersistenceMetadata,
 };
 
+pub use management::{FakeIpClearResult, FakeIpClearTarget};
 pub(crate) use persistence::FakeIpStateLease as StateLease;
 pub use state_path::default_fake_ip_state_path;
 
@@ -620,9 +622,24 @@ fn compact_if_needed(state: &mut AllocatorState) {
     if !should_compact {
         return;
     }
+    let mappings = persisted_mappings(state, None);
+    if let Some(persistence) = state.persistence.as_mut() {
+        if let Err(error) = persistence.compact(&mappings) {
+            tracing::warn!(%error, "failed to compact Fake-IP persistence state");
+        }
+    }
+}
+
+fn persisted_mappings(
+    state: &AllocatorState,
+    excluded_domains: Option<&HashSet<String>>,
+) -> Vec<PersistedMapping> {
     let mut mappings = state
         .forward
         .iter()
+        .filter(|(domain, _)| {
+            excluded_domains.is_none_or(|excluded| !excluded.contains(domain.as_str()))
+        })
         .flat_map(|(domain, mapping)| {
             mapping.addresses().map(|ip| {
                 (
@@ -637,15 +654,10 @@ fn compact_if_needed(state: &mut AllocatorState) {
         })
         .collect::<Vec<_>>();
     mappings.sort_by_key(|(last_used, _)| *last_used);
-    let mappings = mappings
+    mappings
         .into_iter()
         .map(|(_, mapping)| mapping)
-        .collect::<Vec<_>>();
-    if let Some(persistence) = state.persistence.as_mut() {
-        if let Err(error) = persistence.compact(&mappings) {
-            tracing::warn!(%error, "failed to compact Fake-IP persistence state");
-        }
-    }
+        .collect::<Vec<_>>()
 }
 
 fn restore_mappings(

--- a/crates/dns/src/fake_ip/management.rs
+++ b/crates/dns/src/fake_ip/management.rs
@@ -1,0 +1,74 @@
+use std::collections::HashSet;
+use std::io;
+use std::time::Instant;
+
+use zero_traits::IpAddress;
+
+use super::{expire_mappings, persisted_mappings, remove_domain, to_std_address, FakeIpAllocator};
+use crate::message::normalize_domain;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FakeIpClearTarget {
+    All,
+    Domain(String),
+    Address(IpAddress),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FakeIpClearResult {
+    /// Number of domain mappings removed. A dual-stack domain counts once.
+    pub removed_mappings: usize,
+    /// Number of IPv4 and IPv6 reverse-map entries removed.
+    pub removed_addresses: usize,
+    pub live_mappings: usize,
+}
+
+impl FakeIpAllocator {
+    pub(crate) async fn clear(&self, target: FakeIpClearTarget) -> io::Result<FakeIpClearResult> {
+        let clear_all = matches!(&target, FakeIpClearTarget::All);
+        let mut state = self.inner.lock().await;
+        expire_mappings(&mut state, Instant::now(), &self.stats);
+        let domains = match target {
+            FakeIpClearTarget::All => state.forward.keys().cloned().collect::<HashSet<_>>(),
+            FakeIpClearTarget::Domain(domain) => {
+                let domain = normalize_domain(&domain)?;
+                state
+                    .forward
+                    .contains_key(&domain)
+                    .then_some(domain)
+                    .into_iter()
+                    .collect()
+            }
+            FakeIpClearTarget::Address(address) => state
+                .reverse
+                .get(&to_std_address(address))
+                .cloned()
+                .into_iter()
+                .collect(),
+        };
+        let removed_addresses = domains
+            .iter()
+            .filter_map(|domain| state.forward.get(domain))
+            .map(|mapping| mapping.addresses().count())
+            .sum();
+
+        // Rewrite persistence before changing memory so a failed journal
+        // transaction cannot resurrect a mapping that the command reported as
+        // removed. An all-cache clear compacts even an already-empty allocator
+        // to discard historical upserts from the journal.
+        if clear_all || !domains.is_empty() {
+            let mappings = persisted_mappings(&state, Some(&domains));
+            if let Some(persistence) = state.persistence.as_mut() {
+                persistence.compact(&mappings)?;
+            }
+        }
+        for domain in &domains {
+            remove_domain(&mut state, domain);
+        }
+        Ok(FakeIpClearResult {
+            removed_mappings: domains.len(),
+            removed_addresses,
+            live_mappings: state.forward.len(),
+        })
+    }
+}

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -28,7 +28,7 @@ use zero_traits::{DnsResolver, IpAddress};
 use backends::ResolverBackend;
 use cache::{DnsCache, DnsWireCacheValue};
 use fake_ip::FakeIpAllocator;
-pub use fake_ip::{default_fake_ip_state_path, FakeIpStats};
+pub use fake_ip::{default_fake_ip_state_path, FakeIpClearResult, FakeIpClearTarget, FakeIpStats};
 use reverse::RealIpReverseIndex;
 pub use reverse::RealIpReverseLookup;
 use router::DnsDispatcher;
@@ -388,6 +388,18 @@ impl DnsSystem {
 
     pub async fn fake_ip_stats(&self) -> Option<FakeIpStats> {
         Some(self.snapshot_fake_ip()?.stats().await)
+    }
+
+    /// Clear all Fake-IP mappings, or one mapping selected by domain/address.
+    /// The allocator updates its persistent journal before reporting success.
+    pub async fn clear_fake_ip(
+        &self,
+        target: FakeIpClearTarget,
+    ) -> io::Result<Option<FakeIpClearResult>> {
+        let Some(allocator) = self.snapshot_fake_ip() else {
+            return Ok(None);
+        };
+        allocator.clear(target).await.map(Some)
     }
 
     /// Inspect a cached domain (diagnostic). Returns (addresses, seconds to

--- a/crates/dns/tests/fake_ip_persistence.rs
+++ b/crates/dns/tests/fake_ip_persistence.rs
@@ -65,6 +65,57 @@ async fn restores_live_mapping_after_process_rebuild() {
 }
 
 #[tokio::test]
+async fn targeted_and_full_clear_are_persisted_atomically() {
+    let directory = tempfile::tempdir().expect("state directory");
+    let path = directory.path().join("fake-ip.jsonl");
+    let config = config("198.18.0.0/24", 3_600);
+
+    let first = build(&config, &path);
+    zero_traits::DnsResolver::resolve(&first, "remove.example")
+        .await
+        .expect("allocate removed mapping");
+    zero_traits::DnsResolver::resolve(&first, "keep.example")
+        .await
+        .expect("allocate retained mapping");
+    let cleared = first
+        .clear_fake_ip(zero_dns::FakeIpClearTarget::Domain(
+            "REMOVE.EXAMPLE.".to_owned(),
+        ))
+        .await
+        .expect("clear one mapping")
+        .expect("Fake-IP enabled");
+    assert_eq!(cleared.removed_mappings, 1);
+    assert_eq!(cleared.removed_addresses, 1);
+    assert_eq!(cleared.live_mappings, 1);
+    drop(first);
+
+    let restored = build(&config, &path);
+    assert!(restored
+        .lookup_fake_ip_domain("remove.example")
+        .await
+        .is_none());
+    assert_eq!(
+        restored
+            .lookup_fake_ip_domain("keep.example")
+            .await
+            .as_deref(),
+        Some("198.18.0.2")
+    );
+    let cleared = restored
+        .clear_fake_ip(zero_dns::FakeIpClearTarget::All)
+        .await
+        .expect("clear all mappings")
+        .expect("Fake-IP enabled");
+    assert_eq!(cleared.removed_mappings, 1);
+    assert_eq!(cleared.live_mappings, 0);
+    drop(restored);
+
+    let empty = build(&config, &path);
+    assert_eq!(empty.fake_ip_stats().await.unwrap().live_mappings, 0);
+    assert!(empty.lookup_fake_ip_domain("keep.example").await.is_none());
+}
+
+#[tokio::test]
 async fn incompatible_pool_starts_with_an_empty_mapping_set() {
     let directory = tempfile::tempdir().expect("state directory");
     let path = directory.path().join("fake-ip.jsonl");

--- a/crates/engine/src/api/mod.rs
+++ b/crates/engine/src/api/mod.rs
@@ -315,6 +315,10 @@ fn execute_engine_command(
             ApiErrorCode::Internal,
             "fakeip_lookup is handled by the proxy runtime, not the engine",
         )),
+        CommandRequest::FakeIpClear(_) => Err(ApiError::new(
+            ApiErrorCode::Internal,
+            "fakeip.clear is handled by the proxy runtime, not the engine",
+        )),
     }
 }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -31,10 +31,11 @@ pub use principal::{
 pub use runtime::{Engine, EngineRuntimeSnapshot};
 pub use runtime::{RouteDecision, RouteTrace};
 pub use session::{
-    ActiveSession, BlockReason, CompletedSessionRecord, FlowContext, FlowFailureObservation,
-    FlowHook, FlowHookChain, FlowNetworkInterfaceObservation, FlowNetworkObservation,
-    FlowPathObservation, FlowRemoteEndpoint, FlowRouteLookupObservation, FlowRouteObservation,
-    FlowSocketBindingObservation, FlowTraffic, MatchedRouteRule, SessionHandle,
+    ActiveSession, BlockReason, CompletedSessionRecord, FlowContext, FlowEgressObservation,
+    FlowFailureObservation, FlowHook, FlowHookChain, FlowNetworkInterfaceObservation,
+    FlowNetworkObservation, FlowPathObservation, FlowRemoteEndpoint, FlowRouteLookupObservation,
+    FlowRouteObservation, FlowSocketBindingObservation, FlowTraffic, MatchedRouteRule,
+    SessionHandle,
 };
 pub use zero_api::{
     AddressSnapshot, AuthSnapshot, CompletedFlowSnapshot, ConfigSnapshot, FlowSnapshot,

--- a/crates/engine/src/observability/event_log.rs
+++ b/crates/engine/src/observability/event_log.rs
@@ -7,13 +7,13 @@ use std::sync::{mpsc::SyncSender, mpsc::TrySendError, Arc, Mutex};
 use serde_json::{json, Value};
 use std::time::{SystemTime, UNIX_EPOCH};
 use zero_api::{
-    event_type, ApiEvent, AuthInfo, EndpointRef, EventFilter, EventReplay, FlowEventPayload,
-    FlowFailureInfo, FlowNetworkContext, FlowNetworkInterface, FlowOutcome, FlowPath, FlowRecord,
-    FlowRecordTiming, FlowResult, FlowRoute, FlowRouteLookup, FlowSocketBinding, FlowSource,
-    FlowState, FlowTarget, FlowThroughput, FlowTiming, MatchedRuleInfo, Network as ApiNetwork,
-    PassiveRelayHealthChangedPayload, PassiveRelayHealthState, PolicyDecision,
-    PolicyProbeCompletedPayload, PolicySelectedPayload, RawApiEvent, RouteDecision, TargetAddress,
-    TrafficStats,
+    event_type, ApiEvent, AuthInfo, EndpointRef, EventFilter, EventReplay, FlowEgressContext,
+    FlowEventPayload, FlowFailureInfo, FlowNetworkContext, FlowNetworkInterface, FlowOutcome,
+    FlowPath, FlowRecord, FlowRecordTiming, FlowResult, FlowRoute, FlowRouteLookup,
+    FlowSocketBinding, FlowSource, FlowState, FlowTarget, FlowThroughput, FlowTiming,
+    MatchedRuleInfo, Network as ApiNetwork, PassiveRelayHealthChangedPayload,
+    PassiveRelayHealthState, PolicyDecision, PolicyProbeCompletedPayload, PolicySelectedPayload,
+    RawApiEvent, RouteDecision, TargetAddress, TrafficStats,
 };
 use zero_core::{Address, Network, ProtocolType, SessionAuth};
 
@@ -837,11 +837,35 @@ fn flow_path(outbound_tag: Option<&String>, path: &crate::FlowPathObservation) -
                 host: local.host.clone(),
                 port: local.port,
             }),
+            remote_address: network.remote_address.as_ref().map(|remote| TargetAddress {
+                host: remote.host.clone(),
+                port: remote.port,
+            }),
+            resolved_candidates: network
+                .resolved_candidates
+                .iter()
+                .map(|candidate| TargetAddress {
+                    host: candidate.host.clone(),
+                    port: candidate.port,
+                })
+                .collect(),
             selected_interface: network.selected_interface.as_ref().map(|interface| {
                 FlowNetworkInterface {
                     name: interface.name.clone(),
                     index: interface.index,
                 }
+            }),
+            egress: network.egress.as_ref().map(|egress| FlowEgressContext {
+                generation: egress.generation,
+                address_family: egress.address_family.clone(),
+                tun_active: egress.tun_active,
+                configured_interface: egress.configured_interface.as_ref().map(|interface| {
+                    FlowNetworkInterface {
+                        name: interface.name.clone(),
+                        index: interface.index,
+                    }
+                }),
+                unavailable_reason: egress.unavailable_reason.clone(),
             }),
             route_lookup: network.route_lookup.as_ref().map(|route| FlowRouteLookup {
                 status: route.status.clone(),

--- a/crates/engine/src/session/mod.rs
+++ b/crates/engine/src/session/mod.rs
@@ -11,9 +11,9 @@ pub use completed::CompletedSessionRecord;
 pub use hook::{BlockReason, FlowContext, FlowHook, FlowHookChain, FlowTraffic};
 pub use lifecycle::SessionHandle;
 pub use observation::{
-    FlowFailureObservation, FlowNetworkInterfaceObservation, FlowNetworkObservation,
-    FlowPathObservation, FlowRemoteEndpoint, FlowRouteLookupObservation, FlowRouteObservation,
-    FlowSocketBindingObservation, MatchedRouteRule,
+    FlowEgressObservation, FlowFailureObservation, FlowNetworkInterfaceObservation,
+    FlowNetworkObservation, FlowPathObservation, FlowRemoteEndpoint, FlowRouteLookupObservation,
+    FlowRouteObservation, FlowSocketBindingObservation, MatchedRouteRule,
 };
 pub use registry::ActiveSession;
 

--- a/crates/engine/src/session/observation.rs
+++ b/crates/engine/src/session/observation.rs
@@ -32,10 +32,22 @@ pub struct FlowPathObservation {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FlowNetworkObservation {
     pub local_address: Option<FlowRemoteEndpoint>,
+    pub remote_address: Option<FlowRemoteEndpoint>,
+    pub resolved_candidates: Vec<FlowRemoteEndpoint>,
     pub selected_interface: Option<FlowNetworkInterfaceObservation>,
+    pub egress: Option<FlowEgressObservation>,
     pub route_lookup: Option<FlowRouteLookupObservation>,
     pub socket_binding: Option<FlowSocketBindingObservation>,
     pub connect_stage: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FlowEgressObservation {
+    pub generation: u64,
+    pub address_family: String,
+    pub tun_active: bool,
+    pub configured_interface: Option<FlowNetworkInterfaceObservation>,
+    pub unavailable_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/platform/tokio/src/egress.rs
+++ b/crates/platform/tokio/src/egress.rs
@@ -322,18 +322,18 @@ impl EgressInterfaceControl {
                         Some(error.to_string()),
                     ),
                 };
-            let captured = route_source.is_some_and(|source| source.is_loopback());
             return EgressSelection::from_snapshot(
                 &snapshot,
                 None,
                 route_source,
                 route_lookup_status,
                 route_lookup_error,
-                if captured {
-                    EgressBindingReason::TunEgressUnavailable
-                } else {
-                    EgressBindingReason::NoConfiguredInterface
-                },
+                // A loopback source is not authoritative evidence that a TUN
+                // capture route is active. Local filters and stale host routes
+                // can produce the same source selection after TUN state has
+                // already been withdrawn. Only explicit published TUN state
+                // may require a physical egress.
+                EgressBindingReason::NoConfiguredInterface,
             );
         }
         if tunnel_addresses.is_empty() {

--- a/crates/platform/tokio/src/egress.rs
+++ b/crates/platform/tokio/src/egress.rs
@@ -62,6 +62,10 @@ impl EgressBindingReason {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EgressSelection {
     interface: Option<EgressInterface>,
+    configured_interface: Option<EgressInterface>,
+    generation: u64,
+    tun_active: bool,
+    unavailable_reason: Option<String>,
     route_source: Option<IpAddr>,
     route_lookup_status: EgressRouteLookupStatus,
     route_lookup_error: Option<String>,
@@ -71,6 +75,22 @@ pub struct EgressSelection {
 impl EgressSelection {
     pub fn interface(&self) -> Option<&EgressInterface> {
         self.interface.as_ref()
+    }
+
+    pub fn configured_interface(&self) -> Option<&EgressInterface> {
+        self.configured_interface.as_ref()
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn tun_active(&self) -> bool {
+        self.tun_active
+    }
+
+    pub fn unavailable_reason(&self) -> Option<&str> {
+        self.unavailable_reason.as_deref()
     }
 
     pub fn route_source(&self) -> Option<IpAddr> {
@@ -154,8 +174,41 @@ pub struct EgressInterfaceControl(Arc<RwLock<EgressInterfaces>>);
 struct EgressInterfaces {
     ipv4: Option<EgressInterface>,
     ipv6: Option<EgressInterface>,
+    ipv4_unavailable_reason: Option<String>,
+    ipv6_unavailable_reason: Option<String>,
     tunnel_addresses: Vec<IpAddr>,
     generation: u64,
+}
+
+#[derive(Debug, Clone)]
+struct EgressSelectionSnapshot {
+    configured_interface: Option<EgressInterface>,
+    generation: u64,
+    tun_active: bool,
+    unavailable_reason: Option<String>,
+}
+
+impl EgressSelection {
+    fn from_snapshot(
+        snapshot: &EgressSelectionSnapshot,
+        interface: Option<EgressInterface>,
+        route_source: Option<IpAddr>,
+        route_lookup_status: EgressRouteLookupStatus,
+        route_lookup_error: Option<String>,
+        binding_reason: EgressBindingReason,
+    ) -> Self {
+        Self {
+            interface,
+            configured_interface: snapshot.configured_interface.clone(),
+            generation: snapshot.generation,
+            tun_active: snapshot.tun_active,
+            unavailable_reason: snapshot.unavailable_reason.clone(),
+            route_source,
+            route_lookup_status,
+            route_lookup_error,
+            binding_reason,
+        }
+    }
 }
 
 impl EgressInterfaceControl {
@@ -200,24 +253,40 @@ impl EgressInterfaceControl {
     }
 
     pub fn select_for_peer(&self, peer: SocketAddr) -> EgressSelection {
-        if peer.ip().is_loopback() {
-            return EgressSelection {
-                interface: None,
-                route_source: None,
-                route_lookup_status: EgressRouteLookupStatus::Skipped,
-                route_lookup_error: None,
-                binding_reason: EgressBindingReason::Loopback,
-            };
-        }
-        let (physical, tunnel_addresses) = {
+        let (snapshot, tunnel_addresses) = {
             let interfaces = self.0.read().expect("egress interface lock poisoned");
-            let physical = if peer.is_ipv6() {
-                interfaces.ipv6.clone()
+            let (configured_interface, unavailable_reason) = if peer.is_ipv6() {
+                (
+                    interfaces.ipv6.clone(),
+                    interfaces.ipv6_unavailable_reason.clone(),
+                )
             } else {
-                interfaces.ipv4.clone()
+                (
+                    interfaces.ipv4.clone(),
+                    interfaces.ipv4_unavailable_reason.clone(),
+                )
             };
-            (physical, interfaces.tunnel_addresses.clone())
+            (
+                EgressSelectionSnapshot {
+                    configured_interface,
+                    generation: interfaces.generation,
+                    tun_active: !interfaces.tunnel_addresses.is_empty(),
+                    unavailable_reason,
+                },
+                interfaces.tunnel_addresses.clone(),
+            )
         };
+        if peer.ip().is_loopback() {
+            return EgressSelection::from_snapshot(
+                &snapshot,
+                None,
+                None,
+                EgressRouteLookupStatus::Skipped,
+                None,
+                EgressBindingReason::Loopback,
+            );
+        }
+        let physical = snapshot.configured_interface.clone();
         // A wildcard address is used as a family marker when creating a
         // reusable UDP socket; it is not a routable peer. Probing it makes
         // Windows and Linux report loopback as the route source, which can be
@@ -233,13 +302,14 @@ impl EgressInterfaceControl {
                 }
                 (Some(physical), false) => (Some(physical), EgressBindingReason::TunRoute),
             };
-            return EgressSelection {
+            return EgressSelection::from_snapshot(
+                &snapshot,
                 interface,
-                route_source: None,
-                route_lookup_status: EgressRouteLookupStatus::Skipped,
-                route_lookup_error: None,
+                None,
+                EgressRouteLookupStatus::Skipped,
+                None,
                 binding_reason,
-            };
+            );
         }
         let no_physical_interface = physical.is_none();
         if no_physical_interface && tunnel_addresses.is_empty() {
@@ -253,26 +323,28 @@ impl EgressInterfaceControl {
                     ),
                 };
             let captured = route_source.is_some_and(|source| source.is_loopback());
-            return EgressSelection {
-                interface: None,
+            return EgressSelection::from_snapshot(
+                &snapshot,
+                None,
                 route_source,
                 route_lookup_status,
                 route_lookup_error,
-                binding_reason: if captured {
+                if captured {
                     EgressBindingReason::TunEgressUnavailable
                 } else {
                     EgressBindingReason::NoConfiguredInterface
                 },
-            };
+            );
         }
         if tunnel_addresses.is_empty() {
-            return EgressSelection {
-                interface: Some(physical.expect("physical egress checked above")),
-                route_source: None,
-                route_lookup_status: EgressRouteLookupStatus::Skipped,
-                route_lookup_error: None,
-                binding_reason: EgressBindingReason::TunAddressesUnavailable,
-            };
+            return EgressSelection::from_snapshot(
+                &snapshot,
+                Some(physical.expect("physical egress checked above")),
+                None,
+                EgressRouteLookupStatus::Skipped,
+                None,
+                EgressBindingReason::TunAddressesUnavailable,
+            );
         }
         let (route_source, route_lookup_status, route_lookup_error) = match route_source_for(peer) {
             Ok(source) => (Some(source), EgressRouteLookupStatus::Resolved, None),
@@ -292,13 +364,14 @@ impl EgressInterfaceControl {
             }
             (None, _, _) => (None, EgressBindingReason::TunEgressUnavailable),
         };
-        EgressSelection {
+        EgressSelection::from_snapshot(
+            &snapshot,
             interface,
             route_source,
             route_lookup_status,
             route_lookup_error,
             binding_reason,
-        }
+        )
     }
 
     pub fn replace_tunnel_addresses(&self, addresses: impl IntoIterator<Item = IpAddr>) {
@@ -315,9 +388,12 @@ impl EgressInterfaceControl {
     pub fn replace(&self, interface: Option<EgressInterface>) -> Option<EgressInterface> {
         let mut interfaces = self.0.write().expect("egress interface lock poisoned");
         let previous = interfaces.ipv4.clone().or_else(|| interfaces.ipv6.clone());
-        if interfaces.ipv4 != interface || interfaces.ipv6 != interface {
-            interfaces.ipv4 = interface.clone();
-            interfaces.ipv6 = interface;
+        let topology_changed = interfaces.ipv4 != interface || interfaces.ipv6 != interface;
+        interfaces.ipv4 = interface.clone();
+        interfaces.ipv6 = interface;
+        interfaces.ipv4_unavailable_reason = None;
+        interfaces.ipv6_unavailable_reason = None;
+        if topology_changed {
             bump_generation(&mut interfaces);
         }
         previous
@@ -325,26 +401,52 @@ impl EgressInterfaceControl {
 
     pub fn replace_for(&self, ipv6: bool, interface: Option<EgressInterface>) {
         let mut interfaces = self.0.write().expect("egress interface lock poisoned");
-        let current = if ipv6 {
-            &mut interfaces.ipv6
+        let topology_changed = if ipv6 {
+            let changed = interfaces.ipv6 != interface;
+            interfaces.ipv6 = interface;
+            interfaces.ipv6_unavailable_reason = None;
+            changed
         } else {
-            &mut interfaces.ipv4
+            let changed = interfaces.ipv4 != interface;
+            interfaces.ipv4 = interface;
+            interfaces.ipv4_unavailable_reason = None;
+            changed
         };
-        if *current != interface {
-            *current = interface;
+        if topology_changed {
+            bump_generation(&mut interfaces);
+        }
+    }
+
+    pub fn mark_unavailable_for(&self, ipv6: bool, reason: impl Into<String>) {
+        let reason = reason.into();
+        let mut interfaces = self.0.write().expect("egress interface lock poisoned");
+        let topology_changed = if ipv6 {
+            let changed = interfaces.ipv6.is_some();
+            interfaces.ipv6 = None;
+            interfaces.ipv6_unavailable_reason = Some(reason);
+            changed
+        } else {
+            let changed = interfaces.ipv4.is_some();
+            interfaces.ipv4 = None;
+            interfaces.ipv4_unavailable_reason = Some(reason);
+            changed
+        };
+        if topology_changed {
             bump_generation(&mut interfaces);
         }
     }
 
     pub fn clear(&self) {
         let mut interfaces = self.0.write().expect("egress interface lock poisoned");
-        if interfaces.ipv4.is_some()
+        let topology_changed = interfaces.ipv4.is_some()
             || interfaces.ipv6.is_some()
-            || !interfaces.tunnel_addresses.is_empty()
-        {
-            interfaces.ipv4 = None;
-            interfaces.ipv6 = None;
-            interfaces.tunnel_addresses.clear();
+            || !interfaces.tunnel_addresses.is_empty();
+        interfaces.ipv4 = None;
+        interfaces.ipv6 = None;
+        interfaces.ipv4_unavailable_reason = None;
+        interfaces.ipv6_unavailable_reason = None;
+        interfaces.tunnel_addresses.clear();
+        if topology_changed {
             bump_generation(&mut interfaces);
         }
     }

--- a/crates/platform/tokio/tests/egress_interface.rs
+++ b/crates/platform/tokio/tests/egress_interface.rs
@@ -143,6 +143,25 @@ fn peer_selection_rejects_active_tun_without_a_physical_egress() {
 }
 
 #[test]
+fn peer_selection_exposes_the_authoritative_egress_snapshot() {
+    let controller = EgressInterfaceControl::default();
+    let peer = "192.0.2.1:443".parse().unwrap();
+    controller.replace_tunnel_addresses(["10.66.0.1".parse().unwrap()]);
+    let topology_generation = controller.generation();
+    controller.mark_unavailable_for(false, "route reconciliation failed");
+
+    let selection = controller.select_for_peer(peer);
+    assert_eq!(controller.generation(), topology_generation);
+    assert_eq!(selection.generation(), controller.generation());
+    assert!(selection.tun_active());
+    assert!(selection.configured_interface().is_none());
+    assert_eq!(
+        selection.unavailable_reason(),
+        Some("route reconciliation failed")
+    );
+}
+
+#[test]
 fn wildcard_peer_is_not_mistaken_for_a_tun_route_probe() {
     let controller = EgressInterfaceControl::default();
     let wildcard = "0.0.0.0:0".parse().unwrap();

--- a/crates/platform/tokio/tests/egress_interface.rs
+++ b/crates/platform/tokio/tests/egress_interface.rs
@@ -143,6 +143,21 @@ fn peer_selection_rejects_active_tun_without_a_physical_egress() {
 }
 
 #[test]
+fn peer_selection_without_published_tun_state_uses_the_system_route() {
+    let controller = EgressInterfaceControl::default();
+    let peer = "192.0.2.1:443".parse().unwrap();
+
+    let selection = controller.select_for_peer(peer);
+    assert!(!selection.tun_active());
+    assert!(selection.configured_interface().is_none());
+    assert_eq!(
+        selection.binding_reason(),
+        EgressBindingReason::NoConfiguredInterface
+    );
+    assert!(selection.ensure_connectable().is_ok());
+}
+
+#[test]
 fn peer_selection_exposes_the_authoritative_egress_snapshot() {
     let controller = EgressInterfaceControl::default();
     let peer = "192.0.2.1:443".parse().unwrap();

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -442,7 +442,7 @@ impl Proxy {
                     let _ = proxy.configured_tun_failures.send(error.to_string());
                 }
             }
-            clear_matching_tun_state(&proxy, id);
+            finalize_tun_runtime_exit(&proxy, id).await;
             let _ = done_tx.send(());
         });
 
@@ -621,7 +621,10 @@ impl Proxy {
             },
             None => Ok(()),
         };
-        self.egress_interface.clear();
+        // Keep the last known physical egress while automatic route cleanup
+        // is incomplete. Clearing it first leaves direct sockets unable to
+        // bypass a stale capture route after a partial shutdown failure.
+        clear_egress_after_route_cleanup(&self.egress_interface, route_cleanup.is_ok());
         clear_matching_tun_info(self, id);
         let result = match stopped {
             Ok(Ok(())) => route_cleanup,
@@ -661,7 +664,16 @@ fn next_ip(address: IpAddr) -> Option<IpAddr> {
     }
 }
 
-fn clear_matching_tun_state(proxy: &Proxy, id: u64) {
+fn clear_egress_after_route_cleanup(
+    control: &zero_platform_tokio::EgressInterfaceControl,
+    cleanup_complete: bool,
+) {
+    if cleanup_complete {
+        control.clear();
+    }
+}
+
+async fn finalize_tun_runtime_exit(proxy: &Proxy, id: u64) {
     clear_matching_tun_info(proxy, id);
     let removed = {
         let mut control = proxy.tun_control.lock().unwrap();
@@ -671,9 +683,39 @@ fn clear_matching_tun_state(proxy: &Proxy, id: u64) {
             None
         }
     };
-    if removed.is_some() {
-        drop(removed);
-        proxy.egress_interface.clear();
+    let Some(TunControl {
+        shutdown,
+        done,
+        route_done,
+        ..
+    }) = removed
+    else {
+        // An explicit stop owns the route cleanup and final egress update.
+        return;
+    };
+    // This receiver belongs to the task that is currently finalizing. Drop it
+    // instead of waiting on our own completion acknowledgement.
+    drop(done);
+    let _ = shutdown.send(true);
+    let route_cleanup = match route_done {
+        Some(done) => match done.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => Err(error),
+            Err(_) => Err("TUN route runtime exited without cleanup acknowledgement".to_owned()),
+        },
+        None => Ok(()),
+    };
+    match route_cleanup {
+        Ok(()) => proxy.egress_interface.clear(),
+        Err(error) => {
+            warn!(%error, "retaining TUN physical egress after route cleanup failure");
+            let mut last_error = proxy.tun_last_error.lock().unwrap();
+            let error = format!("TUN route cleanup failed after runtime exit: {error}");
+            *last_error = Some(match last_error.take() {
+                Some(runtime_error) => format!("{runtime_error}; {error}"),
+                None => error,
+            });
+        }
     }
 }
 

--- a/crates/proxy/src/inbound/tun/routes/state.rs
+++ b/crates/proxy/src/inbound/tun/routes/state.rs
@@ -67,7 +67,7 @@ pub(super) fn publish_unavailable(proxy: &Proxy, spec: &RouteRuntimeSpec, error:
         return;
     };
     let (managed_v4, managed_v6) = spec.managed_families();
-    withdraw_managed_egress(&proxy.egress_interface, managed_v4, managed_v6);
+    withdraw_managed_egress(&proxy.egress_interface, managed_v4, managed_v6, &error);
 
     if managed_v4 {
         info.egress_interface_v4 = None;
@@ -92,12 +92,13 @@ fn withdraw_managed_egress(
     control: &zero_platform_tokio::EgressInterfaceControl,
     managed_v4: bool,
     managed_v6: bool,
+    error: &str,
 ) {
     if managed_v4 {
-        control.replace_for(false, None);
+        control.mark_unavailable_for(false, error);
     }
     if managed_v6 {
-        control.replace_for(true, None);
+        control.mark_unavailable_for(true, error);
     }
 }
 

--- a/crates/proxy/src/inbound/tun/routes/state/tests.rs
+++ b/crates/proxy/src/inbound/tun/routes/state/tests.rs
@@ -12,7 +12,7 @@ fn strict_failure_withdraws_only_the_managed_family() {
     control.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
     let generation = control.generation();
 
-    withdraw_managed_egress(&control, true, false);
+    withdraw_managed_egress(&control, true, false, "default route lookup failed");
 
     assert!(control.current_for(false).is_none());
     assert_eq!(control.current_for(true), Some(ipv6));
@@ -21,4 +21,10 @@ fn strict_failure_withdraws_only_the_managed_family() {
         .select_for_peer("0.0.0.0:0".parse().unwrap())
         .ensure_connectable()
         .is_err());
+    assert_eq!(
+        control
+            .select_for_peer("0.0.0.0:0".parse().unwrap())
+            .unavailable_reason(),
+        Some("default route lookup failed")
+    );
 }

--- a/crates/proxy/src/inbound/tun/tests.rs
+++ b/crates/proxy/src/inbound/tun/tests.rs
@@ -6,6 +6,118 @@ use super::config::{
 };
 use super::{configured_tun_is_current, tun_route_exclusion_required, PreparedTunNetwork, TunInfo};
 
+#[test]
+fn route_cleanup_failure_retains_the_last_physical_egress() {
+    let control = zero_platform_tokio::EgressInterfaceControl::default();
+    let physical = zero_platform_tokio::EgressInterface::new("ethernet", 9).unwrap();
+    control.replace_for(false, Some(physical.clone()));
+    control.replace_tunnel_addresses(["10.66.0.1".parse().unwrap()]);
+
+    super::clear_egress_after_route_cleanup(&control, false);
+
+    assert_eq!(control.current_for(false), Some(physical));
+    assert!(control
+        .select_for_peer("192.0.2.1:443".parse().unwrap())
+        .tun_active());
+}
+
+#[test]
+fn completed_route_cleanup_clears_tun_egress_state() {
+    let control = zero_platform_tokio::EgressInterfaceControl::default();
+    control.replace_for(
+        false,
+        Some(zero_platform_tokio::EgressInterface::new("ethernet", 9).unwrap()),
+    );
+    control.replace_tunnel_addresses(["10.66.0.1".parse().unwrap()]);
+
+    super::clear_egress_after_route_cleanup(&control, true);
+
+    assert!(control.current().is_none());
+    assert!(!control
+        .select_for_peer("192.0.2.1:443".parse().unwrap())
+        .tun_active());
+}
+
+#[tokio::test]
+async fn unexpected_runtime_exit_waits_for_route_cleanup_before_clearing_egress() {
+    let config =
+        zero_config::RuntimeConfig::parse(r#"{"route":{"rules":[],"final":{"type":"direct"}}}"#)
+            .unwrap();
+    let proxy = crate::Proxy::new(config).unwrap();
+    proxy.egress_interface.replace_for(
+        false,
+        Some(zero_platform_tokio::EgressInterface::new("ethernet", 9).unwrap()),
+    );
+    proxy
+        .egress_interface
+        .replace_tunnel_addresses(["10.66.0.1".parse().unwrap()]);
+    let (shutdown, mut shutdown_rx) = tokio::sync::watch::channel(false);
+    let (_done_tx, done) = tokio::sync::oneshot::channel();
+    let (route_done_tx, route_done) = tokio::sync::oneshot::channel();
+    *proxy.tun_control.lock().unwrap() = Some(crate::runtime::TunControl {
+        id: 41,
+        shutdown,
+        done,
+        route_done: Some(route_done),
+    });
+
+    let finalize = super::finalize_tun_runtime_exit(&proxy, 41);
+    let acknowledge = async move {
+        shutdown_rx.changed().await.unwrap();
+        assert!(*shutdown_rx.borrow());
+        route_done_tx.send(Ok(())).unwrap();
+    };
+    tokio::join!(finalize, acknowledge);
+
+    assert!(proxy.egress_interface.current().is_none());
+    assert!(!proxy
+        .egress_interface
+        .select_for_peer("192.0.2.1:443".parse().unwrap())
+        .tun_active());
+}
+
+#[tokio::test]
+async fn unexpected_runtime_cleanup_failure_retains_egress_and_error() {
+    let config =
+        zero_config::RuntimeConfig::parse(r#"{"route":{"rules":[],"final":{"type":"direct"}}}"#)
+            .unwrap();
+    let proxy = crate::Proxy::new(config).unwrap();
+    let physical = zero_platform_tokio::EgressInterface::new("ethernet", 9).unwrap();
+    proxy
+        .egress_interface
+        .replace_for(false, Some(physical.clone()));
+    proxy
+        .egress_interface
+        .replace_tunnel_addresses(["10.66.0.1".parse().unwrap()]);
+    let (shutdown, mut shutdown_rx) = tokio::sync::watch::channel(false);
+    let (_done_tx, done) = tokio::sync::oneshot::channel();
+    let (route_done_tx, route_done) = tokio::sync::oneshot::channel();
+    *proxy.tun_control.lock().unwrap() = Some(crate::runtime::TunControl {
+        id: 42,
+        shutdown,
+        done,
+        route_done: Some(route_done),
+    });
+
+    let finalize = super::finalize_tun_runtime_exit(&proxy, 42);
+    let reject_cleanup = async move {
+        shutdown_rx.changed().await.unwrap();
+        route_done_tx
+            .send(Err("remove stale capture route".to_owned()))
+            .unwrap();
+    };
+    tokio::join!(finalize, reject_cleanup);
+
+    assert_eq!(proxy.egress_interface.current_for(false), Some(physical));
+    assert!(proxy
+        .tun_last_error
+        .lock()
+        .unwrap()
+        .as_deref()
+        .unwrap()
+        .contains("remove stale capture route"));
+}
+
 #[cfg(all(feature = "udp-runtime", feature = "dns"))]
 #[tokio::test]
 async fn command_tun_start_rejects_fake_ip_pool_collision_before_device_creation() {

--- a/crates/proxy/src/runtime/handle/command.rs
+++ b/crates/proxy/src/runtime/handle/command.rs
@@ -1,5 +1,6 @@
 mod diagnostics;
 mod dispatch;
+mod fake_ip;
 mod runtime;
 mod tun;
 

--- a/crates/proxy/src/runtime/handle/command/dispatch.rs
+++ b/crates/proxy/src/runtime/handle/command/dispatch.rs
@@ -4,6 +4,7 @@ use super::diagnostics::{
     execute_diagnostics_fakeip_lookup, execute_diagnostics_probe_outbound,
     execute_diagnostics_probe_target, execute_diagnostics_trace_route,
 };
+use super::fake_ip::execute_fake_ip_clear;
 use super::tun::{execute_tun_start, execute_tun_stop};
 
 impl zero_api::CommandService for ProxyHandle {
@@ -34,6 +35,7 @@ impl zero_api::CommandService for ProxyHandle {
             zero_api::CommandRequest::DiagnosticsFakeipLookup(cmd) => {
                 execute_diagnostics_fakeip_lookup(self, cmd)
             }
+            zero_api::CommandRequest::FakeIpClear(cmd) => execute_fake_ip_clear(self, cmd),
             zero_api::CommandRequest::DiagnosticsTraceRoute(cmd) => {
                 execute_diagnostics_trace_route(self, cmd)
             }

--- a/crates/proxy/src/runtime/handle/command/fake_ip.rs
+++ b/crates/proxy/src/runtime/handle/command/fake_ip.rs
@@ -1,0 +1,78 @@
+use zero_dns::FakeIpClearTarget;
+
+use super::super::util::parse_ip_address;
+use super::super::ProxyHandle;
+use super::runtime::with_current_runtime;
+
+pub(super) fn execute_fake_ip_clear(
+    handle: &ProxyHandle,
+    cmd: &zero_api::FakeIpClearCommand,
+) -> zero_api::ApiResult<zero_api::CommandResponse> {
+    let domain = cmd.domain.clone();
+    let ip = cmd.ip.clone();
+    let (target, scope) = match (domain.as_ref(), ip.as_ref()) {
+        (None, None) => (FakeIpClearTarget::All, "all"),
+        (Some(domain), None) => (FakeIpClearTarget::Domain(domain.clone()), "domain"),
+        (None, Some(ip)) => {
+            let address = parse_ip_address(ip).ok_or_else(|| {
+                zero_api::ApiError::new(
+                    zero_api::ApiErrorCode::InvalidArgument,
+                    format!("invalid ip `{ip}`"),
+                )
+            })?;
+            (FakeIpClearTarget::Address(address), "ip")
+        }
+        (Some(_), Some(_)) => {
+            return Err(zero_api::ApiError::new(
+                zero_api::ApiErrorCode::InvalidArgument,
+                "fakeip.clear accepts at most one of `domain` or `ip`",
+            ));
+        }
+    };
+    let proxy = handle.proxy.clone();
+
+    with_current_runtime(
+        "no tokio runtime available for fakeip.clear command",
+        |rt| {
+            rt.block_on(async move {
+                let enabled = proxy.resolver.fake_ip_enabled();
+                let cleared = proxy
+                    .resolver
+                    .clear_fake_ip(target)
+                    .await
+                    .map_err(|error| {
+                        let code = if error.kind() == std::io::ErrorKind::InvalidInput {
+                            zero_api::ApiErrorCode::InvalidArgument
+                        } else {
+                            zero_api::ApiErrorCode::Internal
+                        };
+                        zero_api::ApiError::new(code, error.to_string())
+                    })?
+                    .unwrap_or_default();
+                tracing::info!(
+                    scope,
+                    domain = domain.as_deref(),
+                    ip = ip.as_deref(),
+                    removed_mappings = cleared.removed_mappings,
+                    removed_addresses = cleared.removed_addresses,
+                    live_mappings = cleared.live_mappings,
+                    "cleared Fake-IP mappings"
+                );
+                Ok(zero_api::CommandResponse {
+                    accepted: true,
+                    result: Some(serde_json::json!({
+                        "core_instance_id": proxy.engine().core_instance_id(),
+                        "config_revision": proxy.engine().config_revision(),
+                        "enabled": enabled,
+                        "scope": scope,
+                        "domain": domain,
+                        "ip": ip,
+                        "removed_mappings": cleared.removed_mappings,
+                        "removed_addresses": cleared.removed_addresses,
+                        "live_mappings": cleared.live_mappings,
+                    })),
+                })
+            })
+        },
+    )
+}

--- a/crates/proxy/src/runtime/handle/command/tests.rs
+++ b/crates/proxy/src/runtime/handle/command/tests.rs
@@ -1,7 +1,14 @@
 use std::io;
 
-use zero_api::ApiErrorCode;
+use zero_api::{ApiErrorCode, CommandRequest, CommandService, FakeIpClearCommand};
+use zero_config::RuntimeConfig;
 use zero_engine::EngineError;
+use zero_engine::EngineHandle;
+use zero_traits::DnsResolver;
+
+use crate::runtime::Proxy;
+
+use super::super::ProxyHandle;
 
 use super::tun::{map_tun_start_error, TUN_PRIVILEGE_MESSAGE};
 
@@ -26,4 +33,76 @@ fn tun_start_keeps_unclassified_runtime_failures_internal() {
 
     assert_eq!(error.code, ApiErrorCode::Internal);
     assert_eq!(error.message, "device failed");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fake_ip_clear_command_supports_address_and_all_scopes() {
+    let config = RuntimeConfig::parse(
+        r#"{
+            "runtime": {
+                "dns": {
+                    "servers": { "system": { "type": "system" } },
+                    "default_server": "system",
+                    "answer": {
+                        "type": "fake_ip",
+                        "cidr": "198.18.0.0/24",
+                        "ttl_seconds": 60,
+                        "max_entries": 16
+                    }
+                }
+            },
+            "route": { "rules": [], "final": { "type": "direct" } }
+        }"#,
+    )
+    .expect("parse Fake-IP config");
+    let proxy = Proxy::new(config).expect("build proxy");
+    let resolver = proxy.resolver.clone();
+    DnsResolver::resolve(resolver.as_ref(), "first.example")
+        .await
+        .expect("allocate first mapping");
+    DnsResolver::resolve(resolver.as_ref(), "second.example")
+        .await
+        .expect("allocate second mapping");
+    let handle = ProxyHandle::new(EngineHandle::new(proxy.engine().clone()), proxy);
+
+    let response = tokio::task::block_in_place(|| {
+        handle.execute(CommandRequest::FakeIpClear(FakeIpClearCommand {
+            domain: None,
+            ip: Some("198.18.0.1".to_owned()),
+        }))
+    })
+    .expect("clear mapping by address");
+    let result = response.result.expect("clear result");
+    assert_eq!(result["scope"], "ip");
+    assert_eq!(result["removed_mappings"], 1);
+    assert_eq!(result["live_mappings"], 1);
+    assert!(resolver
+        .lookup_fake_ip_domain("first.example")
+        .await
+        .is_none());
+
+    let response = tokio::task::block_in_place(|| {
+        handle.execute(CommandRequest::FakeIpClear(FakeIpClearCommand::default()))
+    })
+    .expect("clear all mappings");
+    let result = response.result.expect("clear-all result");
+    assert_eq!(result["scope"], "all");
+    assert_eq!(result["removed_mappings"], 1);
+    assert_eq!(result["live_mappings"], 0);
+}
+
+#[test]
+fn fake_ip_clear_rejects_multiple_selectors_before_execution() {
+    let config = RuntimeConfig::parse(r#"{"route":{"rules":[],"final":{"type":"direct"}}}"#)
+        .expect("parse minimal config");
+    let proxy = Proxy::new(config).expect("build proxy");
+    let handle = ProxyHandle::new(EngineHandle::new(proxy.engine().clone()), proxy);
+
+    let error = handle
+        .execute(CommandRequest::FakeIpClear(FakeIpClearCommand {
+            domain: Some("example.com".to_owned()),
+            ip: Some("198.18.0.1".to_owned()),
+        }))
+        .expect_err("multiple selectors must fail");
+    assert_eq!(error.code, ApiErrorCode::InvalidArgument);
 }

--- a/crates/proxy/src/transport/direct.rs
+++ b/crates/proxy/src/transport/direct.rs
@@ -3,8 +3,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use zero_core::{Address, Error, Session};
 use zero_dns::DnsSystem;
 use zero_engine::{
-    FlowNetworkInterfaceObservation, FlowNetworkObservation, FlowRemoteEndpoint,
-    FlowRouteLookupObservation, FlowSocketBindingObservation,
+    FlowEgressObservation, FlowNetworkInterfaceObservation, FlowNetworkObservation,
+    FlowRemoteEndpoint, FlowRouteLookupObservation, FlowSocketBindingObservation,
 };
 use zero_platform_tokio::{EgressSelection, TokioSocket};
 use zero_traits::IpAddress;
@@ -50,6 +50,8 @@ impl DirectConnector {
                 let network = direct_network_observation(
                     &success.selection,
                     local,
+                    success.remote,
+                    &success.resolved_candidates,
                     "connected",
                     success.selection.interface().is_some(),
                 );
@@ -67,6 +69,8 @@ impl DirectConnector {
                     network: Box::new(direct_network_observation(
                         &failure.selection,
                         failure.local_addr,
+                        failure.remote,
+                        &failure.resolved_candidates,
                         failure.stage,
                         failure.interface_bound,
                     )),
@@ -181,11 +185,23 @@ fn log_dial_failure(kind: &str, failure: &TcpDialFailure) {
     tracing::debug!(
         connect_kind = kind,
         target = %failure.remote,
+        candidates = ?failure.resolved_candidates,
+        egress_generation = failure.selection.generation(),
+        tun_active = failure.selection.tun_active(),
         route_source = ?failure.selection.route_source(),
         route_lookup = failure.selection.route_lookup_status().as_str(),
         binding_reason = failure.selection.binding_reason().as_str(),
         egress_name = failure.selection.interface().map(|value| value.name()),
         egress_index = failure.selection.interface().map(|value| value.index()),
+        configured_egress_name = failure
+            .selection
+            .configured_interface()
+            .map(|value| value.name()),
+        configured_egress_index = failure
+            .selection
+            .configured_interface()
+            .map(|value| value.index()),
+        egress_unavailable_reason = failure.selection.unavailable_reason(),
         connect_stage = failure.stage,
         error = %failure.error,
         "TCP candidate dial failed"
@@ -203,6 +219,8 @@ fn dial_failure_error(failure: &TcpDialFailure, connect_error: &'static str) -> 
 fn direct_network_observation(
     selection: &EgressSelection,
     local: Option<SocketAddr>,
+    remote: SocketAddr,
+    resolved_candidates: &[SocketAddr],
     connect_stage: &str,
     interface_bound: bool,
 ) -> FlowNetworkObservation {
@@ -211,11 +229,29 @@ fn direct_network_observation(
             host: address.ip().to_string(),
             port: address.port(),
         }),
+        remote_address: Some(socket_endpoint(remote)),
+        resolved_candidates: resolved_candidates
+            .iter()
+            .copied()
+            .map(socket_endpoint)
+            .collect(),
         selected_interface: selection.interface().map(|interface| {
             FlowNetworkInterfaceObservation {
                 name: interface.name().to_owned(),
                 index: interface.index(),
             }
+        }),
+        egress: Some(FlowEgressObservation {
+            generation: selection.generation(),
+            address_family: if remote.is_ipv6() { "ipv6" } else { "ipv4" }.to_owned(),
+            tun_active: selection.tun_active(),
+            configured_interface: selection.configured_interface().map(|interface| {
+                FlowNetworkInterfaceObservation {
+                    name: interface.name().to_owned(),
+                    index: interface.index(),
+                }
+            }),
+            unavailable_reason: selection.unavailable_reason().map(ToOwned::to_owned),
         }),
         route_lookup: Some(FlowRouteLookupObservation {
             status: selection.route_lookup_status().as_str().to_owned(),
@@ -233,6 +269,13 @@ fn direct_network_observation(
             interface_bound,
         }),
         connect_stage: Some(connect_stage.to_owned()),
+    }
+}
+
+fn socket_endpoint(address: SocketAddr) -> FlowRemoteEndpoint {
+    FlowRemoteEndpoint {
+        host: address.ip().to_string(),
+        port: address.port(),
     }
 }
 

--- a/crates/proxy/src/transport/direct_dial.rs
+++ b/crates/proxy/src/transport/direct_dial.rs
@@ -11,12 +11,14 @@ const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
 pub(super) struct TcpDialSuccess {
     pub(super) socket: TokioSocket,
     pub(super) remote: SocketAddr,
+    pub(super) resolved_candidates: Vec<SocketAddr>,
     pub(super) selection: EgressSelection,
 }
 
 #[derive(Debug)]
 pub(super) struct TcpDialFailure {
     pub(super) remote: SocketAddr,
+    pub(super) resolved_candidates: Vec<SocketAddr>,
     pub(super) selection: EgressSelection,
     pub(super) stage: &'static str,
     pub(super) interface_bound: bool,
@@ -28,8 +30,8 @@ pub(super) async fn dial_tcp_candidates(
     candidates: Vec<SocketAddr>,
     egress: &EgressInterfaceControl,
 ) -> Result<TcpDialSuccess, Box<TcpDialFailure>> {
-    let candidates = interleave_address_families(candidates);
-    let mut next_candidate = candidates.into_iter();
+    let resolved_candidates = interleave_address_families(candidates);
+    let mut next_candidate = resolved_candidates.iter().copied();
     let first = next_candidate
         .next()
         .expect("dial candidates are non-empty");
@@ -42,7 +44,10 @@ pub(super) async fn dial_tcp_candidates(
             tokio::select! {
                 result = attempts.next() => {
                     match result.expect("at least one dial attempt is active") {
-                        Ok(success) => return Ok(success),
+                        Ok(mut success) => {
+                            success.resolved_candidates = resolved_candidates.clone();
+                            return Ok(success);
+                        }
                         Err(failure) => {
                             last_failure = Some(failure);
                             attempts.push(dial_tcp_candidate(candidate, egress.clone()));
@@ -57,9 +62,16 @@ pub(super) async fn dial_tcp_candidates(
         }
 
         match attempts.next().await {
-            Some(Ok(success)) => return Ok(success),
+            Some(Ok(mut success)) => {
+                success.resolved_candidates = resolved_candidates.clone();
+                return Ok(success);
+            }
             Some(Err(failure)) => last_failure = Some(failure),
-            None => return Err(last_failure.expect("at least one dial candidate was attempted")),
+            None => {
+                let mut failure = last_failure.expect("at least one dial candidate was attempted");
+                failure.resolved_candidates = resolved_candidates.clone();
+                return Err(failure);
+            }
         }
     }
 }
@@ -72,6 +84,7 @@ async fn dial_tcp_candidate(
     if let Err(error) = selection.ensure_connectable() {
         return Err(Box::new(TcpDialFailure {
             remote,
+            resolved_candidates: Vec::new(),
             selection,
             stage: "select_egress",
             interface_bound: false,
@@ -89,11 +102,13 @@ async fn dial_tcp_candidate(
         Ok(Ok(socket)) => Ok(TcpDialSuccess {
             socket,
             remote,
+            resolved_candidates: Vec::new(),
             selection,
         }),
         Ok(Err(error)) => Err(connect_failure(remote, selection, error)),
         Err(_) => Err(Box::new(TcpDialFailure {
             remote,
+            resolved_candidates: Vec::new(),
             interface_bound: selection.interface().is_some(),
             selection,
             stage: "connect_timeout",
@@ -110,6 +125,7 @@ fn connect_failure(
 ) -> Box<TcpDialFailure> {
     Box::new(TcpDialFailure {
         remote,
+        resolved_candidates: Vec::new(),
         selection,
         stage: error.stage(),
         interface_bound: error.interface_bound(),

--- a/crates/proxy/src/transport/tcp_outbound/model.rs
+++ b/crates/proxy/src/transport/tcp_outbound/model.rs
@@ -25,7 +25,7 @@ pub(super) enum EstablishedTcpOutboundKind {
         tag: String,
         remote: (String, u16),
         upstream: TcpRelayStream,
-        network: zero_engine::FlowNetworkObservation,
+        network: Box<zero_engine::FlowNetworkObservation>,
     },
     Block,
     Proxied {
@@ -54,7 +54,7 @@ impl EstablishedTcpOutbound {
                 tag: tag.into(),
                 remote,
                 upstream,
-                network,
+                network: Box::new(network),
             },
         }
     }

--- a/crates/proxy/src/transport/tcp_outbound/result.rs
+++ b/crates/proxy/src/transport/tcp_outbound/result.rs
@@ -23,7 +23,7 @@ pub(crate) fn extract_tcp_stream(
             relay_chain: Vec::new(),
             route_action: RouteDecision::Direct,
             passive_relay_selections: Vec::new(),
-            network: Some(network),
+            network: Some(*network),
         }),
         EstablishedTcpOutboundKind::Block => Err(EngineError::Io(io::Error::new(
             io::ErrorKind::ConnectionRefused,

--- a/crates/proxy/src/transport/tests.rs
+++ b/crates/proxy/src/transport/tests.rs
@@ -76,5 +76,6 @@ async fn tcp_dial_candidates_fall_back_after_the_first_address_fails() {
     .unwrap();
 
     assert_eq!(connection.remote, reachable);
+    assert_eq!(connection.resolved_candidates, vec![unavailable, reachable]);
     assert_eq!(connection.socket.peer_addr().unwrap(), reachable);
 }

--- a/crates/proxy/tests/runtime_boundary.rs
+++ b/crates/proxy/tests/runtime_boundary.rs
@@ -3049,6 +3049,7 @@ fn handle_command_root_stays_facade_only() {
     for module_name in [
         "mod diagnostics;",
         "mod dispatch;",
+        "mod fake_ip;",
         "mod runtime;",
         "mod tun;",
     ] {
@@ -3060,6 +3061,7 @@ fn handle_command_root_stays_facade_only() {
         "CommandRequest::DiagnosticsProbeOutbound",
         "CommandRequest::DiagnosticsDnsCache",
         "CommandRequest::DiagnosticsFakeipLookup",
+        "CommandRequest::FakeIpClear",
     ] {
         assert!(
             !command_root.contains(forbidden),
@@ -3072,6 +3074,7 @@ fn handle_command_root_stays_facade_only() {
         "CommandRequest::DiagnosticsProbeOutbound",
         "CommandRequest::DiagnosticsDnsCache",
         "CommandRequest::DiagnosticsFakeipLookup",
+        "CommandRequest::FakeIpClear",
     ] {
         assert!(
             command.contains(expected),

--- a/crates/proxy/tests/socks5/relays_tcp_through_socks5_direct_outbound.rs
+++ b/crates/proxy/tests/socks5/relays_tcp_through_socks5_direct_outbound.rs
@@ -97,6 +97,10 @@ async fn relays_tcp_through_socks5_direct_outbound() {
     let network = &events[0].payload["record"]["path"]["network"];
     assert_eq!(network["local_address"]["host"], "127.0.0.1");
     assert!(network["local_address"]["port"].as_u64().unwrap() > 0);
+    assert_eq!(network["remote_address"]["host"], "127.0.0.1");
+    assert_eq!(network["resolved_candidates"].as_array().unwrap().len(), 1);
+    assert_eq!(network["egress"]["address_family"], "ipv4");
+    assert_eq!(network["egress"]["tun_active"], false);
     assert_eq!(network["connect_stage"], "connected");
     assert_eq!(network["route_lookup"]["status"], "skipped");
     assert_eq!(network["socket_binding"]["reason"], "loopback");

--- a/crates/tun/src/route/journal.rs
+++ b/crates/tun/src/route/journal.rs
@@ -27,6 +27,7 @@ pub(super) struct RouteJournal {
 #[derive(Debug)]
 pub(super) struct RouteLease {
     journal_path: PathBuf,
+    owner_path: PathBuf,
     _lock: std::fs::File,
 }
 
@@ -48,6 +49,7 @@ impl RouteLease {
         lock_path: PathBuf,
         owner: &str,
     ) -> io::Result<Self> {
+        let owner_path = lock_owner_path(&lock_path);
         let lock = std::fs::OpenOptions::new()
             .create(true)
             .truncate(false)
@@ -55,7 +57,7 @@ impl RouteLease {
             .write(true)
             .open(&lock_path)?;
         fs2::FileExt::try_lock_exclusive(&lock).map_err(|error| {
-            let active_owner = std::fs::read_to_string(&lock_path)
+            let active_owner = std::fs::read_to_string(&owner_path)
                 .ok()
                 .map(|owner| owner.trim().to_owned())
                 .filter(|owner| !owner.is_empty())
@@ -68,11 +70,26 @@ impl RouteLease {
                 ),
             )
         })?;
-        persist_lock_owner(&lock, owner)?;
+        persist_lock_owner(&owner_path, owner)?;
         Ok(Self {
             journal_path,
+            owner_path,
             _lock: lock,
         })
+    }
+}
+
+impl Drop for RouteLease {
+    fn drop(&mut self) {
+        match std::fs::remove_file(&self.owner_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => tracing::warn!(
+                path = %self.owner_path.display(),
+                error = %error,
+                "failed to remove TUN route lease owner metadata"
+            ),
+        }
     }
 }
 
@@ -273,14 +290,12 @@ fn safe_recovery_key(recovery_key: &str) -> String {
     }
 }
 
-fn persist_lock_owner(lock: &std::fs::File, owner: &str) -> io::Result<()> {
-    use std::io::{Seek, Write};
+fn lock_owner_path(lock_path: &Path) -> PathBuf {
+    lock_path.with_extension("")
+}
 
-    let mut lock = lock;
-    lock.set_len(0)?;
-    lock.rewind()?;
-    lock.write_all(safe_recovery_key(owner).as_bytes())?;
-    lock.sync_data()
+fn persist_lock_owner(owner_path: &Path, owner: &str) -> io::Result<()> {
+    std::fs::write(owner_path, safe_recovery_key(owner))
 }
 
 pub(super) fn route_state_root() -> io::Result<PathBuf> {

--- a/crates/tun/src/route/tests.rs
+++ b/crates/tun/src/route/tests.rs
@@ -191,6 +191,7 @@ fn route_lease_serializes_same_device_transactions() {
 fn route_lease_serializes_different_instances_per_address_family() {
     let directory = tempfile::tempdir().expect("temporary lease directory");
     let lock_path = directory.path().join("routes-v4.owner.lock");
+    let owner_path = lock_path.with_extension("");
     let first = RouteLease::acquire_paths(
         directory.path().join("routes-first-v4.json"),
         lock_path.clone(),
@@ -206,8 +207,13 @@ fn route_lease_serializes_different_instances_per_address_family() {
     .expect_err("a different tag must not own the same family concurrently");
     assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
     assert!(error.to_string().contains("active owner `first-instance`"));
+    assert_eq!(
+        std::fs::read_to_string(&owner_path).unwrap(),
+        "first-instance"
+    );
 
     drop(first);
+    assert!(!owner_path.exists());
     RouteLease::acquire_paths(
         directory.path().join("routes-second-v4.json"),
         lock_path,

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -144,6 +144,21 @@ share one TTL, LRU identity, and capacity slot. A compatible hot reload
 preserves live mappings; changing either pool, TTL, capacity, or exclusions
 creates a new allocator.
 `diagnostics.fakeip_lookup` reports mapping counters and capacity.
+The admin command `fakeip.clear` manages the same allocator and persistent
+journal. Empty params clear every mapping; `domain` or `ip` selects one mapping
+in both directions:
+
+```json
+{ "method": "fakeip.clear", "params": {} }
+{ "method": "fakeip.clear", "params": { "domain": "example.com" } }
+{ "method": "fakeip.clear", "params": { "ip": "198.18.0.1" } }
+```
+
+At most one selector is accepted. Success reports `removed_mappings`,
+`removed_addresses`, and the remaining `live_mappings`. Clearing mappings is a
+disruptive diagnostic action: applications may still hold synthetic DNS answers
+whose reverse mappings no longer exist, so clients should warn before a full
+clear and expect affected connections to resolve again.
 `diagnostics.dns_lookup` returns the query role plus the newest backend attempts,
 including server tag, transport, concrete endpoint candidates, selected outbound,
 success, and the failure reason that caused an ordered fallback.

--- a/src/application/tun.rs
+++ b/src/application/tun.rs
@@ -71,7 +71,7 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
             let status = decode_tun_status(response.result.unwrap_or_default())?;
             if status.running {
                 println!(
-                    "tun: running, healthy={}, managed_by_config={}, name={}, addr={}, addresses={}, mtu={}, tag={}, auto_route={}, include_cidrs={}, exclude_cidrs={}, dual_stack={}, strict_route={}, dns_hijack={}, egress={}, egress_v4={}, egress_v6={}",
+                    "tun: running, healthy={}, managed_by_config={}, name={}, addr={}, addresses={}, mtu={}, tag={}, auto_route={}, include_cidrs={}, exclude_cidrs={}, dual_stack={}, strict_route={}, dns_hijack={}, egress={}, egress_v4={}, egress_v6={}, last_error={}",
                     status.healthy,
                     status.managed_by_config,
                     status.name.as_deref().unwrap_or("-"),
@@ -103,14 +103,13 @@ pub fn execute(command: Command) -> Result<(), Box<dyn Error>> {
                     status.dns_hijack,
                     status.egress_interface.as_deref().unwrap_or("-"),
                     status.egress_interface_v4.as_deref().unwrap_or("-"),
-                    status.egress_interface_v6.as_deref().unwrap_or("-")
+                    status.egress_interface_v6.as_deref().unwrap_or("-"),
+                    status.last_error.as_deref().unwrap_or("-")
                 );
+            } else if let Some(error) = status.last_error {
+                println!("tun: not running, last_error={error}");
             } else {
-                if let Some(error) = status.last_error {
-                    println!("tun: not running, last_error={error}");
-                } else {
-                    println!("tun: not running");
-                }
+                println!("tun: not running");
             }
             Ok(())
         }


### PR DESCRIPTION
## Summary

- keep Windows TUN route lease owner metadata outside the locked file so a competing process can report the active owner reliably
- capture the complete resolved TCP candidate set, terminal remote address, and authoritative per-family egress snapshot for direct connections
- preserve the original route-reconciliation failure reason and expose it through flow API/event records, debug logs, and `tun status`
- keep all new flow fields additive and optional for forward compatibility

## Motivation

Builds on #46 and delivers the first implementation slice of #47.

Previously a failed direct connection could stop at `tun_egress_unavailable` without showing whether the physical egress was never published, withdrawn after reconciliation failed, selected for the wrong family, or evaluated against a different DNS candidate. The additional context makes those states distinguishable from one completed flow record.

This PR does not yet implement the full bounded incident timeline or support-bundle export described in #47.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --exclude zero-grpc`
- `cargo clippy --workspace --all-targets --exclude zero-grpc`

`zero-grpc` was excluded locally because this machine has no `protoc`; the repository CI covers that surface. Clippy reports only the two pre-existing Windows WFP warnings introduced before this branch.