### PR TITLE
test(http): qualify POST forwarding regression

### DIFF
--- a/crates/proxy/tests/http.rs
+++ b/crates/proxy/tests/http.rs
@@ -545,7 +545,7 @@ async fn close_delimited_response_is_reframed_for_persistent_client() {
 }
 
 #[tokio::test]
-async fn routes_plain_http_through_a_configured_proxy_outbound() {
+async fn routes_plain_http_post_through_a_configured_proxy_outbound() {
     let origin_port = free_port();
     let upstream_port = free_port();
     let proxy_port = free_port();
@@ -555,9 +555,14 @@ async fn routes_plain_http_through_a_configured_proxy_outbound() {
             .expect("bind origin");
         let (mut stream, _) = listener.accept().await.expect("accept origin");
         let head = String::from_utf8(read_http_head(&mut stream).await).expect("head");
-        assert!(head.starts_with("GET /proxied HTTP/1.1\r\n"));
+        assert!(head.starts_with("POST /proxied HTTP/1.1\r\n"));
+        assert!(head.contains("Content-Length: 2\r\n"));
+        assert!(!head.to_ascii_lowercase().contains("proxy-connection:"));
+        let mut body = [0_u8; 2];
+        stream.read_exact(&mut body).await.expect("request body");
+        assert_eq!(&body, b"{}");
         stream
-            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\nproxied")
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\npong\r\n0\r\n\r\n")
             .await
             .expect("response");
     });
@@ -589,13 +594,16 @@ async fn routes_plain_http_through_a_configured_proxy_outbound() {
         .expect("connect proxy");
     client
         .write_all(
-            format!("GET http://127.0.0.1:{origin_port}/proxied HTTP/1.1\r\nHost: ignored\r\n\r\n")
+            format!("POST http://127.0.0.1:{origin_port}/proxied HTTP/1.1\r\nHost: ignored\r\nProxy-Connection: keep-alive\r\nContent-Length: 2\r\n\r\n{{}}")
                 .as_bytes(),
         )
         .await
         .expect("request");
-    let (_, body) = read_http_response(&mut client).await;
-    assert_eq!(body, b"proxied");
+    let (head, body) = read_http_response(&mut client).await;
+    assert!(String::from_utf8_lossy(&head)
+        .to_ascii_lowercase()
+        .contains("transfer-encoding: chunked"));
+    assert_eq!(body, b"4\r\npong\r\n0\r\n\r\n");
     wait_for("proxied HTTP session", || {
         outer_handle.completed_sessions().iter().any(|session| {
             session.outbound_tag.as_deref() == Some("socks-out")

--- a/crates/proxy/tests/mixed.rs
+++ b/crates/proxy/tests/mixed.rs
@@ -299,28 +299,36 @@ async fn mixed_http_branch_reparses_persistent_requests() {
 }
 
 #[tokio::test]
-async fn mixed_http_branch_relays_tiny_fixed_length_post_body() {
+async fn mixed_http_branch_relays_split_post_and_next_request() {
     let mixed_port = free_port();
     let origin_port = free_port();
     let origin_task = tokio::spawn(async move {
         let listener = TcpListener::bind(("127.0.0.1", origin_port))
             .await
             .expect("bind origin");
-        let (mut stream, _) = listener.accept().await.expect("accept origin");
-        let request = String::from_utf8(read_http_head(&mut stream).await).expect("request");
+        let (mut first, _) = listener.accept().await.expect("accept first origin");
+        let request = String::from_utf8(read_http_head(&mut first).await).expect("request");
         assert!(request.starts_with("POST /api/v1/nodes/4/diagnostics HTTP/1.1\r\n"));
         assert!(request.contains("Content-Length: 2\r\n"));
         assert!(!request.to_ascii_lowercase().contains("proxy-connection:"));
         let mut body = [0_u8; 2];
-        tokio::time::timeout(Duration::from_millis(100), stream.read_exact(&mut body))
+        tokio::time::timeout(Duration::from_millis(100), first.read_exact(&mut body))
             .await
             .expect("request body must arrive with the forwarded head")
             .expect("request body");
         assert_eq!(&body, b"{}");
-        stream
+        first
             .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")
             .await
-            .expect("response");
+            .expect("first response");
+
+        let (mut second, _) = listener.accept().await.expect("accept second origin");
+        let request = String::from_utf8(read_http_head(&mut second).await).expect("request");
+        assert!(request.starts_with("GET /after HTTP/1.1\r\n"));
+        second
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n4\r\npong\r\n0\r\n\r\n")
+            .await
+            .expect("second response");
     });
     let config = RuntimeConfig::parse(&format!(
         r#"{{
@@ -350,6 +358,24 @@ async fn mixed_http_branch_relays_tiny_fixed_length_post_body() {
     let mut body = [0_u8; 2];
     client.read_exact(&mut body).await.expect("response body");
     assert_eq!(&body, b"OK");
+
+    client
+        .write_all(
+            format!("GET http://127.0.0.1:{origin_port}/after HTTP/1.1\r\nHost: ignored\r\n\r\n")
+                .as_bytes(),
+        )
+        .await
+        .expect("next request");
+    let response = read_http_head(&mut client).await;
+    assert!(String::from_utf8_lossy(&response)
+        .to_ascii_lowercase()
+        .contains("transfer-encoding: chunked\r\n"));
+    let mut body = [0_u8; 14];
+    client
+        .read_exact(&mut body)
+        .await
+        .expect("chunked response body");
+    assert_eq!(&body, b"4\r\npong\r\n0\r\n\r\n");
 
     engine_handle.shutdown().await.expect("shutdown engine");
     origin_task.await.expect("origin task");


### PR DESCRIPTION
## Summary

- upgrade the configured proxy-outbound HTTP integration case from GET to an absolute-form POST with a non-empty body
- assert the SOCKS5-routed origin receives the method, rewritten target, `Content-Length`, and body exactly once
- assert hop-by-hop `Proxy-Connection` is removed and a complete chunked response is relayed through the non-DIRECT path
- extend the Mixed regression to split the POST head/body across writes, verify the complete fixed-length response, then issue a second request on the same client-proxy connection and verify a complete chunked response

The data-plane fixes already present on `develop` (`28fafa72` and `82d73706`) pass these stricter acceptance cases. This PR closes the remaining regression-evidence gap for #24 without changing runtime behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p http --locked --jobs 1 -- --test-threads=1` — 10 passed
- `cargo test -p zero-proxy --all-features --locked --test http --test mixed --jobs 1 -- --test-threads=1` — 15 passed
- `cargo test -p zero-proxy --all-features --locked --jobs 1 -- --test-threads=1` — all normal unit/integration tests passed; external binary interop tests retained their declared ignore conditions

Closes #24
Part of #52