### PR TITLE
fix(tun): support system DNS auto-discovery

### DIFF
--- a/crates/config/src/model/dns.rs
+++ b/crates/config/src/model/dns.rs
@@ -123,8 +123,11 @@ const fn default_dns_timeout_ms() -> u64 {
 }
 
 impl DnsConfig {
-    /// Return DNS endpoint addresses that can be safely excluded from a TUN
-    /// default route without recursively consulting the system resolver.
+    /// Return statically configured DNS endpoint addresses that can be safely
+    /// excluded from a TUN default route without recursive resolution.
+    ///
+    /// System resolver endpoints are discovered by the platform runtime and
+    /// merged into this list before TUN capture routes are installed.
     pub fn tun_route_exclusion_addresses(&self) -> Result<Vec<IpAddr>, String> {
         let mut addresses = BTreeSet::new();
         for (tag, server) in &self.servers {
@@ -132,9 +135,7 @@ impl DnsConfig {
                 continue;
             }
             if matches!(server, DnsServerConfig::System) {
-                return Err(format!(
-                    "TUN DNS hijack cannot use system DNS backend `{tag}`"
-                ));
+                continue;
             }
 
             let endpoint_addresses = server.endpoint_addresses().map_err(|error| {
@@ -143,6 +144,13 @@ impl DnsConfig {
             addresses.extend(endpoint_addresses);
         }
         Ok(addresses.into_iter().collect())
+    }
+
+    /// Whether TUN route preparation must discover host resolver endpoints.
+    pub fn uses_system_dns(&self) -> bool {
+        self.servers
+            .values()
+            .any(|server| matches!(server, DnsServerConfig::System))
     }
 
     pub fn fake_ip(&self) -> Option<FakeIpConfigRef<'_>> {

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -415,7 +415,7 @@ fn validate_tun_config(
             .as_ref()
             .ok_or_else(|| {
                 ConfigError::InvalidRuntime(
-                    "TUN DNS hijack requires configured non-system DNS servers".to_owned(),
+                    "TUN DNS hijack requires a configured DNS server".to_owned(),
                 )
             })?
             .tun_route_exclusion_addresses()

--- a/crates/config/tests/config_parse.rs
+++ b/crates/config/tests/config_parse.rs
@@ -1891,10 +1891,9 @@ fn rejects_tun_tag_that_duplicates_a_listener_tag() {
 }
 
 #[test]
-fn strict_declarative_tun_rejects_recursive_or_hostname_dns_endpoints() {
+fn strict_declarative_tun_rejects_missing_or_hostname_dns_endpoints() {
     for dns in [
         r#"{ "servers": {}, "default_server": "missing" }"#,
-        r#"{ "servers": { "local": { "type": "system" } }, "default_server": "local" }"#,
         r#"{ "servers": { "named": { "type": "udp", "host": "dns.example" } }, "default_server": "named" }"#,
         r#"{ "servers": { "named": { "type": "doh", "host": "dns.example" } }, "default_server": "named" }"#,
         r#"{ "servers": { "named": { "type": "dot", "host": "dns.example" } }, "default_server": "named" }"#,

--- a/crates/config/tests/config_parse.rs
+++ b/crates/config/tests/config_parse.rs
@@ -1791,6 +1791,27 @@ fn parses_declarative_tun_runtime_with_safe_defaults() {
 }
 
 #[test]
+fn strict_tun_dns_hijack_accepts_system_dns_for_runtime_discovery() {
+    let config = RuntimeConfig::parse(
+        r#"{
+            "runtime": {
+                "dns": {
+                    "servers": { "system-auto": { "type": "system" } },
+                    "default_server": "system-auto"
+                },
+                "tun": { "addr": "10.23.0.1/24" }
+            },
+            "route": { "rules": [], "final": { "type": "direct" } }
+        }"#,
+    )
+    .expect("system DNS endpoints are resolved during TUN route preparation");
+
+    let dns = config.runtime.dns.expect("DNS config");
+    assert!(dns.uses_system_dns());
+    assert!(dns.tun_route_exclusion_addresses().unwrap().is_empty());
+}
+
+#[test]
 fn validates_declarative_tun_capture_cidrs() {
     for tun in [
         r#"{ "addr": "10.0.0.1/24", "auto_route": false, "include_cidrs": ["10.0.0.0/8"] }"#,

--- a/crates/platform/tokio/src/lib.rs
+++ b/crates/platform/tokio/src/lib.rs
@@ -12,12 +12,14 @@ use zero_traits::{
 
 mod egress;
 mod process;
+mod system_dns;
 use egress::{bind_tcp_to_interface, bind_udp_to_interface, datagram_bind_address};
 pub use egress::{
     EgressBindingReason, EgressFamilySnapshot, EgressInterface, EgressInterfaceControl,
     EgressRouteLookupStatus, EgressSelection,
 };
 pub use process::{lookup_local_tcp_process, lookup_local_udp_process, LocalProcessInfo};
+pub use system_dns::system_dns_servers;
 
 #[derive(Debug)]
 pub struct TokioSocket {

--- a/crates/platform/tokio/src/system_dns.rs
+++ b/crates/platform/tokio/src/system_dns.rs
@@ -1,0 +1,84 @@
+use std::io;
+use std::net::IpAddr;
+
+#[cfg(target_os = "linux")]
+#[path = "system_dns/linux.rs"]
+mod platform;
+#[cfg(target_os = "macos")]
+#[path = "system_dns/macos.rs"]
+mod platform;
+#[cfg(target_os = "windows")]
+#[path = "system_dns/windows.rs"]
+mod platform;
+
+/// Discover the non-local DNS endpoints used by the host resolver.
+///
+/// TUN strict-route mode installs explicit bypass routes for these endpoints
+/// before publishing capture routes. Local stubs are intentionally rejected:
+/// their real upstreams must be discovered so the stub cannot re-enter TUN.
+pub fn system_dns_servers() -> io::Result<Vec<IpAddr>> {
+    let mut servers = platform::system_dns_servers()?;
+    servers.retain(|address| usable_upstream(*address));
+    servers.sort_unstable();
+    servers.dedup();
+    servers.truncate(32);
+    if servers.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "system DNS auto-discovery found no non-local upstream endpoints; configure an explicit UDP, DoH, DoT, or DoQ backend",
+        ));
+    }
+    Ok(servers)
+}
+
+fn usable_upstream(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            !address.is_unspecified()
+                && !address.is_loopback()
+                && !address.is_link_local()
+                && !address.is_multicast()
+                && !address.is_broadcast()
+        }
+        IpAddr::V6(address) => {
+            !address.is_unspecified()
+                && !address.is_loopback()
+                && !address.is_unicast_link_local()
+                && !address.is_multicast()
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn parse_nameserver_lines(input: &str) -> Vec<IpAddr> {
+    input
+        .lines()
+        .filter_map(|line| {
+            let line = line.split('#').next()?.trim();
+            let rest = line.strip_prefix("nameserver")?;
+            let value = if rest.starts_with('[') {
+                rest.split_once(':')?.1.trim()
+            } else {
+                rest.split_whitespace().next()?
+            };
+            let value = value.split('%').next().unwrap_or(value).trim();
+            value.parse().ok()
+        })
+        .collect()
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+mod platform {
+    use std::io;
+    use std::net::IpAddr;
+
+    pub(super) fn system_dns_servers() -> io::Result<Vec<IpAddr>> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "system DNS auto-discovery is unsupported on this platform",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/platform/tokio/src/system_dns/linux.rs
+++ b/crates/platform/tokio/src/system_dns/linux.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::net::IpAddr;
+use std::path::Path;
+
+const RESOLVER_PATHS: [&str; 3] = [
+    "/run/systemd/resolve/resolv.conf",
+    "/run/NetworkManager/no-stub-resolv.conf",
+    "/etc/resolv.conf",
+];
+
+pub(super) fn system_dns_servers() -> io::Result<Vec<IpAddr>> {
+    let mut servers = Vec::new();
+    let mut readable = false;
+    let mut last_error = None;
+    for path in RESOLVER_PATHS {
+        if !Path::new(path).exists() {
+            continue;
+        }
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                readable = true;
+                servers.extend(super::parse_nameserver_lines(&contents));
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    if readable {
+        Ok(servers)
+    } else {
+        Err(last_error.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "no readable system resolver configuration was found",
+            )
+        }))
+    }
+}

--- a/crates/platform/tokio/src/system_dns/macos.rs
+++ b/crates/platform/tokio/src/system_dns/macos.rs
@@ -1,0 +1,23 @@
+use std::io;
+use std::net::IpAddr;
+use std::process::Command;
+
+pub(super) fn system_dns_servers() -> io::Result<Vec<IpAddr>> {
+    let output = Command::new("scutil").arg("--dns").output();
+    if let Ok(output) = output {
+        if output.status.success() {
+            let servers = super::parse_nameserver_lines(&String::from_utf8_lossy(&output.stdout));
+            if !servers.is_empty() {
+                return Ok(servers);
+            }
+        }
+    }
+
+    let contents = std::fs::read_to_string("/etc/resolv.conf").map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("discover macOS system DNS with scutil or /etc/resolv.conf: {error}"),
+        )
+    })?;
+    Ok(super::parse_nameserver_lines(&contents))
+}

--- a/crates/platform/tokio/src/system_dns/tests.rs
+++ b/crates/platform/tokio/src/system_dns/tests.rs
@@ -1,0 +1,52 @@
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::net::IpAddr;
+
+use super::usable_upstream;
+
+#[test]
+fn upstream_filter_rejects_local_and_non_routable_addresses() {
+    for address in [
+        "0.0.0.0",
+        "127.0.0.1",
+        "169.254.1.1",
+        "224.0.0.1",
+        "255.255.255.255",
+        "::",
+        "::1",
+        "fe80::1",
+        "ff02::1",
+    ] {
+        assert!(!usable_upstream(address.parse().unwrap()));
+    }
+    assert!(usable_upstream("192.168.1.1".parse().unwrap()));
+    assert!(usable_upstream("2001:4860:4860::8888".parse().unwrap()));
+}
+
+#[cfg(windows)]
+#[test]
+#[ignore = "requires an active non-local Windows DNS configuration"]
+fn discovers_current_windows_dns_upstreams() {
+    let servers = super::system_dns_servers().expect("discover Windows DNS upstreams");
+    assert!(!servers.is_empty());
+    assert!(servers.into_iter().all(usable_upstream));
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn resolver_text_parser_accepts_resolv_conf_and_scutil_shapes() {
+    let parsed = super::parse_nameserver_lines(
+        "nameserver 1.1.1.1\n\
+         nameserver 2606:4700:4700::1111 # comment\n\
+         nameserver[0] : 192.0.2.53\n\
+         nameserver[1] : fe80::53%en0\n",
+    );
+    assert_eq!(
+        parsed,
+        vec![
+            "1.1.1.1".parse::<IpAddr>().unwrap(),
+            "2606:4700:4700::1111".parse().unwrap(),
+            "192.0.2.53".parse().unwrap(),
+            "fe80::53".parse().unwrap(),
+        ]
+    );
+}

--- a/crates/platform/tokio/src/system_dns/windows.rs
+++ b/crates/platform/tokio/src/system_dns/windows.rs
@@ -1,0 +1,99 @@
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use windows_sys::Win32::Foundation::{ERROR_BUFFER_OVERFLOW, ERROR_SUCCESS};
+use windows_sys::Win32::NetworkManagement::IpHelper::{
+    GetAdaptersAddresses, GAA_FLAG_SKIP_ANYCAST, GAA_FLAG_SKIP_MULTICAST, GAA_FLAG_SKIP_UNICAST,
+    IF_TYPE_SOFTWARE_LOOPBACK, IP_ADAPTER_ADDRESSES_LH,
+};
+use windows_sys::Win32::NetworkManagement::Ndis::IfOperStatusUp;
+use windows_sys::Win32::Networking::WinSock::{
+    AF_INET, AF_INET6, AF_UNSPEC, SOCKADDR_IN, SOCKADDR_IN6, SOCKET_ADDRESS,
+};
+
+pub(super) fn system_dns_servers() -> io::Result<Vec<IpAddr>> {
+    let flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST;
+    let mut size = 0_u32;
+    let initial = unsafe {
+        GetAdaptersAddresses(
+            AF_UNSPEC as u32,
+            flags,
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            &mut size,
+        )
+    };
+    if initial != ERROR_BUFFER_OVERFLOW && initial != ERROR_SUCCESS {
+        return Err(win32_error("size Windows adapter DNS table", initial));
+    }
+    if size == 0 {
+        return Ok(Vec::new());
+    }
+
+    for _ in 0..3 {
+        let words = (size as usize).div_ceil(std::mem::size_of::<u64>());
+        let mut buffer = vec![0_u64; words];
+        let adapters = buffer.as_mut_ptr().cast::<IP_ADAPTER_ADDRESSES_LH>();
+        let status = unsafe {
+            GetAdaptersAddresses(
+                AF_UNSPEC as u32,
+                flags,
+                std::ptr::null(),
+                adapters,
+                &mut size,
+            )
+        };
+        if status == ERROR_BUFFER_OVERFLOW {
+            continue;
+        }
+        if status != ERROR_SUCCESS {
+            return Err(win32_error("read Windows adapter DNS table", status));
+        }
+        return Ok(unsafe { collect_servers(adapters) });
+    }
+
+    Err(io::Error::other(
+        "Windows adapter DNS table changed repeatedly during discovery",
+    ))
+}
+
+unsafe fn collect_servers(mut adapter: *mut IP_ADAPTER_ADDRESSES_LH) -> Vec<IpAddr> {
+    let mut servers = Vec::new();
+    while let Some(current) = adapter.as_ref() {
+        if current.OperStatus == IfOperStatusUp && current.IfType != IF_TYPE_SOFTWARE_LOOPBACK {
+            let mut server = current.FirstDnsServerAddress;
+            while let Some(dns) = server.as_ref() {
+                if let Some(address) = socket_address_ip(&dns.Address) {
+                    servers.push(address);
+                }
+                server = dns.Next;
+            }
+        }
+        adapter = current.Next;
+    }
+    servers
+}
+
+unsafe fn socket_address_ip(address: &SOCKET_ADDRESS) -> Option<IpAddr> {
+    let sockaddr = address.lpSockaddr.as_ref()?;
+    match sockaddr.sa_family {
+        AF_INET => {
+            let address = &*address.lpSockaddr.cast::<SOCKADDR_IN>();
+            Some(IpAddr::V4(Ipv4Addr::from(
+                address.sin_addr.S_un.S_addr.to_ne_bytes(),
+            )))
+        }
+        AF_INET6 => {
+            let address = &*address.lpSockaddr.cast::<SOCKADDR_IN6>();
+            Some(IpAddr::V6(Ipv6Addr::from(address.sin6_addr.u.Byte)))
+        }
+        _ => None,
+    }
+}
+
+fn win32_error(context: &str, status: u32) -> io::Error {
+    io::Error::other(format!(
+        "{context}: {}",
+        io::Error::from_raw_os_error(status as i32)
+    ))
+}

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -540,8 +540,9 @@ impl Proxy {
         dns_hijack: bool,
         strict_route: bool,
     ) -> Result<PreparedTunNetwork, EngineError> {
-        let (dns_hijack, dns_route_exclusions) =
-            self.prepare_tun_dns_hijack(dns_hijack, strict_route)?;
+        let (dns_hijack, dns_route_exclusions) = self
+            .prepare_tun_dns_hijack(dns_hijack, strict_route)
+            .await?;
         let mut route_exclusions = if auto_route {
             dns_route_exclusions
         } else {
@@ -558,7 +559,7 @@ impl Proxy {
         })
     }
 
-    fn prepare_tun_dns_hijack(
+    async fn prepare_tun_dns_hijack(
         &self,
         requested: bool,
         strict: bool,
@@ -566,7 +567,14 @@ impl Proxy {
         if !requested {
             return Ok((false, Vec::new()));
         }
-        let result = configured_dns_endpoint_addresses(self.engine().config().as_ref());
+        let config = self.engine().config();
+        let result =
+            tokio::task::spawn_blocking(move || configured_dns_endpoint_addresses(config.as_ref()))
+                .await
+                .map_err(|error| {
+                    io::Error::other(format!("system DNS discovery task failed: {error}"))
+                })
+                .and_then(|result| result);
         match result {
             Ok(addresses) => Ok((true, addresses)),
             Err(error) if strict => Err(EngineError::Io(error)),

--- a/crates/proxy/src/inbound/tun/config.rs
+++ b/crates/proxy/src/inbound/tun/config.rs
@@ -89,14 +89,28 @@ pub(super) fn parse_address_and_mask(
 pub(super) fn configured_dns_endpoint_addresses(
     config: &zero_config::RuntimeConfig,
 ) -> io::Result<Vec<IpAddr>> {
+    configured_dns_endpoint_addresses_with(config, zero_platform_tokio::system_dns_servers)
+}
+
+pub(super) fn configured_dns_endpoint_addresses_with(
+    config: &zero_config::RuntimeConfig,
+    discover_system_dns: impl FnOnce() -> io::Result<Vec<IpAddr>>,
+) -> io::Result<Vec<IpAddr>> {
     let dns = config.runtime.dns.as_ref().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
-            "TUN DNS hijack requires configured non-system DNS servers",
+            "TUN DNS hijack requires a configured DNS server",
         )
     })?;
-    dns.tun_route_exclusion_addresses()
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))
+    let mut addresses = dns
+        .tun_route_exclusion_addresses()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+    if dns.uses_system_dns() {
+        addresses.extend(discover_system_dns()?);
+    }
+    addresses.sort_unstable();
+    addresses.dedup();
+    Ok(addresses)
 }
 
 fn parse_ip(value: &str, field: &str) -> Result<IpAddr, EngineError> {

--- a/crates/proxy/src/inbound/tun/tests.rs
+++ b/crates/proxy/src/inbound/tun/tests.rs
@@ -1,8 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use super::config::{
-    configured_dns_endpoint_addresses, parse_address_and_mask, parse_interface_addresses,
-    DEFAULT_TUN_IPV4_ADDR, DEFAULT_TUN_IPV6_ADDR,
+    configured_dns_endpoint_addresses, configured_dns_endpoint_addresses_with,
+    parse_address_and_mask, parse_interface_addresses, DEFAULT_TUN_IPV4_ADDR,
+    DEFAULT_TUN_IPV6_ADDR,
 };
 use super::{configured_tun_is_current, tun_route_exclusion_required, PreparedTunNetwork, TunInfo};
 
@@ -251,18 +252,33 @@ fn explicit_secondary_address_must_be_cidr_and_opposite_family() {
 }
 
 #[test]
-fn strict_dns_hijack_requires_literal_non_system_endpoints() {
+fn strict_dns_hijack_discovers_and_merges_system_dns_endpoints() {
     let system = zero_config::RuntimeConfig::parse(
         r#"{
             "runtime":{"dns":{
-                "servers":{"local":{"type":"system"}},
+                "servers":{
+                    "local":{"type":"system"},
+                    "fallback":{"type":"udp","host":"198.51.100.53"}
+                },
                 "default_server":"local"
             }},
             "route":{"rules":[],"final":{"type":"direct"}}
         }"#,
     )
     .expect("parse system DNS config");
-    assert!(configured_dns_endpoint_addresses(&system).is_err());
+    assert_eq!(
+        configured_dns_endpoint_addresses_with(&system, || {
+            Ok(vec![
+                "192.0.2.53".parse().unwrap(),
+                "192.0.2.53".parse().unwrap(),
+            ])
+        })
+        .expect("discover system DNS endpoints"),
+        vec![
+            "192.0.2.53".parse::<IpAddr>().unwrap(),
+            "198.51.100.53".parse().unwrap(),
+        ]
+    );
 
     let udp = zero_config::RuntimeConfig::parse(
         r#"{
@@ -278,6 +294,28 @@ fn strict_dns_hijack_requires_literal_non_system_endpoints() {
         configured_dns_endpoint_addresses(&udp).expect("literal DNS endpoint"),
         vec![IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))]
     );
+}
+
+#[test]
+fn strict_dns_hijack_fails_closed_when_system_dns_discovery_fails() {
+    let system = zero_config::RuntimeConfig::parse(
+        r#"{
+            "runtime":{"dns":{
+                "servers":{"local":{"type":"system"}},
+                "default_server":"local"
+            }},
+            "route":{"rules":[],"final":{"type":"direct"}}
+        }"#,
+    )
+    .expect("parse system DNS config");
+    let error = configured_dns_endpoint_addresses_with(&system, || {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no upstream endpoints",
+        ))
+    })
+    .expect_err("strict system DNS must fail closed");
+    assert!(error.to_string().contains("no upstream endpoints"));
 }
 
 #[test]

--- a/docs/testing/tun-e2e.md
+++ b/docs/testing/tun-e2e.md
@@ -27,7 +27,7 @@ Zero 的 TUN 模式面向 Linux、macOS 和 Windows。`tun start` 会创建并�
 
 ## DNS 前置约束
 
-严格 DNS 劫持要求至少配置一个非 system DNS 后端。域名形式的上游必须提供 `bootstrap` IP；Zero 会为实际端点建立明确的物理出口排除，避免解析 DNS 上游本身时递归进入 TUN。
+严格 DNS 劫持要求至少配置一个 DNS 后端。`system` 后端会在启动前自动发现主机解析器的非本地上游，并为其建立动态物理出口排除；网络拓扑变化后会重新发现和协调。若系统只暴露本地 stub 且无法发现真实上游，严格模式会失败关闭并要求配置显式 UDP、DoH、DoT 或 DoQ 后端。域名形式的显式上游仍必须提供 `bootstrap` IP，避免解析 DNS 上游本身时递归进入 TUN。
 
 示例：
 


### PR DESCRIPTION
Part of #52
Part of #33
Closes #53

## Summary

- allow strict TUN DNS hijack to use the existing `type: system` backend
- discover real non-local system DNS upstreams before installing capture routes
- merge and deduplicate system endpoints with explicit DNS/bootstrap endpoints
- preserve strict fail-closed behavior when only a local stub is visible or discovery fails
- run potentially blocking platform discovery outside the async executor
- reuse the existing route monitor/reconciliation path so DNS bypass routes follow network changes
- document the system-auto contract and explicit-backend fallback

## Platform implementation

- Windows: native `GetAdaptersAddresses` / IP Helper enumeration over active adapters
- Linux: systemd-resolved and NetworkManager upstream resolver files, then `/etc/resolv.conf`
- macOS: `scutil --dns`, then `/etc/resolv.conf`
- all platforms reject unspecified, loopback, link-local, multicast and broadcast-only endpoints

## Safety behavior

This does not merely remove the old validation. TUN capture is not activated until usable upstream endpoints have been discovered and added to the physical route exclusions. In strict mode, missing upstreams remain a startup error with an actionable explicit UDP/DoH/DoT/DoQ fallback.

The configured system backend still uses the OS resolver, preserving hosts-file and platform search behavior rather than silently selecting a public provider.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `cargo test -p zero-platform-tokio system_dns --locked`
- live Windows discovery: `cargo test -p zero-platform-tokio discovers_current_windows_dns_upstreams --locked -- --ignored`
- `cargo test -p zero-config strict_tun_dns_hijack_accepts_system_dns_for_runtime_discovery --locked`
- `cargo test -p zero-proxy --lib strict_dns_hijack --features dns,udp-runtime --locked --jobs 1`
- `cargo check --workspace --exclude zero-grpc --locked --jobs 1`

Environment limitations:

- full workspace check reached `zero-grpc` and stopped because this host has no `protoc`
- an initial command that built every zero-proxy integration-test binary exhausted the Windows page file (OS error 1455); the scoped library tests above passed after constraining the build