### PR TITLE
fix(stack): retry TUN TCP control packets under backpressure

### DIFF
--- a/crates/stack/src/tcp.rs
+++ b/crates/stack/src/tcp.rs
@@ -35,8 +35,10 @@ use zero_traits::{SocketAddress, TcpStack};
 
 use crate::packet::{self, tcp_flags, Endpoint, ParsedTcp};
 
+mod control;
 mod receive;
 mod retransmission;
+use control::TcpControlPackets;
 use receive::TcpReceiveBuffer;
 use retransmission::{RetransmissionResult, RetransmissionWait, TcpSendControl};
 
@@ -189,7 +191,7 @@ pub struct UserTcpStream {
 struct TcpRead {
     receive_buffer: Arc<TcpReceiveBuffer>,
     send_control: Arc<TcpSendControl>,
-    outbound: mpsc::Sender<Vec<u8>>,
+    control_packets: TcpControlPackets,
     src_ip: IpAddr,
     dst_ip: IpAddr,
     sport: u16,
@@ -201,6 +203,7 @@ struct TcpRead {
 struct TcpWrite {
     /// Outbound packet channel (→ TUN writer task).
     outbound: mpsc::Sender<Vec<u8>>,
+    control_packets: TcpControlPackets,
     /// Our IP (server side).
     src_ip: IpAddr,
     /// Application IP (client side).
@@ -224,10 +227,17 @@ type OutboundReservation = Pin<
 >;
 
 impl TcpWrite {
-    fn new(outbound: mpsc::Sender<Vec<u8>>, conn_key: &ConnKey, conn: &Conn, mss: u16) -> Self {
+    fn new(
+        outbound: mpsc::Sender<Vec<u8>>,
+        control_packets: TcpControlPackets,
+        conn_key: &ConnKey,
+        conn: &Conn,
+        mss: u16,
+    ) -> Self {
         let rev = key_reversed(conn_key);
         let value = Self {
             outbound,
+            control_packets,
             src_ip: rev.0,
             dst_ip: rev.2,
             sport: rev.1,
@@ -294,7 +304,7 @@ impl UserTcpStream {
             read: StdMutex::new(TcpRead {
                 receive_buffer,
                 send_control,
-                outbound: write.outbound.clone(),
+                control_packets: write.control_packets.clone(),
                 src_ip: write.src_ip,
                 dst_ip: write.dst_ip,
                 sport: write.sport,
@@ -326,7 +336,7 @@ impl Drop for UserTcpStream {
             w.receive_buffer.window(),
             &[],
         );
-        if w.outbound.try_send(reset).is_ok() {
+        if w.control_packets.try_send(reset) {
             w.fin_sent.store(true, Ordering::Release);
         }
         w.send_control.stop();
@@ -360,9 +370,7 @@ impl AsyncRead for UserTcpStream {
                 read.receive_buffer.window(),
                 &[],
             );
-            if let Err(error) = read.outbound.try_send(update) {
-                warn!(%error, "TCP receive-window update could not be queued");
-            }
+            read.control_packets.try_send(update);
         }
         match result {
             Poll::Ready(()) => Poll::Ready(Ok(())),
@@ -503,26 +511,27 @@ pub struct UserTcpStack {
     accept_tx: mpsc::Sender<ReadyConn>,
     accept_rx: Mutex<mpsc::Receiver<ReadyConn>>,
     outbound: mpsc::Sender<Vec<u8>>,
+    control_packets: TcpControlPackets,
     mss: u16,
 }
 
 impl UserTcpStack {
     pub(crate) fn new(outbound: mpsc::Sender<Vec<u8>>, mss: u16) -> Self {
         let (tx, rx) = mpsc::channel::<ReadyConn>(64);
+        let control_packets = TcpControlPackets::new(outbound.clone());
         Self {
             connections: Arc::new(Mutex::new(HashMap::new())),
             accept_tx: tx,
             accept_rx: Mutex::new(rx),
             outbound,
+            control_packets,
             mss,
         }
     }
 
-    /// Send a response packet.  Silently drops if the channel is full.
+    /// Queue a control response without awaiting while connection state is locked.
     fn send_response(&self, pkt: Vec<u8>) {
-        if let Err(e) = self.outbound.try_send(pkt) {
-            warn!("tcp stack outbound full: {e}");
-        }
+        self.control_packets.try_send(pkt);
     }
 
     /// Remove connections idle beyond `timeout`.
@@ -592,6 +601,7 @@ impl TcpStack for UserTcpStack {
     type Connection = UserTcpStream;
 
     async fn feed(&self, packet: &[u8]) {
+        self.control_packets.ensure_worker();
         if packet::ip_protocol(packet) != Some(packet::IPPROTO_TCP) {
             return;
         }
@@ -645,6 +655,7 @@ impl TcpStack for UserTcpStack {
 
                     let write = TcpWrite::new(
                         self.outbound.clone(),
+                        self.control_packets.clone(),
                         &key,
                         conn,
                         conn.peer_mss.min(self.mss),

--- a/crates/stack/src/tcp/control.rs
+++ b/crates/stack/src/tcp/control.rs
@@ -1,0 +1,166 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{mpsc, watch};
+use tracing::warn;
+
+const TCP_CONTROL_QUEUE_CAPACITY: usize = 256;
+
+#[derive(Clone)]
+pub(super) struct TcpControlPackets {
+    sender: mpsc::Sender<Vec<u8>>,
+    outbound: mpsc::Sender<Vec<u8>>,
+    pending: Arc<AtomicUsize>,
+    dropped: Arc<AtomicU64>,
+    closed: Arc<AtomicBool>,
+    send_gate: Arc<Mutex<()>>,
+    _lifetime: Arc<ControlLifetime>,
+    worker: Arc<Mutex<Option<ControlWorker>>>,
+}
+
+struct ControlLifetime {
+    shutdown: watch::Sender<bool>,
+}
+
+impl Drop for ControlLifetime {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(true);
+    }
+}
+
+struct ControlWorker {
+    receiver: mpsc::Receiver<Vec<u8>>,
+    outbound: mpsc::Sender<Vec<u8>>,
+    pending: Arc<AtomicUsize>,
+    dropped: Arc<AtomicU64>,
+    closed: Arc<AtomicBool>,
+    shutdown: watch::Receiver<bool>,
+}
+
+impl TcpControlPackets {
+    pub(super) fn new(outbound: mpsc::Sender<Vec<u8>>) -> Self {
+        let (sender, receiver) = mpsc::channel(TCP_CONTROL_QUEUE_CAPACITY);
+        let pending = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicU64::new(0));
+        let closed = Arc::new(AtomicBool::new(false));
+        let (shutdown, shutdown_rx) = watch::channel(false);
+        Self {
+            sender,
+            outbound: outbound.clone(),
+            pending: Arc::clone(&pending),
+            dropped: Arc::clone(&dropped),
+            closed: Arc::clone(&closed),
+            send_gate: Arc::new(Mutex::new(())),
+            _lifetime: Arc::new(ControlLifetime { shutdown }),
+            worker: Arc::new(Mutex::new(Some(ControlWorker {
+                receiver,
+                outbound,
+                pending,
+                dropped,
+                closed,
+                shutdown: shutdown_rx,
+            }))),
+        }
+    }
+
+    pub(super) fn ensure_worker(&self) {
+        let worker = self
+            .worker
+            .lock()
+            .expect("TCP control worker lock poisoned")
+            .take();
+        if let Some(worker) = worker {
+            tokio::spawn(run_control_worker(worker));
+        }
+    }
+
+    pub(super) fn try_send(&self, packet: Vec<u8>) -> bool {
+        let _gate = self
+            .send_gate
+            .lock()
+            .expect("TCP control send gate poisoned");
+        if self.closed.load(Ordering::Acquire) {
+            return false;
+        }
+        if self.pending.load(Ordering::Acquire) == 0 {
+            match self.outbound.try_send(packet) {
+                Ok(()) => return true,
+                Err(mpsc::error::TrySendError::Full(packet)) => {
+                    return self.enqueue(packet);
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    self.report_closed("TCP control packet transport is closed");
+                    return false;
+                }
+            }
+        }
+        self.enqueue(packet)
+    }
+
+    fn enqueue(&self, packet: Vec<u8>) -> bool {
+        self.pending.fetch_add(1, Ordering::AcqRel);
+        match self.sender.try_send(packet) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.pending.fetch_sub(1, Ordering::AcqRel);
+                if self.dropped.fetch_add(1, Ordering::AcqRel) == 0 {
+                    warn!(
+                        capacity = TCP_CONTROL_QUEUE_CAPACITY,
+                        "TCP control packet retry queue is full; coalescing further drop warnings"
+                    );
+                }
+                false
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.pending.fetch_sub(1, Ordering::AcqRel);
+                self.report_closed("TCP control packet retry queue is closed");
+                false
+            }
+        }
+    }
+
+    fn report_closed(&self, message: &'static str) {
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            warn!(dropped = self.dropped.load(Ordering::Acquire), "{message}");
+        }
+    }
+}
+
+async fn run_control_worker(mut worker: ControlWorker) {
+    loop {
+        let packet = tokio::select! {
+            biased;
+            _ = worker.shutdown.changed() => return,
+            packet = worker.receiver.recv() => match packet {
+                Some(packet) => packet,
+                None => return,
+            },
+        };
+        let send_result = tokio::select! {
+            biased;
+            _ = worker.shutdown.changed() => return,
+            result = worker.outbound.send(packet) => result,
+        };
+        if send_result.is_err() {
+            worker.receiver.close();
+            let first_close = !worker.closed.swap(true, Ordering::AcqRel);
+            worker.pending.store(0, Ordering::Release);
+            if first_close {
+                warn!(
+                    dropped = worker.dropped.load(Ordering::Acquire),
+                    "TCP control packet transport closed with queued responses"
+                );
+            }
+            return;
+        }
+        if worker.pending.fetch_sub(1, Ordering::AcqRel) == 1 {
+            let dropped = worker.dropped.swap(0, Ordering::AcqRel);
+            if dropped > 0 {
+                warn!(
+                    dropped,
+                    "TCP control packet retry queue recovered after saturation"
+                );
+            }
+        }
+    }
+}

--- a/crates/stack/tests/tcp_accept_identity.rs
+++ b/crates/stack/tests/tcp_accept_identity.rs
@@ -288,7 +288,7 @@ async fn lost_syn_ack_is_retransmitted_by_the_rto_timer() {
 }
 
 #[tokio::test]
-async fn dropping_stack_releases_retransmission_workers_and_packet_channel() {
+async fn dropping_stack_releases_retransmission_and_control_workers() {
     let (outbound_tx, mut outbound_rx) = mpsc::channel(16);
     let stack = UserNetworkStack::new(outbound_tx, 1_440);
     let (tcp, udp) = stack.into_parts();
@@ -480,6 +480,191 @@ async fn outbound_writer_waits_for_tun_queue_capacity() {
             .expect("parse outbound data")
             .payload,
         &[7]
+    );
+}
+
+#[tokio::test]
+async fn dropping_stack_cancels_control_worker_blocked_on_full_outbound() {
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    let stack = UserNetworkStack::new(outbound_tx, 1_440);
+    let (tcp, udp) = stack.into_parts();
+    let client_sequence = 7_875;
+    let server_sequence = establish(&tcp, &mut outbound_rx, client_sequence).await;
+    let (mut stream, _, _) = tcp.accept().await.expect("accepted connection");
+
+    stream.write_all(&[7]).await.expect("fill TUN queue");
+    tcp.feed(&client_packet_with_payload(
+        packet::tcp_flags::PSH | packet::tcp_flags::ACK,
+        client_sequence + 1,
+        server_sequence + 2,
+        &[1],
+    ))
+    .await;
+    drop(stream);
+    drop(tcp);
+    drop(udp);
+    tokio::task::yield_now().await;
+
+    let data = outbound_rx.recv().await.expect("queued data packet");
+    assert_eq!(packet::parse_tcp(&data).expect("parse data").payload, &[7]);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), outbound_rx.recv())
+            .await
+            .expect("blocked control worker retained packet channel")
+            .is_none(),
+        "control worker emitted queued packets after stack shutdown"
+    );
+}
+
+#[tokio::test]
+async fn control_ack_waits_for_tun_queue_capacity_and_preserves_fifo() {
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    let stack = UserNetworkStack::new(outbound_tx, 1_440);
+    let (tcp, _udp) = stack.into_parts();
+    let client_sequence = 10_650;
+    let server_sequence = establish(&tcp, &mut outbound_rx, client_sequence).await;
+    let (mut stream, _, _) = tcp.accept().await.expect("accepted connection");
+
+    stream.write_all(&[7]).await.expect("fill TUN queue");
+    let server_ack = server_sequence + 2;
+    tcp.feed(&client_packet_with_payload(
+        packet::tcp_flags::PSH | packet::tcp_flags::ACK,
+        client_sequence + 1,
+        server_ack,
+        b"a",
+    ))
+    .await;
+    tcp.feed(&client_packet_with_payload(
+        packet::tcp_flags::PSH | packet::tcp_flags::ACK,
+        client_sequence + 2,
+        server_ack,
+        b"b",
+    ))
+    .await;
+
+    let data = outbound_rx.recv().await.expect("queued data packet");
+    assert_eq!(packet::parse_tcp(&data).expect("parse data").payload, &[7]);
+    let first = tokio::time::timeout(Duration::from_millis(100), outbound_rx.recv())
+        .await
+        .expect("first ACK was not retried")
+        .expect("control worker closed");
+    let second = tokio::time::timeout(Duration::from_millis(100), outbound_rx.recv())
+        .await
+        .expect("second ACK was not retried")
+        .expect("control worker closed");
+    assert_eq!(
+        packet::parse_tcp(&first).expect("parse first ACK").ack,
+        client_sequence + 2
+    );
+    assert_eq!(
+        packet::parse_tcp(&second).expect("parse second ACK").ack,
+        client_sequence + 3
+    );
+}
+
+#[tokio::test]
+async fn receive_window_update_waits_for_tun_queue_capacity() {
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    let stack = UserNetworkStack::new(outbound_tx, 1_440);
+    let (tcp, _udp) = stack.into_parts();
+    let client_sequence = 10_675;
+    let server_sequence = establish(&tcp, &mut outbound_rx, client_sequence).await;
+    let (mut stream, _, _) = tcp.accept().await.expect("accepted connection");
+
+    let mut sequence = client_sequence + 1;
+    let mut remaining = u16::MAX as usize;
+    while remaining > 0 {
+        let count = remaining.min(1_024);
+        tcp.feed(&client_packet_with_payload(
+            packet::tcp_flags::PSH | packet::tcp_flags::ACK,
+            sequence,
+            server_sequence + 1,
+            &vec![7; count],
+        ))
+        .await;
+        sequence = sequence.wrapping_add(count as u32);
+        remaining -= count;
+        let acknowledgement = outbound_rx.recv().await.expect("payload ACK");
+        if remaining == 0 {
+            assert_eq!(packet::tcp_window(&acknowledgement), Some(0));
+        }
+    }
+
+    stream.write_all(&[9]).await.expect("fill TUN queue");
+    tcp.feed(&client_packet(
+        packet::tcp_flags::ACK,
+        sequence,
+        server_sequence + 2,
+    ))
+    .await;
+    let mut byte = [0_u8; 1];
+    stream
+        .read_exact(&mut byte)
+        .await
+        .expect("reopen receive window");
+
+    let data = outbound_rx.recv().await.expect("queued data packet");
+    assert_eq!(packet::parse_tcp(&data).expect("parse data").payload, &[9]);
+    let update = tokio::time::timeout(Duration::from_millis(100), outbound_rx.recv())
+        .await
+        .expect("receive-window update was not retried")
+        .expect("control worker closed");
+    assert_eq!(packet::tcp_window(&update), Some(1));
+}
+
+#[tokio::test]
+async fn saturated_control_retry_queue_stays_bounded_and_recovers() {
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    let stack = UserNetworkStack::new(outbound_tx, 1_440);
+    let (tcp, _udp) = stack.into_parts();
+    let client_sequence = 10_690;
+    let server_sequence = establish(&tcp, &mut outbound_rx, client_sequence).await;
+    let (mut stream, _, _) = tcp.accept().await.expect("accepted connection");
+
+    stream.write_all(&[8]).await.expect("fill TUN queue");
+    let server_ack = server_sequence + 2;
+    let mut sequence = client_sequence + 1;
+    for _ in 0..300 {
+        tcp.feed(&client_packet_with_payload(
+            packet::tcp_flags::PSH | packet::tcp_flags::ACK,
+            sequence,
+            server_ack,
+            &[1],
+        ))
+        .await;
+        sequence += 1;
+    }
+
+    let data = outbound_rx.recv().await.expect("queued data packet");
+    assert_eq!(packet::parse_tcp(&data).expect("parse data").payload, &[8]);
+    let mut delivered = 0;
+    while let Ok(Some(_)) =
+        tokio::time::timeout(Duration::from_millis(20), outbound_rx.recv()).await
+    {
+        delivered += 1;
+    }
+    assert!(delivered > 0, "control retry queue did not recover");
+    assert!(
+        delivered <= 257,
+        "bounded control queue delivered {delivered} retained packets"
+    );
+
+    tcp.feed(&client_packet_with_payload(
+        packet::tcp_flags::PSH | packet::tcp_flags::ACK,
+        sequence - 1,
+        server_ack,
+        &[1],
+    ))
+    .await;
+    let cumulative = tokio::time::timeout(Duration::from_millis(100), outbound_rx.recv())
+        .await
+        .expect("client retransmission did not recover the saturated queue")
+        .expect("control worker closed");
+    assert_eq!(
+        packet::parse_tcp(&cumulative)
+            .expect("parse cumulative ACK")
+            .ack,
+        sequence
     );
 }
 


### PR DESCRIPTION
## Summary

- add one bounded FIFO retry queue per TCP stack for TUN TCP control packets
- keep the direct fast path when the outbound queue is clear, while retrying ACK, receive-window update, FIN ACK, and RST packets after temporary queue pressure
- preserve FIFO ordering with a single lazy worker, without per-packet tasks or lock-held awaits
- bound retained control packets to 256 queued packets plus one in-flight packet
- coalesce saturation warnings and report transport closure once
- cancel a worker blocked on outbound capacity when the final stack/stream control handle is dropped

## Validation

- `cargo test -p zero-stack --test tcp_accept_identity --locked --jobs 1 -- --test-threads=1` — 26 passed
- `cargo test -p zero-stack --locked --jobs 1 -- --test-threads=1` — passed
- `cargo clippy -p zero-stack --all-targets --locked --jobs 1 -- -D warnings` — passed
- `cargo check --workspace --all-features --locked --jobs 1` — passed
- full `cargo test --workspace --all-features --locked --jobs 1 -- --test-threads=1` passed during implementation; the final lifecycle/logging refinement was revalidated by the complete zero-stack suite and workspace all-features check, with PR CI as the authoritative final gate

Closes #65
Part of #32
Part of #52