### PR TITLE
fix(tun): correct macOS PF owner rule order

### DIFF
--- a/crates/tun/src/route/leak/macos.rs
+++ b/crates/tun/src/route/leak/macos.rs
@@ -172,7 +172,7 @@ fn flush_anchor(anchor: &str) -> io::Result<()> {
 fn policy_rules(tun_name: &str, protected: &[IpNet], excluded: &[IpAddr]) -> String {
     let uid = unsafe { libc::geteuid() };
     let mut rules = format!(
-        "pass out quick on lo0 all\npass out quick on {tun_name} all\npass out quick user {uid} all\n"
+        "pass out quick on lo0 all\npass out quick on {tun_name} all\npass out quick all user {uid}\n"
     );
     for address in excluded {
         rules.push_str(&format!("pass out quick to {address}\n"));
@@ -201,7 +201,10 @@ mod tests {
             &["203.0.113.0/24".parse().unwrap()],
             &["192.0.2.1".parse().unwrap()],
         );
+        let uid = unsafe { libc::geteuid() };
         assert!(rules.contains("pass out quick on utun8 all"));
+        assert!(rules.contains(&format!("pass out quick all user {uid}\n")));
+        assert!(!rules.contains("pass out quick user"));
         assert!(rules.contains("pass out quick to 192.0.2.1"));
         assert!(rules.ends_with("block drop out quick to 203.0.113.0/24\n"));
     }


### PR DESCRIPTION
## Summary

- emit the macOS strict-route owner bypass as `pass out quick all user <uid>`, matching PF's accepted filter-option order
- add an exact regression assertion and reject the previously emitted `quick user ... all` form
- preserve anchor isolation, rule precedence, protected-prefix blocking and cleanup behavior

## Why

Hosted macOS Privileged TUN E2E run 33261406691 failed during `strict_route=true` startup with:

```text
stdin:3: syntax error
pfctl: Syntax error in config file: pf rules not loaded
```

The rejected third line was generated before any TUN smoke or direct UDP workload could run.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p zero-tun --locked --jobs 1` (26 unit tests and 7 integration tests passed; one privileged Windows test ignored)
- `git diff --check`
- hosted macOS privileged execution is the authoritative native parser validation

Closes #71
Part of #25
Part of #52