### PR TITLE
fix(connector): back off blocked outbox writes

### DIFF
--- a/crates/connector/src/dispatcher.rs
+++ b/crates/connector/src/dispatcher.rs
@@ -468,8 +468,13 @@ async fn run_event_dispatcher<S>(
             }
         }
 
-        let wait_interval =
-            next_wait_interval(&pending, &workers, options.poll_interval, !shutting_down);
+        let wait_interval = next_wait_interval(
+            &pending,
+            &workers,
+            &blocked_events,
+            options.poll_interval,
+            !shutting_down,
+        );
         tokio::select! {
             biased;
             _ = &mut shutdown, if !shutting_down => {
@@ -549,6 +554,12 @@ where
 {
     let mut progressed = false;
     while let Some(blocked) = blocked_events.front_mut() {
+        if blocked
+            .persistence_retry_due
+            .is_some_and(|due| due > Instant::now())
+        {
+            return false;
+        }
         if let Some(sequence) = blocked.event.sequence {
             if last_sequence.is_some_and(|last| sequence <= last) {
                 blocked_events.pop_front();
@@ -556,14 +567,7 @@ where
             }
         }
         if blocked.event.event_type != event_type::FLOW_SNAPSHOT
-            && !dispatch_event(
-                workers,
-                stats,
-                pending,
-                blocked,
-                outbox,
-                dispatcher_config.max_in_memory_deliveries,
-            )
+            && !dispatch_event(workers, stats, pending, blocked, outbox, dispatcher_config)
         {
             return false;
         }
@@ -645,7 +649,7 @@ where
                 pending,
                 &mut blocked,
                 outbox,
-                dispatcher_config.max_in_memory_deliveries,
+                dispatcher_config,
             ) {
                 blocked_events.push_back(blocked);
                 blocked_events.extend(events.map(BlockedEvent::new));
@@ -747,7 +751,7 @@ fn dispatch_event(
     pending: &mut VecDeque<PendingDelivery>,
     blocked: &mut BlockedEvent,
     outbox: &mut Option<DeliveryOutbox>,
-    max_in_memory_deliveries: usize,
+    dispatcher_config: EventDispatcherConfig,
 ) -> bool {
     for worker in workers {
         if blocked.persisted_sinks.contains(&worker.tag) || !worker.accepts(&blocked.event) {
@@ -762,7 +766,11 @@ fn dispatch_event(
         if is_discardable_sample(&blocked.event) {
             let delivery = PendingDelivery::new(worker.tag.clone(), prepared, false);
             blocked.persisted_sinks.insert(worker.tag.clone());
-            enqueue_sample(pending, delivery, max_in_memory_deliveries);
+            enqueue_sample(
+                pending,
+                delivery,
+                dispatcher_config.max_in_memory_deliveries,
+            );
             continue;
         }
 
@@ -771,7 +779,8 @@ fn dispatch_event(
         // Without an outbox, stop consuming source events once the bounded
         // in-memory workset is full. This keeps backpressure bounded instead
         // of allowing a slow sink to grow the process indefinitely.
-        let pending_limit = effective_pending_limit(max_in_memory_deliveries, workers.len());
+        let pending_limit =
+            effective_pending_limit(dispatcher_config.max_in_memory_deliveries, workers.len());
         if outbox.is_none() && pending.len() >= pending_limit {
             return false;
         }
@@ -780,11 +789,16 @@ fn dispatch_event(
             if blocked.reported_failures.insert(worker.tag.clone()) {
                 record_outbox_failure(stats, &worker.tag, &error);
             }
+            blocked.defer_persistence_retry(dispatcher_config);
             return false;
         }
         blocked.persisted_sinks.insert(worker.tag.clone());
         if outbox.is_some()
-            && pending.len() >= effective_pending_limit(max_in_memory_deliveries, workers.len())
+            && pending.len()
+                >= effective_pending_limit(
+                    dispatcher_config.max_in_memory_deliveries,
+                    workers.len(),
+                )
         {
             continue;
         }
@@ -948,11 +962,12 @@ fn drain_worker_results(
 fn next_wait_interval(
     pending: &VecDeque<PendingDelivery>,
     workers: &[SinkWorker],
+    blocked_events: &VecDeque<BlockedEvent>,
     source_poll_interval: Duration,
     allow_durable: bool,
 ) -> Duration {
     let now = Instant::now();
-    pending
+    let pending_due = pending
         .iter()
         .filter(|delivery| {
             (!delivery.uses_outbox || allow_durable)
@@ -962,9 +977,19 @@ fn next_wait_interval(
                     }))
         })
         .map(|delivery| delivery.next_due.saturating_duration_since(now))
+        .min();
+    let persistence_due = blocked_events
+        .front()
+        .and_then(|blocked| blocked.persistence_retry_due)
+        .map(|due| due.saturating_duration_since(now));
+    let source_poll_due = blocked_events.is_empty().then_some(source_poll_interval);
+
+    pending_due
+        .into_iter()
+        .chain(persistence_due)
+        .chain(source_poll_due)
         .min()
         .unwrap_or(source_poll_interval)
-        .min(source_poll_interval)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1091,6 +1116,8 @@ struct BlockedEvent {
     event: RawApiEvent,
     persisted_sinks: HashSet<String>,
     reported_failures: HashSet<String>,
+    persistence_attempts: u32,
+    persistence_retry_due: Option<Instant>,
 }
 
 impl BlockedEvent {
@@ -1099,7 +1126,15 @@ impl BlockedEvent {
             event,
             persisted_sinks: HashSet::new(),
             reported_failures: HashSet::new(),
+            persistence_attempts: 0,
+            persistence_retry_due: None,
         }
+    }
+
+    fn defer_persistence_retry(&mut self, config: EventDispatcherConfig) {
+        self.persistence_attempts = self.persistence_attempts.saturating_add(1);
+        self.persistence_retry_due =
+            Some(Instant::now() + retry_delay(self.persistence_attempts, config));
     }
 }
 

--- a/crates/connector/tests/event_dispatcher.rs
+++ b/crates/connector/tests/event_dispatcher.rs
@@ -2,6 +2,7 @@
 
 use std::collections::VecDeque;
 use std::fs;
+use std::io::Write;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -417,6 +418,96 @@ async fn dispatcher_pauses_before_outbox_consumes_the_filesystem_reserve() {
 }
 
 #[tokio::test]
+async fn dispatcher_backs_off_then_recovers_after_outbox_capacity_returns() {
+    const BALLAST_BYTES: usize = 32 * 1024 * 1024;
+    const RETRY_DELAY: Duration = Duration::from_millis(500);
+
+    let directory = tempfile::tempdir().expect("dispatcher retry directory");
+    let events_path = directory.path().join("events.jsonl");
+    let outbox_path = directory.path().join("outbox.jsonl");
+    let ballast_path = directory.path().join("ballast.bin");
+    let available_before =
+        fs2::available_space(directory.path()).expect("available space before ballast");
+    let mut ballast = vec![0_u8; BALLAST_BYTES];
+    let mut state = 0x9e37_79b9_u32;
+    for byte in &mut ballast {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        *byte = state as u8;
+    }
+    let mut ballast_file = fs::File::create(&ballast_path).expect("create ballast");
+    ballast_file.write_all(&ballast).expect("write ballast");
+    ballast_file.sync_all().expect("sync ballast");
+    drop(ballast_file);
+    drop(ballast);
+    let available_with_ballast =
+        fs2::available_space(directory.path()).expect("available space with ballast");
+    let reclaimed_bytes = available_before.saturating_sub(available_with_ballast);
+    assert!(
+        reclaimed_bytes >= BALLAST_BYTES as u64 / 2,
+        "test filesystem did not allocate enough ballast: {reclaimed_bytes} bytes"
+    );
+    let reserve_bytes = available_with_ballast.saturating_add(reclaimed_bytes / 2);
+
+    let mut event = ApiEvent::new(
+        "reserve-recovery-event",
+        event_type::FLOW_COMPLETED,
+        1_760_000_000_001,
+        json!({ "value": 1 }),
+    );
+    event.sequence = Some(1);
+    let dispatcher = spawn_event_dispatcher(
+        StaticEventSource {
+            events: Arc::new(Mutex::new(vec![event])),
+        },
+        ApiConfig {
+            event_sinks: vec![EventSinkConfig::JsonLines {
+                tag: "reserve-protected".to_owned(),
+                path: events_path.display().to_string(),
+                events: Vec::new(),
+                source_id: None,
+            }],
+            outbox_path: Some(outbox_path.display().to_string()),
+            dispatcher: EventDispatcherConfig {
+                retry_initial_delay_ms: RETRY_DELAY.as_millis() as u64,
+                retry_max_delay_ms: RETRY_DELAY.as_millis() as u64,
+                outbox_min_free_bytes: reserve_bytes,
+                // This direct runtime test isolates the absolute reserve. The
+                // validated production configuration still requires 1..=50.
+                outbox_min_free_percent: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        None,
+        EventDispatcherOptions {
+            poll_interval: Duration::from_millis(10),
+            max_retry_attempts: 1,
+        },
+    )
+    .expect("spawn reserve-recovery dispatcher")
+    .expect("reserve-recovery dispatcher handle");
+    let status = dispatcher.status_handle();
+
+    wait_for_outbox_write_block(&status).await;
+    fs::remove_file(&ballast_path).expect("release ballast capacity");
+    wait_for_available_space(directory.path(), reserve_bytes).await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        fs::read_to_string(&events_path)
+            .map(|content| !content.contains("reserve-recovery-event"))
+            .unwrap_or(true),
+        "blocked event retried before its persistence deadline"
+    );
+
+    let written = wait_for_file_contains(&events_path, "reserve-recovery-event").await;
+    assert!(written.contains("reserve-recovery-event"));
+    dispatcher.shutdown().await;
+}
+
+#[tokio::test]
 async fn dispatcher_replays_a_live_queue_gap_and_keeps_a_monotonic_gap_counter() {
     let path = temp_path("zero-connector-replayed-events.jsonl");
     let _ = fs::remove_file(&path);
@@ -693,6 +784,17 @@ async fn wait_for_outbox_write_block(
     }
 
     panic!("outbox storage did not enter the protected state");
+}
+
+async fn wait_for_available_space(path: &std::path::Path, required_bytes: u64) {
+    for _ in 0..1_000 {
+        if fs2::available_space(path).is_ok_and(|available| available > required_bytes) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    panic!("filesystem capacity did not recover above {required_bytes} bytes");
 }
 
 fn temp_path(name: &str) -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

- retain an unpersisted lifecycle event without advancing the source cursor when the durable outbox storage reserve blocks a `Put`
- schedule the next persistence attempt with the existing bounded exponential retry policy instead of immediately retrying every dispatcher iteration
- include the blocked persistence deadline in event-driven wake selection and suppress periodic replay polling while that cursor is blocked
- add a deterministic capacity-loss/recovery regression that proves no early retry and eventual lossless delivery

The configured filesystem reserve is unchanged. This PR fixes scheduler behavior after a legitimate reserve refusal.

## Root cause

`dispatch_event` returned `false` after `DeliveryOutbox::put` failed, correctly retaining the event in `blocked_events`. However, `BlockedEvent` had no retry deadline, so the next loop immediately retried the same filesystem probe/write and warning indefinitely.

The failure was reproduced on Windows with about 2.17 GB available and the default 5% reserve requiring about 25.59 GB free.

## Validation

Passed locally:

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features --locked`
- `cargo test -p zero-connector --all-features --locked -- --test-threads=1` — 26 passed, 2 qualification tests ignored
- `RUST_MIN_STACK=16777216 cargo test --workspace --all-features --locked --jobs 1` — passed; privileged/external interop/soak tests retain their declared ignore conditions
- `cargo clippy -p zero-connector --all-features --all-targets --no-deps --locked --jobs 1 -- -D warnings`

The full Windows workspace Clippy invocation reaches two pre-existing warnings in `crates/tun/src/route/leak/windows.rs` outside this diff; Linux PR CI remains the authoritative full-workspace static gate.

Closes #62
Part of #18
Part of #52
Related to #23