### PR TITLE
fix(dns): fail closed on missing Fake-IP mappings

### DIFF
--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -45,6 +45,8 @@ pub enum EngineError {
     },
     #[error("outbound `{tag}` is temporarily unhealthy")]
     UnhealthyOutbound { tag: String },
+    #[error("Fake-IP reverse mapping is missing for synthetic target `{address}`")]
+    FakeIpReverseMissing { address: String },
     #[error("flow admission denied: {reason}")]
     AdmissionDenied { reason: String },
 }
@@ -66,6 +68,7 @@ impl EngineError {
             Self::SelectorGroupTypeMismatch { .. } => "selector_group_type_mismatch",
             Self::SelectorTargetNotFound { .. } => "selector_target_not_found",
             Self::UnhealthyOutbound { .. } => "unhealthy_outbound",
+            Self::FakeIpReverseMissing { .. } => "fake_ip_reverse_missing",
             Self::AdmissionDenied { .. } => "admission_denied",
         }
     }

--- a/crates/engine/src/session/completed.rs
+++ b/crates/engine/src/session/completed.rs
@@ -91,7 +91,7 @@ pub struct CompletedSessionRecord {
     pub outcome: SessionOutcome,
     /// Why the session ended. `None` = normal peer close / unspecified.
     /// Recognised values: `"manual"` (flows.close), `"idle_timeout"`,
-    /// `"upstream_error"`.
+    /// `"target_error"`, `"upstream_error"`.
     pub close_reason: Option<String>,
     pub failure: Option<FlowFailureObservation>,
 }

--- a/crates/proxy/src/runtime/target.rs
+++ b/crates/proxy/src/runtime/target.rs
@@ -1,35 +1,49 @@
 use zero_core::{Address, FakeIpReverseStatus, Session, TargetHostSource};
 use zero_dns::{DnsSystem, RealIpReverseLookup};
+use zero_engine::EngineError;
 use zero_traits::IpAddress;
 
-/// Recover a logical DNS target while preserving transparent direct semantics.
-pub(crate) async fn resolve_dns_target(resolver: &DnsSystem, session: &mut Session) {
-    let (ip, standard_ip) = match &session.target {
-        Address::Ipv4(octets) => (
-            IpAddress::V4(*octets),
-            std::net::IpAddr::V4((*octets).into()),
-        ),
-        Address::Ipv6(octets) => (
-            IpAddress::V6(*octets),
-            std::net::IpAddr::V6((*octets).into()),
-        ),
-        _ => return,
-    };
+mod failure;
+pub(crate) use failure::finish_target_recovery_failure;
 
-    if resolver.fake_ip_contains(standard_ip) {
-        session.original_target = Some(session.target.clone());
+/// Recover a logical DNS target while preserving transparent direct semantics.
+pub(crate) async fn resolve_dns_target(
+    resolver: &DnsSystem,
+    session: &mut Session,
+) -> Result<(), EngineError> {
+    let current_ip = address_ip(&session.target);
+    let original_ip = session.original_target.as_ref().and_then(address_ip);
+    let synthetic = current_ip
+        .filter(|(_, standard_ip)| resolver.fake_ip_contains(*standard_ip))
+        .or_else(|| original_ip.filter(|(_, standard_ip)| resolver.fake_ip_contains(*standard_ip)));
+
+    if let Some((ip, standard_ip)) = synthetic {
+        let synthetic_target = address_from_ip(ip);
+        if session.original_target.is_none() {
+            session.original_target = Some(synthetic_target.clone());
+        }
         if let Some(domain) = resolver.lookup_fake_ip(&ip).await {
             session.target = Address::Domain(domain);
+            session.direct_target = None;
             session.target_host_source = Some(TargetHostSource::FakeIp);
             session.fake_ip_reverse_status = Some(FakeIpReverseStatus::Resolved);
         } else {
+            session.target = synthetic_target;
+            session.direct_target = None;
+            session.target_host_source = None;
             session.fake_ip_reverse_status = Some(FakeIpReverseStatus::Missing);
+            return Err(EngineError::FakeIpReverseMissing {
+                address: standard_ip.to_string(),
+            });
         }
-        return;
+        return Ok(());
     }
 
+    let Some((ip, _)) = current_ip else {
+        return Ok(());
+    };
     if !session.transparent_target {
-        return;
+        return Ok(());
     }
     match resolver.lookup_real_ip(&ip).await {
         RealIpReverseLookup::Resolved(domain) => {
@@ -43,6 +57,28 @@ pub(crate) async fn resolve_dns_target(resolver: &DnsSystem, session: &mut Sessi
             tracing::trace!(target = ?session.target, "real-IP reverse lookup is ambiguous");
         }
         RealIpReverseLookup::Missing => {}
+    }
+    Ok(())
+}
+
+fn address_ip(address: &Address) -> Option<(IpAddress, std::net::IpAddr)> {
+    match address {
+        Address::Ipv4(octets) => Some((
+            IpAddress::V4(*octets),
+            std::net::IpAddr::V4((*octets).into()),
+        )),
+        Address::Ipv6(octets) => Some((
+            IpAddress::V6(*octets),
+            std::net::IpAddr::V6((*octets).into()),
+        )),
+        Address::Domain(_) => None,
+    }
+}
+
+fn address_from_ip(address: IpAddress) -> Address {
+    match address {
+        IpAddress::V4(octets) => Address::Ipv4(octets),
+        IpAddress::V6(octets) => Address::Ipv6(octets),
     }
 }
 

--- a/crates/proxy/src/runtime/target/failure.rs
+++ b/crates/proxy/src/runtime/target/failure.rs
@@ -1,0 +1,26 @@
+use std::time::Instant;
+
+use zero_core::Session;
+use zero_engine::{EngineError, SessionHandle};
+
+use crate::logging::{log_session_failed, session_failure_observation};
+
+pub(crate) fn finish_target_recovery_failure(
+    handle: &mut SessionHandle,
+    session: &Session,
+    started_at: Instant,
+    error: &EngineError,
+) {
+    let record = handle.finish_with_failure(
+        "target_error",
+        session_failure_observation("target_recovery", error, None),
+    );
+    log_session_failed(
+        session,
+        record.as_ref(),
+        "target_recovery",
+        started_at.elapsed(),
+        error,
+        None,
+    );
+}

--- a/crates/proxy/src/runtime/target/tests.rs
+++ b/crates/proxy/src/runtime/target/tests.rs
@@ -4,7 +4,8 @@ use zero_config::{
     DnsAddressFamilyPolicy, DnsAnswerConfig, DnsConfig, DnsPolicyConfig, DnsReverseMappingConfig,
     DnsServerConfig,
 };
-use zero_core::{Address, Network, ProtocolType, Session, TargetHostSource};
+use zero_core::{Address, FakeIpReverseStatus, Network, ProtocolType, Session, TargetHostSource};
+use zero_engine::EngineError;
 use zero_traits::{DnsResolver, IpAddress};
 
 use super::resolve_dns_target;
@@ -64,7 +65,9 @@ async fn recovers_only_transparent_real_ip_targets_and_preserves_direct_ip() {
         Network::Tcp,
         ProtocolType::UNKNOWN,
     );
-    resolve_dns_target(&dns, &mut explicit).await;
+    resolve_dns_target(&dns, &mut explicit)
+        .await
+        .expect("preserve explicit target");
     assert_eq!(explicit.target, original);
 
     let mut transparent = Session::new(
@@ -75,7 +78,9 @@ async fn recovers_only_transparent_real_ip_targets_and_preserves_direct_ip() {
         ProtocolType::UNKNOWN,
     );
     transparent.transparent_target = true;
-    resolve_dns_target(&dns, &mut transparent).await;
+    resolve_dns_target(&dns, &mut transparent)
+        .await
+        .expect("recover transparent target");
     assert_eq!(
         transparent.target,
         Address::Domain("transparent.example".to_owned())
@@ -87,4 +92,150 @@ async fn recovers_only_transparent_real_ip_targets_and_preserves_direct_ip() {
         Some(TargetHostSource::DnsReverse)
     );
     server.await.expect("DNS server task");
+}
+
+#[tokio::test]
+async fn missing_ipv4_and_ipv6_fake_ip_mappings_fail_closed() {
+    let dns = fake_dns();
+    for (target, address) in [
+        (Address::Ipv4([198, 18, 0, 7]), "198.18.0.7"),
+        (
+            Address::Ipv6([0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7]),
+            "fd00::7",
+        ),
+    ] {
+        let mut session = Session::new(1, target.clone(), 443, Network::Tcp, ProtocolType::UNKNOWN);
+        session.transparent_target = true;
+
+        let error = resolve_dns_target(&dns, &mut session)
+            .await
+            .expect_err("unmapped synthetic target must fail");
+
+        assert!(matches!(
+            error,
+            EngineError::FakeIpReverseMissing { address: ref value } if value == address
+        ));
+        assert_eq!(session.target, target.clone());
+        assert_eq!(session.original_target, Some(target));
+        assert!(session.direct_target.is_none());
+        assert!(session.target_host_source.is_none());
+        assert_eq!(
+            session.fake_ip_reverse_status,
+            Some(FakeIpReverseStatus::Missing)
+        );
+    }
+}
+
+#[tokio::test]
+async fn sniffed_tcp_and_quic_domains_cannot_bypass_fake_ip_ownership() {
+    let dns = fake_dns();
+    let synthetic = Address::Ipv4([198, 18, 0, 9]);
+    for source in [
+        TargetHostSource::TlsSni,
+        TargetHostSource::HttpHost,
+        TargetHostSource::QuicSni,
+    ] {
+        let network = if source == TargetHostSource::QuicSni {
+            Network::Udp
+        } else {
+            Network::Tcp
+        };
+        let mut session = Session::new(
+            1,
+            Address::Domain("sniffed.example".to_owned()),
+            443,
+            network,
+            ProtocolType::UNKNOWN,
+        );
+        session.transparent_target = true;
+        session.original_target = Some(synthetic.clone());
+        session.direct_target = Some(synthetic.clone());
+        session.target_host_source = Some(source);
+
+        let error = resolve_dns_target(&dns, &mut session)
+            .await
+            .expect_err("sniffing must not repair a missing Fake-IP mapping");
+
+        assert_eq!(error.code(), "fake_ip_reverse_missing");
+        assert_eq!(session.target, synthetic);
+        assert!(session.direct_target.is_none());
+        assert!(session.target_host_source.is_none());
+        assert_eq!(
+            session.fake_ip_reverse_status,
+            Some(FakeIpReverseStatus::Missing)
+        );
+    }
+}
+
+#[tokio::test]
+async fn live_fake_ip_mapping_is_authoritative_over_sniffed_domain() {
+    let dns = fake_dns();
+    let response = dns
+        .answer_udp_query(&dns_a_query("mapped.example"))
+        .await
+        .expect("allocate Fake-IP mapping");
+    let synthetic = Address::Ipv4(
+        response[response.len() - 4..]
+            .try_into()
+            .expect("four-byte A response"),
+    );
+    let mut session = Session::new(
+        1,
+        Address::Domain("different-sni.example".to_owned()),
+        443,
+        Network::Tcp,
+        ProtocolType::UNKNOWN,
+    );
+    session.transparent_target = true;
+    session.original_target = Some(synthetic.clone());
+    session.direct_target = Some(synthetic.clone());
+    session.target_host_source = Some(TargetHostSource::TlsSni);
+    session.sni = Some("different-sni.example".to_owned());
+
+    resolve_dns_target(&dns, &mut session)
+        .await
+        .expect("restore mapped Fake-IP domain");
+
+    assert_eq!(session.target, Address::Domain("mapped.example".to_owned()));
+    assert_eq!(session.original_target, Some(synthetic));
+    assert!(session.direct_target.is_none());
+    assert_eq!(session.target_host_source, Some(TargetHostSource::FakeIp));
+    assert_eq!(
+        session.fake_ip_reverse_status,
+        Some(FakeIpReverseStatus::Resolved)
+    );
+    assert_eq!(session.sni.as_deref(), Some("different-sni.example"));
+}
+
+fn fake_dns() -> zero_dns::DnsSystem {
+    zero_dns::DnsSystem::build(Some(&DnsConfig {
+        servers: BTreeMap::from([("system".to_owned(), DnsServerConfig::System)]),
+        default_server: "system".to_owned(),
+        dispatch: Vec::new(),
+        cache: None,
+        reverse_mapping: None,
+        answer: DnsAnswerConfig::FakeIp {
+            cidr: "198.18.0.0/24".to_owned(),
+            ipv6_cidr: Some("fd00::/120".to_owned()),
+            ttl_seconds: 60,
+            max_entries: Some(16),
+            exclude_domains: Vec::new(),
+        },
+        policy: DnsPolicyConfig::default(),
+    }))
+    .expect("build Fake-IP DNS")
+}
+
+fn dns_a_query(domain: &str) -> Vec<u8> {
+    let mut query = vec![
+        0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    for label in domain.split('.') {
+        query.push(label.len() as u8);
+        query.extend_from_slice(label.as_bytes());
+    }
+    query.push(0);
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    query
 }

--- a/crates/proxy/src/runtime/tcp_ingress/lifecycle/serve.rs
+++ b/crates/proxy/src/runtime/tcp_ingress/lifecycle/serve.rs
@@ -64,20 +64,31 @@ pub(crate) async fn serve_inbound<P: InboundProtocol>(
 ) -> Result<(), EngineError> {
     let mut session = session;
     let mut client = client;
+    let started_at = Instant::now();
 
-    runtime.resolve_fake_ip_target(&mut session).await;
-    runtime.apply_url_rewrite(&mut session);
+    let target_resolution = runtime.resolve_fake_ip_target(&mut session).await;
+    if target_resolution.is_ok() {
+        runtime.apply_url_rewrite(&mut session);
+    }
     runtime.apply_kernel_rate_limits(&mut session);
     runtime.prepare_session(&mut session).await?;
     let traffic_rate_limiters = runtime.traffic_rate_limiters(&session);
 
     let mut handle = runtime.track_session(session.id);
+    if let Err(error) = target_resolution {
+        let _ = protocol.send_upstream_failure(&mut client).await;
+        crate::runtime::target::finish_target_recovery_failure(
+            &mut handle,
+            &session,
+            started_at,
+            &error,
+        );
+        return Err(error);
+    }
     let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel();
     handle.register_cancellation(move || {
         let _ = cancel_tx.send(());
     });
-    let started_at = Instant::now();
-
     let mut pipe = TcpPipe::new(runtime);
     let dispatch_result = tokio::select! {
         result = pipe.dispatch(TcpPipeInput { session: &mut session }) => result,

--- a/crates/proxy/src/runtime/tcp_ingress/runtime/message.rs
+++ b/crates/proxy/src/runtime/tcp_ingress/runtime/message.rs
@@ -24,8 +24,11 @@ impl TcpIngressRuntime {
         let original_target = protocol.session(&request).target.clone();
         let original_port = protocol.session(&request).port;
         let mut session = protocol.session(&request).clone();
-        self.resolve_fake_ip_target(&mut session).await;
-        self.apply_url_rewrite(&mut session);
+        let started_at = Instant::now();
+        let target_resolution = self.resolve_fake_ip_target(&mut session).await;
+        if target_resolution.is_ok() {
+            self.apply_url_rewrite(&mut session);
+        }
         if session.target != original_target || session.port != original_port {
             protocol.set_effective_target(&mut request, &session.target, session.port);
         }
@@ -33,12 +36,20 @@ impl TcpIngressRuntime {
         self.prepare_session(&mut session).await?;
         let rate_limiters = self.traffic_rate_limiters(&session);
         let mut handle = self.track_session(session.id);
+        if let Err(error) = target_resolution {
+            let _ = protocol.send_upstream_failure(client).await;
+            crate::runtime::target::finish_target_recovery_failure(
+                &mut handle,
+                &session,
+                started_at,
+                &error,
+            );
+            return Err(error);
+        }
         let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel();
         handle.register_cancellation(move || {
             let _ = cancel_tx.send(());
         });
-        let started_at = Instant::now();
-
         let mut pipe = TcpPipe::new(self);
         let dispatch = tokio::select! {
             result = pipe.dispatch(TcpPipeInput { session: &mut session }) => result,

--- a/crates/proxy/src/runtime/tcp_ingress/runtime/session.rs
+++ b/crates/proxy/src/runtime/tcp_ingress/runtime/session.rs
@@ -5,8 +5,11 @@ use super::super::lifecycle::apply_kernel_rate_limits_from_config;
 use super::model::TcpIngressRuntime;
 
 impl TcpIngressRuntime {
-    pub(crate) async fn resolve_fake_ip_target(&self, session: &mut Session) {
-        crate::runtime::target::resolve_dns_target(self.services.resolver(), session).await;
+    pub(crate) async fn resolve_fake_ip_target(
+        &self,
+        session: &mut Session,
+    ) -> Result<(), EngineError> {
+        crate::runtime::target::resolve_dns_target(self.services.resolver(), session).await
     }
 
     pub(crate) fn apply_url_rewrite(&self, session: &mut Session) {

--- a/crates/proxy/src/runtime/tcp_ingress/runtime/tests.rs
+++ b/crates/proxy/src/runtime/tcp_ingress/runtime/tests.rs
@@ -1,3 +1,4 @@
+use zero_api::{event_type, EventFilter, EventSource};
 use zero_config::RuntimeConfig;
 use zero_core::{Address, Network, ProtocolType, Session};
 use zero_engine::RouteDecision;
@@ -79,7 +80,10 @@ async fn fake_ip_restoration_records_success_and_missing_mapping() {
         Network::Tcp,
         ProtocolType::UNKNOWN,
     );
-    runtime.resolve_fake_ip_target(&mut mapped).await;
+    runtime
+        .resolve_fake_ip_target(&mut mapped)
+        .await
+        .expect("restore mapped Fake-IP");
     assert_eq!(mapped.target, Address::Domain("mapped.example".to_owned()));
     assert!(mapped.direct_target.is_none());
     assert_eq!(mapped.original_target, Some(Address::Ipv4([198, 18, 0, 1])));
@@ -99,7 +103,11 @@ async fn fake_ip_restoration_records_success_and_missing_mapping() {
         Network::Tcp,
         ProtocolType::UNKNOWN,
     );
-    runtime.resolve_fake_ip_target(&mut missing).await;
+    let error = runtime
+        .resolve_fake_ip_target(&mut missing)
+        .await
+        .expect_err("missing Fake-IP mapping must fail closed");
+    assert_eq!(error.code(), "fake_ip_reverse_missing");
     assert_eq!(missing.target, Address::Ipv4([198, 18, 0, 99]));
     assert_eq!(
         missing.fake_ip_reverse_status,
@@ -122,11 +130,99 @@ async fn ip_target_without_fake_ip_configuration_remains_unannotated() {
         ProtocolType::UNKNOWN,
     );
 
-    runtime.resolve_fake_ip_target(&mut session).await;
+    runtime
+        .resolve_fake_ip_target(&mut session)
+        .await
+        .expect("preserve ordinary IP target");
 
     assert_eq!(session.target, Address::Ipv4([203, 0, 113, 7]));
     assert!(session.original_target.is_none());
     assert!(session.fake_ip_reverse_status.is_none());
+}
+
+#[tokio::test]
+async fn tcp_reverse_miss_completes_once_with_stable_target_failure() {
+    let config = RuntimeConfig::parse(
+        r#"{
+            "runtime": {
+                "dns": {
+                    "servers": { "system": { "type": "system" } },
+                    "default_server": "system",
+                    "answer": {
+                        "type": "fake_ip",
+                        "cidr": "198.18.0.0/15",
+                        "ttl_seconds": 60,
+                        "max_entries": 16
+                    }
+                }
+            },
+            "route": { "rules": [], "final": { "type": "direct" } }
+        }"#,
+    )
+    .expect("parse Fake-IP config");
+    let proxy = crate::runtime::Proxy::new(config).expect("build proxy");
+    let engine = proxy.engine().clone();
+    let runtime = TcpIngressRuntime::new(proxy.tcp_runtime_services(), "tun-test".to_owned(), None);
+    let mut session = Session::new(
+        0,
+        Address::Ipv4([198, 18, 0, 99]),
+        443,
+        Network::Tcp,
+        ProtocolType::UNKNOWN,
+    );
+    session.transparent_target = true;
+    let (client, _peer) = tokio::io::duplex(64);
+    let protocol = crate::runtime::tcp_ingress::NoClientResponseStreamProtocol::new();
+
+    let error = runtime
+        .serve(session, client, &protocol)
+        .await
+        .expect_err("unmapped Fake-IP TCP target must fail");
+
+    assert_eq!(error.code(), "fake_ip_reverse_missing");
+    let completed = engine.completed_sessions();
+    assert_eq!(completed.len(), 1);
+    let record = &completed[0];
+    assert_eq!(record.close_reason.as_deref(), Some("target_error"));
+    assert_eq!(
+        record.fake_ip_reverse_status,
+        Some(zero_core::FakeIpReverseStatus::Missing)
+    );
+    assert_eq!(
+        record.original_target,
+        Some(Address::Ipv4([198, 18, 0, 99]))
+    );
+    assert!(record.route.is_none());
+    assert!(record.path.network.is_none());
+    assert_eq!(record.outbound_tx_bytes, 0);
+    assert_eq!(record.outbound_rx_bytes, 0);
+    let failure = record.failure.as_ref().expect("target failure observation");
+    assert_eq!(failure.stage, "target_recovery");
+    assert_eq!(failure.code.as_deref(), Some("fake_ip_reverse_missing"));
+    assert!(failure.remote.is_none());
+
+    let events = engine
+        .latest(
+            usize::MAX,
+            EventFilter {
+                event_types: vec![event_type::FLOW_COMPLETED.to_owned()],
+                ..EventFilter::default()
+            },
+        )
+        .expect("read completed flow event");
+    assert_eq!(events.len(), 1);
+    let event = &events[0].payload["record"];
+    assert_eq!(event["target"]["host"], "198.18.0.99");
+    assert_eq!(event["target"]["original_ip"], "198.18.0.99");
+    assert_eq!(event["target"]["fake_ip_reverse_status"], "missing");
+    assert_eq!(event["route"]["action"], "pending");
+    assert!(event["path"]["network"].is_null());
+    assert_eq!(event["result"]["close_reason"], "target_error");
+    assert_eq!(event["result"]["failure"]["stage"], "target_recovery");
+    assert_eq!(
+        event["result"]["failure"]["code"],
+        "fake_ip_reverse_missing"
+    );
 }
 
 fn dns_a_query(domain: &str) -> Vec<u8> {

--- a/crates/proxy/src/runtime/udp_dispatch/dispatch.rs
+++ b/crates/proxy/src/runtime/udp_dispatch/dispatch.rs
@@ -73,11 +73,21 @@ impl UdpDispatch {
             });
             session.source_port = Some(source_addr.port());
         }
-        runtime.resolve_fake_ip_target(&mut session).await;
+        let started_at = Instant::now();
+        let target_resolution = runtime.resolve_fake_ip_target(&mut session).await;
         runtime
             .prepare_udp_session(&mut session, &self.inbound_tag)
             .await?;
         let mut session_handle = runtime.track_session(session.id);
+        if let Err(error) = target_resolution {
+            crate::runtime::target::finish_target_recovery_failure(
+                &mut session_handle,
+                &session,
+                started_at,
+                &error,
+            );
+            return Err(error);
+        }
         let rate_limiters = UdpFlowRateLimiters::new(runtime.traffic_rate_limiters(&session));
         let cancellation_rate_limiters = rate_limiters.clone();
         let cancel_tx = self.cancel_tx.clone();
@@ -103,7 +113,6 @@ impl UdpDispatch {
                 "UDP flow cancelled while upload was rate limited: {reason}"
             ))));
         }
-        let started_at = Instant::now();
         runtime
             .services()
             .record_session_inbound_rx(session.id, input.payload.len() as u64);

--- a/crates/proxy/src/runtime/udp_dispatch/dispatch/tests.rs
+++ b/crates/proxy/src/runtime/udp_dispatch/dispatch/tests.rs
@@ -184,3 +184,81 @@ async fn failed_tuple_is_not_recreated_for_every_packet() {
         "backoff attempt created another failed session"
     );
 }
+
+#[tokio::test]
+async fn raw_and_quic_sniffed_fake_ip_reverse_misses_share_failure_contract() {
+    let config = RuntimeConfig::parse(
+        r#"{
+            "runtime": {
+                "dns": {
+                    "servers": { "system": { "type": "system" } },
+                    "default_server": "system",
+                    "answer": {
+                        "type": "fake_ip",
+                        "cidr": "198.18.0.0/24",
+                        "ipv6_cidr": "fd00::/120",
+                        "ttl_seconds": 60,
+                        "max_entries": 16
+                    }
+                }
+            },
+            "route": { "rules": [], "final": { "type": "direct" } }
+        }"#,
+    )
+    .expect("parse Fake-IP config");
+    let proxy = crate::runtime::Proxy::new(config).expect("build proxy");
+    let engine = proxy.engine().clone();
+    let runtime = UdpIngressRuntime::new(proxy.tcp_runtime_services());
+    let mut dispatch = runtime
+        .new_dispatch("tun-in")
+        .await
+        .expect("create UDP dispatch");
+    let auth = SessionAuth::new("test");
+
+    let mut raw = input(
+        Address::Ipv6([0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9]),
+        443,
+        b"raw",
+        &auth,
+    );
+    raw.transparent_target = true;
+    let raw_error = dispatch
+        .dispatch(raw)
+        .await
+        .expect_err("raw synthetic UDP target must fail");
+    assert_eq!(raw_error.code(), "fake_ip_reverse_missing");
+
+    let original = Address::Ipv4([198, 18, 0, 10]);
+    let mut quic = input(
+        Address::Domain("sniffed-quic.example".to_owned()),
+        443,
+        b"quic",
+        &auth,
+    );
+    quic.transparent_target = true;
+    quic.transparent_original_target = Some(original);
+    quic.transparent_host_source = Some(zero_core::TargetHostSource::QuicSni);
+    let quic_error = dispatch
+        .dispatch(quic)
+        .await
+        .expect_err("QUIC SNI must not bypass missing Fake-IP ownership");
+    assert_eq!(quic_error.code(), "fake_ip_reverse_missing");
+
+    let completed = engine.completed_sessions();
+    assert_eq!(completed.len(), 2);
+    for record in completed {
+        assert_eq!(record.close_reason.as_deref(), Some("target_error"));
+        assert_eq!(
+            record.fake_ip_reverse_status,
+            Some(zero_core::FakeIpReverseStatus::Missing)
+        );
+        assert!(record.route.is_none());
+        assert!(record.path.network.is_none());
+        assert_eq!(record.outbound_tx_bytes, 0);
+        assert_eq!(record.outbound_rx_bytes, 0);
+        let failure = record.failure.expect("target failure observation");
+        assert_eq!(failure.stage, "target_recovery");
+        assert_eq!(failure.code.as_deref(), Some("fake_ip_reverse_missing"));
+        assert!(failure.remote.is_none());
+    }
+}

--- a/crates/proxy/src/runtime/udp_ingress/session.rs
+++ b/crates/proxy/src/runtime/udp_ingress/session.rs
@@ -51,8 +51,11 @@ impl UdpIngressRuntime {
         self.tcp_services.traffic_rate_limiters(session)
     }
 
-    pub(crate) async fn resolve_fake_ip_target(&self, session: &mut Session) {
-        crate::runtime::target::resolve_dns_target(self.tcp_services.resolver(), session).await;
+    pub(crate) async fn resolve_fake_ip_target(
+        &self,
+        session: &mut Session,
+    ) -> Result<(), EngineError> {
+        crate::runtime::target::resolve_dns_target(self.tcp_services.resolver(), session).await
     }
 
     #[cfg(any(

--- a/docs/project/flow-query-contract.md
+++ b/docs/project/flow-query-contract.md
@@ -21,3 +21,20 @@ does not discard fields after startup or reconnect.
 Older servers may omit `record`, and older clients may ignore it. Consumers
 that support the canonical shape should fall back to the flattened fields only
 when `record` is absent.
+
+## Stable Fake-IP target recovery failure
+
+When the current or preserved transparent destination belongs to a configured
+Fake-IP pool but has no live reverse mapping, the flow terminates before route
+selection and outbound establishment. Every TCP, UDP, and QUIC path exposes the
+same additive contract:
+
+- `result.close_reason = "target_error"`
+- `result.failure.stage = "target_recovery"`
+- `result.failure.code = "fake_ip_reverse_missing"`
+- `target.fake_ip_reverse_status = "missing"`
+
+The record retains the synthetic `target.original_ip`, has no route or outbound
+network observation, and reports zero outbound bytes. Application-layer target
+sniffing does not replace Fake-IP ownership; a live reverse mapping remains the
+logical target authority.


### PR DESCRIPTION
Part of #52
Part of #33
Closes #57

## Summary

- require a live reverse mapping whenever the current or preserved transparent target belongs to a configured Fake-IP pool
- fail before route selection, DNS resolution, or outbound socket creation when ownership is missing
- validate preserved synthetic destinations even after TCP TLS/HTTP or UDP QUIC sniffing has changed the logical target to a domain
- make the live Fake-IP mapping authoritative over sniffed host metadata
- preserve existing explicit/transparent non-Fake-IP behavior

## Stable failure contract

All TCP, UDP, and QUIC reverse misses now emit the same additive flow contract:

- `close_reason=target_error`
- `failure.stage=target_recovery`
- `failure.code=fake_ip_reverse_missing`
- `target.fake_ip_reverse_status=missing`

The completed flow retains the synthetic original address, has no route or outbound-network observation, and reports zero outbound bytes.

## Lifecycle

Target recovery still happens before routing. To keep a fail-closed rejection observable, TCP and UDP register the already-annotated session and immediately finish it through one shared target-recovery failure helper. No outbound selection, health mutation, DNS resolution, or socket creation occurs.

Repeated UDP packets continue to use the existing bounded flow-start backoff.

## Coverage

- raw IPv4 and IPv6 reverse misses
- TLS SNI, HTTP Host, and QUIC SNI bypass prevention
- live mapping authority over different sniffed metadata
- TCP canonical `flow.completed` JSON contract
- UDP/QUIC completed-session parity
- exactly one completed failure with no route/network attempt
- unchanged non-Fake-IP explicit and transparent targets

## Local validation

Passed:

- `cargo fmt --all -- --check`
- `cargo check -p zero-proxy --features dns,udp-runtime --locked --jobs 1`
- `cargo test -p zero-engine --locked --jobs 1`
- `cargo test -p zero-proxy --lib --features dns,udp-runtime --locked --jobs 1` (143 passed)
- `cargo test -p zero-proxy --lib --all-features --locked --jobs 1` (147 passed)
- `cargo test -p zero-proxy --test runtime_boundary --all-features --locked --jobs 1` (180 passed)
- `cargo clippy -p zero-proxy --all-targets --all-features --locked --jobs 1`
- `cargo check --workspace --exclude zero-grpc --locked --jobs 1`

The local host does not provide `protoc`, so CI remains authoritative for the complete workspace including `zero-grpc` and the cross-platform matrix.
