### PR TITLE
fix(proxy): support IPv6-only direct UDP egress

### DIFF
--- a/crates/proxy/src/runtime/udp_socket.rs
+++ b/crates/proxy/src/runtime/udp_socket.rs
@@ -54,31 +54,59 @@ impl DirectUdpSockets {
         preferred_port: Option<u16>,
     ) -> Result<Self, EngineError> {
         let generation = services.egress_generation();
-        let ipv4 = services
-            .bind_direct_datagram_socket(
-                "0.0.0.0:0".parse().expect("valid IPv4 wildcard"),
-                preferred_port,
-            )
-            .await?;
-        let ipv6 = services
-            .bind_direct_datagram_socket(
-                "[::]:0".parse().expect("valid IPv6 wildcard"),
-                preferred_port,
-            )
-            .await
-            .map_err(|error| {
-                tracing::debug!(error = %error, "IPv6 direct UDP socket is unavailable");
-                error
+        Self::bind_with(generation, preferred_port, |peer, preferred_port| {
+            services.bind_direct_datagram_socket(peer, preferred_port)
+        })
+        .await
+    }
+
+    async fn bind_with<F, Fut>(
+        generation: u64,
+        preferred_port: Option<u16>,
+        mut bind: F,
+    ) -> Result<Self, EngineError>
+    where
+        F: FnMut(SocketAddr, Option<u16>) -> Fut,
+        Fut: std::future::Future<Output = Result<TokioDatagramSocket, EngineError>>,
+    {
+        let ipv4 = bind(
+            "0.0.0.0:0".parse().expect("valid IPv4 wildcard"),
+            preferred_port,
+        )
+        .await;
+        let ipv6 = bind(
+            "[::]:0".parse().expect("valid IPv6 wildcard"),
+            preferred_port,
+        )
+        .await;
+        let outcomes = collect_family_bind_outcomes(ipv4, ipv6);
+        if outcomes.available.is_empty() {
+            let failures = outcomes
+                .failures
+                .iter()
+                .map(|(ipv6, error)| format!("{}: {error}", family_name(*ipv6)))
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(EngineError::Io(std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                format!("no direct UDP address family is available ({failures})"),
+            )));
+        }
+        for (ipv6, error) in &outcomes.failures {
+            tracing::debug!(
+                address_family = family_name(*ipv6),
+                error = %error,
+                "direct UDP socket family is unavailable"
+            );
+        }
+        let sockets = outcomes
+            .available
+            .into_iter()
+            .map(|(ipv6, socket)| {
+                log_direct_socket(family_name(ipv6), &socket);
+                DirectUdpSocket::new(socket, ipv6)
             })
-            .ok();
-        log_direct_socket("IPv4", &ipv4);
-        if let Some(ipv6) = ipv6.as_ref() {
-            log_direct_socket("IPv6", ipv6);
-        }
-        let mut sockets = vec![DirectUdpSocket::new(ipv4, false)];
-        if let Some(ipv6) = ipv6 {
-            sockets.push(DirectUdpSocket::new(ipv6, true));
-        }
+            .collect();
         Ok(Self {
             sockets,
             preferred_port,
@@ -124,13 +152,15 @@ impl DirectUdpSockets {
         logical_target: &Address,
         candidates: &[SocketAddr],
     ) -> Result<SocketAddr, EngineError> {
+        let ipv4_available = self.sockets.iter().any(|socket| !socket.binding.ipv6);
         let ipv6_available = self.sockets.iter().any(|socket| socket.binding.ipv6);
-        select_stable_udp_target(logical_target, candidates, ipv6_available).ok_or_else(|| {
-            EngineError::Io(std::io::Error::new(
-                std::io::ErrorKind::AddrNotAvailable,
-                "no usable direct UDP target address",
-            ))
-        })
+        select_stable_udp_target(logical_target, candidates, ipv4_available, ipv6_available)
+            .ok_or_else(|| {
+                EngineError::Io(std::io::Error::new(
+                    std::io::ErrorKind::AddrNotAvailable,
+                    "no usable direct UDP target address",
+                ))
+            })
     }
 
     pub(crate) fn generation(&self) -> u64 {
@@ -197,19 +227,57 @@ impl DirectUdpSockets {
 fn select_stable_udp_target(
     logical_target: &Address,
     candidates: &[SocketAddr],
+    ipv4_available: bool,
     ipv6_available: bool,
 ) -> Option<SocketAddr> {
     let preferred_ipv6 = candidates
         .iter()
-        .find(|candidate| candidate.is_ipv4() || ipv6_available)
+        .find(|candidate| {
+            (candidate.is_ipv4() && ipv4_available) || (candidate.is_ipv6() && ipv6_available)
+        })
         .map(SocketAddr::is_ipv6)?;
 
     candidates
         .iter()
         .copied()
-        .filter(|candidate| candidate.is_ipv4() || ipv6_available)
+        .filter(|candidate| {
+            (candidate.is_ipv4() && ipv4_available) || (candidate.is_ipv6() && ipv6_available)
+        })
         .filter(|candidate| candidate.is_ipv6() == preferred_ipv6)
         .max_by_key(|candidate| udp_candidate_score(logical_target, *candidate))
+}
+
+#[cfg(feature = "udp-runtime")]
+struct FamilyBindOutcomes<T, E> {
+    available: Vec<(bool, T)>,
+    failures: Vec<(bool, E)>,
+}
+
+#[cfg(feature = "udp-runtime")]
+fn collect_family_bind_outcomes<T, E>(
+    ipv4: Result<T, E>,
+    ipv6: Result<T, E>,
+) -> FamilyBindOutcomes<T, E> {
+    let mut outcomes = FamilyBindOutcomes {
+        available: Vec::with_capacity(2),
+        failures: Vec::with_capacity(2),
+    };
+    for (ipv6, result) in [(false, ipv4), (true, ipv6)] {
+        match result {
+            Ok(value) => outcomes.available.push((ipv6, value)),
+            Err(error) => outcomes.failures.push((ipv6, error)),
+        }
+    }
+    outcomes
+}
+
+#[cfg(feature = "udp-runtime")]
+fn family_name(ipv6: bool) -> &'static str {
+    if ipv6 {
+        "IPv6"
+    } else {
+        "IPv4"
+    }
 }
 
 #[cfg(feature = "udp-runtime")]

--- a/crates/proxy/src/runtime/udp_socket/tests.rs
+++ b/crates/proxy/src/runtime/udp_socket/tests.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use zero_core::Address;
 
-use super::{select_stable_udp_target, DirectUdpSocketBinding};
+use super::{collect_family_bind_outcomes, select_stable_udp_target, DirectUdpSocketBinding};
 
 #[test]
 fn udp_target_selection_is_stable_across_same_family_answer_reordering() {
@@ -18,24 +18,90 @@ fn udp_target_selection_is_stable_across_same_family_answer_reordering() {
     .collect();
     let reordered = vec![first[2], first[0], first[1], first[3]];
 
-    let selected = select_stable_udp_target(&target, &first, true).unwrap();
+    let selected = select_stable_udp_target(&target, &first, true, true).unwrap();
     assert!(selected.is_ipv4());
     assert_eq!(
-        select_stable_udp_target(&target, &reordered, true),
+        select_stable_udp_target(&target, &reordered, true, true),
         Some(selected)
     );
 }
 
 #[test]
 fn udp_target_selection_falls_back_to_an_available_family() {
-    let target = Address::Domain("ipv6-only.example".to_owned());
-    let candidates = ["[2001:db8::10]:443".parse().unwrap()];
+    let target = Address::Domain("single-family.example".to_owned());
+    let ipv4 = "192.0.2.10:443".parse().unwrap();
+    let ipv6 = "[2001:db8::10]:443".parse().unwrap();
+    let candidates = [ipv4, ipv6];
 
-    assert_eq!(select_stable_udp_target(&target, &candidates, false), None);
     assert_eq!(
-        select_stable_udp_target(&target, &candidates, true),
-        Some(candidates[0])
+        select_stable_udp_target(&target, &candidates, false, true),
+        Some(ipv6)
     );
+    assert_eq!(
+        select_stable_udp_target(&target, &candidates, true, false),
+        Some(ipv4)
+    );
+    assert_eq!(
+        select_stable_udp_target(&target, &candidates, false, false),
+        None
+    );
+}
+
+#[test]
+fn direct_udp_family_binding_accepts_either_family_and_retains_both_failures() {
+    let ipv6_only = collect_family_bind_outcomes::<_, &str>(Err("IPv4 unavailable"), Ok(6));
+    assert_eq!(ipv6_only.available, vec![(true, 6)]);
+    assert_eq!(ipv6_only.failures, vec![(false, "IPv4 unavailable")]);
+
+    let ipv4_only = collect_family_bind_outcomes::<_, &str>(Ok(4), Err("IPv6 unavailable"));
+    assert_eq!(ipv4_only.available, vec![(false, 4)]);
+    assert_eq!(ipv4_only.failures, vec![(true, "IPv6 unavailable")]);
+
+    let unavailable =
+        collect_family_bind_outcomes::<u8, _>(Err("IPv4 unavailable"), Err("IPv6 unavailable"));
+    assert!(unavailable.available.is_empty());
+    assert_eq!(
+        unavailable.failures,
+        vec![(false, "IPv4 unavailable"), (true, "IPv6 unavailable")]
+    );
+}
+
+#[tokio::test]
+async fn direct_udp_socket_set_builds_with_ipv6_only_and_reports_dual_failure() {
+    let sockets = super::DirectUdpSockets::bind_with(7, None, |peer, _| async move {
+        if peer.is_ipv4() {
+            Err(zero_engine::EngineError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "IPv4 egress unavailable",
+            )))
+        } else {
+            zero_platform_tokio::TokioDatagramSocket::bind_for_peer_on(peer, None)
+                .await
+                .map_err(zero_engine::EngineError::Io)
+        }
+    })
+    .await
+    .expect("an IPv6 socket is sufficient for a direct UDP socket set");
+
+    assert_eq!(sockets.generation(), 7);
+    assert_eq!(sockets.sockets.len(), 1);
+    assert!(sockets.sockets[0].binding.ipv6);
+
+    let error = match super::DirectUdpSockets::bind_with(8, None, |peer, _| async move {
+        let family = if peer.is_ipv6() { "IPv6" } else { "IPv4" };
+        Err(zero_engine::EngineError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            format!("{family} egress unavailable"),
+        )))
+    })
+    .await
+    {
+        Ok(_) => panic!("both unavailable families must fail deterministically"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(message.contains("IPv4 egress unavailable"), "{message}");
+    assert!(message.contains("IPv6 egress unavailable"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- bind IPv4 and IPv6 direct UDP sockets independently
- keep strict fail-closed behavior for each unavailable egress family while allowing IPv4-only or IPv6-only operation
- select direct UDP targets only from address families backed by an available socket
- retain both family-specific errors when neither family can be bound
- reuse the same symmetric bind path when the egress generation changes

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-features --locked --jobs 1`
- `cargo test -p zero-proxy --lib --all-features --locked --jobs 1 -- --test-threads=1` (144 passed)
- `cargo test -p zero-proxy --all-features --locked --jobs 1 -- --test-threads=1`
- `cargo clippy -p zero-proxy --all-targets --all-features --no-deps --locked --jobs 1 -- -D warnings`

Workspace-wide strict clippy remains blocked by two pre-existing Windows `zero-tun` warnings outside this diff.

Closes #67
Part of #25
Part of #52