### PR TITLE
fix(dns): preserve Fake-IP state across config rollback

### DIFF
--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -90,6 +90,7 @@ impl DnsQueryRole {
 /// hot-reloaded without restarting the proxy.
 pub struct DnsSystem {
     inner: std::sync::RwLock<DnsSystemInner>,
+    prepared_reload: std::sync::Mutex<Option<PreparedDnsReload>>,
     egress_interface: zero_platform_tokio::EgressInterfaceControl,
     fake_ip_state_path: Option<PathBuf>,
     fake_ip_state_lease: std::sync::Mutex<Option<Arc<fake_ip::StateLease>>>,
@@ -123,6 +124,12 @@ enum DnsSystemInner {
         reverse_mapping: Option<RealIpReverseIndex>,
         policy: Box<DnsPolicyConfig>,
     },
+}
+
+#[derive(Clone)]
+struct PreparedDnsReload {
+    config: Option<DnsConfig>,
+    dispatch: Option<zero_router::DomainDispatcher<String>>,
 }
 
 #[derive(Clone)]
@@ -205,6 +212,7 @@ impl DnsSystem {
         )?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            prepared_reload: std::sync::Mutex::new(None),
             egress_interface,
             fake_ip_state_path,
             fake_ip_state_lease: std::sync::Mutex::new(fake_ip_state_lease),
@@ -292,9 +300,39 @@ impl DnsSystem {
         config: Option<&DnsConfig>,
         dispatch: Option<zero_router::DomainDispatcher<String>>,
     ) -> io::Result<()> {
+        self.prepare_reload_with_dispatch(config, dispatch)?;
+        let result = self.commit_prepared_reload();
+        if result.is_err() {
+            self.discard_prepared_reload();
+        }
+        result
+    }
+
+    /// Validate and stage a DNS configuration without making it observable or
+    /// replacing the committed Fake-IP journal.
+    ///
+    /// The proxy uses this boundary while the remaining TUN, listener, and
+    /// application components reconcile. It must call
+    /// [`Self::commit_prepared_reload`] only after the complete configuration
+    /// transaction succeeds, or [`Self::discard_prepared_reload`] on failure.
+    pub fn prepare_reload_with_dispatch(
+        &self,
+        config: Option<&DnsConfig>,
+        dispatch: Option<zero_router::DomainDispatcher<String>>,
+    ) -> io::Result<()> {
+        let mut prepared = self
+            .prepared_reload
+            .lock()
+            .expect("DNS prepared reload lock poisoned");
+        if prepared.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "another DNS reload is already prepared",
+            ));
+        }
         let previous_fake_ip = self.snapshot_fake_ip();
         let previous_reverse_mapping = self.snapshot_reverse_mapping();
-        let fake_ip_state_lease = if config.and_then(DnsConfig::fake_ip).is_some() {
+        if config.and_then(DnsConfig::fake_ip).is_some() {
             let mut guard = self
                 .fake_ip_state_lease
                 .lock()
@@ -306,21 +344,73 @@ impl DnsSystem {
                     .map(|path| fake_ip::StateLease::acquire(path.clone()))
                     .transpose()?;
             }
-            guard.clone()
+        }
+
+        // Build once without persistence to validate every candidate backend
+        // and allocator field. Incompatible Fake-IP state is intentionally not
+        // opened here because `open` replaces the durable journal.
+        Self::build_inner(
+            config,
+            dispatch.clone(),
+            &self.egress_interface,
+            previous_fake_ip,
+            previous_reverse_mapping,
+            None,
+        )?;
+        *prepared = Some(PreparedDnsReload {
+            config: config.cloned(),
+            dispatch,
+        });
+        Ok(())
+    }
+
+    /// Commit the staged DNS configuration atomically.
+    ///
+    /// Persistent Fake-IP state is opened only at this point, so a candidate
+    /// that is later rejected cannot erase mappings from the last committed
+    /// configuration.
+    pub fn commit_prepared_reload(&self) -> io::Result<()> {
+        let prepared = self
+            .prepared_reload
+            .lock()
+            .expect("DNS prepared reload lock poisoned")
+            .clone()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no DNS reload is prepared"))?;
+        let previous_fake_ip = self.snapshot_fake_ip();
+        let previous_reverse_mapping = self.snapshot_reverse_mapping();
+        let fake_ip_state_lease = if prepared
+            .config
+            .as_ref()
+            .and_then(DnsConfig::fake_ip)
+            .is_some()
+        {
+            self.fake_ip_state_lease
+                .lock()
+                .expect("Fake-IP state lease lock poisoned")
+                .clone()
         } else {
             None
         };
         let new_inner = Self::build_inner(
-            config,
-            dispatch,
+            prepared.config.as_ref(),
+            prepared.dispatch,
             &self.egress_interface,
             previous_fake_ip,
             previous_reverse_mapping,
             fake_ip_state_lease,
         )?;
-        let mut guard = self.inner.write().expect("dns system lock poisoned");
-        *guard = new_inner;
+        *self.inner.write().expect("dns system lock poisoned") = new_inner;
+        self.discard_prepared_reload();
         Ok(())
+    }
+
+    /// Drop a staged DNS candidate while retaining the committed resolver and
+    /// Fake-IP journal unchanged.
+    pub fn discard_prepared_reload(&self) {
+        self.prepared_reload
+            .lock()
+            .expect("DNS prepared reload lock poisoned")
+            .take();
     }
 
     /// Install the runtime bridge used by DNS servers that specify a detour.

--- a/crates/dns/tests/fake_ip_persistence.rs
+++ b/crates/dns/tests/fake_ip_persistence.rs
@@ -217,6 +217,77 @@ async fn incompatible_hot_reload_replaces_the_persistent_allocator() {
     );
 }
 
+#[tokio::test]
+async fn prepared_incompatible_reload_is_invisible_and_preserves_committed_journal_until_commit() {
+    let directory = tempfile::tempdir().expect("state directory");
+    let path = directory.path().join("fake-ip.jsonl");
+    let original = config("198.18.0.0/24", 3_600);
+    let changed = config("198.19.0.0/24", 3_600);
+    let dns = build(&original, &path);
+
+    zero_traits::DnsResolver::resolve(&dns, "rollback.example")
+        .await
+        .expect("allocate committed Fake-IP");
+    let committed_journal = std::fs::read(&path).expect("read committed journal");
+    let changed_dispatch = changed
+        .compile_dispatch(&[], None)
+        .expect("compile changed DNS dispatch");
+
+    dns.prepare_reload_with_dispatch(Some(&changed), Some(changed_dispatch.clone()))
+        .expect("prepare incompatible reload");
+    assert_eq!(
+        dns.lookup_fake_ip(&zero_traits::IpAddress::V4([198, 18, 0, 1]))
+            .await
+            .as_deref(),
+        Some("rollback.example"),
+        "a prepared candidate must not replace the committed resolver"
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read journal after prepare"),
+        committed_journal,
+        "preparing an incompatible pool must not rewrite durable state"
+    );
+
+    dns.discard_prepared_reload();
+    drop(dns);
+    let restored = build(&original, &path);
+    assert_eq!(
+        restored
+            .lookup_fake_ip(&zero_traits::IpAddress::V4([198, 18, 0, 1]))
+            .await
+            .as_deref(),
+        Some("rollback.example"),
+        "discarded candidate must preserve restart recovery"
+    );
+
+    restored
+        .prepare_reload_with_dispatch(Some(&changed), Some(changed_dispatch))
+        .expect("prepare committed replacement");
+    restored
+        .commit_prepared_reload()
+        .expect("commit incompatible replacement");
+    assert!(restored
+        .lookup_fake_ip(&zero_traits::IpAddress::V4([198, 18, 0, 1]))
+        .await
+        .is_none());
+    assert_eq!(
+        zero_traits::DnsResolver::resolve(&restored, "replacement.example")
+            .await
+            .expect("allocate replacement Fake-IP"),
+        vec![zero_traits::IpAddress::V4([198, 19, 0, 1])]
+    );
+    drop(restored);
+
+    let committed = build(&changed, &path);
+    assert_eq!(
+        committed
+            .lookup_fake_ip_domain("replacement.example")
+            .await
+            .as_deref(),
+        Some("198.19.0.1")
+    );
+}
+
 #[test]
 fn rejects_a_second_live_owner_of_the_same_state() {
     let directory = tempfile::tempdir().expect("state directory");

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -250,13 +250,19 @@ impl Proxy {
                 .iter()
                 .filter_map(|address| next_ip(address.address)),
         );
-        if let Some(conflict) = self.resolver.fake_ip_conflict(&tun_owned_addresses) {
-            return Err(EngineError::Io(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "Fake-IP pool overlaps TUN-owned address `{conflict}`; choose a non-overlapping DNS fake-IP CIDR"
-                ),
-            )));
+        // Declarative TUN/Fake-IP pairs are cross-validated together before
+        // the runtime config is staged. Command-driven TUN starts have no such
+        // candidate config, so they must still validate against the committed
+        // resolver here.
+        if managed_config.is_none() {
+            if let Some(conflict) = self.resolver.fake_ip_conflict(&tun_owned_addresses) {
+                return Err(EngineError::Io(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "Fake-IP pool overlaps TUN-owned address `{conflict}`; choose a non-overlapping DNS fake-IP CIDR"
+                    ),
+                )));
+            }
         }
         let primary = &interface_addresses[0];
         let address = primary.address;

--- a/crates/proxy/src/runtime.rs
+++ b/crates/proxy/src/runtime.rs
@@ -226,6 +226,14 @@ impl Proxy {
             .is_none_or(|pending| pending.persist)
     }
 
+    pub(crate) fn pending_reload_matches(&self, expected: &RuntimeConfig) -> bool {
+        self.reload_ack
+            .lock()
+            .expect("reload ack lock poisoned")
+            .as_ref()
+            .is_some_and(|pending| pending.expected == *expected)
+    }
+
     pub(crate) fn tcp_runtime_services(&self) -> TcpRuntimeServices {
         self.tcp_runtime_services_for_snapshot(self.engine.runtime_snapshot())
     }

--- a/crates/proxy/src/runtime/handle/configuration.rs
+++ b/crates/proxy/src/runtime/handle/configuration.rs
@@ -70,18 +70,50 @@ impl ProxyHandle {
             .await?;
 
         let Some(reconciler) = &self.config_reconciler else {
+            if let Err(error) = self.proxy.resolver.commit_prepared_reload() {
+                let rollback = self
+                    .rollback_proxy_dns_under_guard(previous, timeout, persist)
+                    .await;
+                let mut message = format!("DNS config commit failed: {error}");
+                if let Err(error) = rollback {
+                    message.push_str(&format!("; proxy rollback failed: {error}"));
+                } else {
+                    message.push_str("; restored last-known-good configuration");
+                }
+                return Err(message);
+            }
             self.proxy.engine.commit_config_change();
             return Ok(Some(ConfigReconcileResult::default()));
         };
         let candidate = Arc::new(candidate);
         match reconciler.reconcile(candidate).await {
             Ok(result) => {
+                if let Err(error) = self.proxy.resolver.commit_prepared_reload() {
+                    let proxy_rollback = self
+                        .rollback_proxy_dns_under_guard(previous.clone(), timeout, persist)
+                        .await;
+                    let app_rollback = if proxy_rollback.is_ok() {
+                        reconciler.reconcile(previous).await
+                    } else {
+                        Err("application rollback skipped because proxy rollback failed".to_owned())
+                    };
+                    let mut message = format!("DNS config commit failed: {error}");
+                    if let Err(error) = proxy_rollback {
+                        message.push_str(&format!("; proxy rollback failed: {error}"));
+                    }
+                    if let Err(error) = app_rollback {
+                        message.push_str(&format!("; application rollback failed: {error}"));
+                    } else {
+                        message.push_str("; restored last-known-good configuration");
+                    }
+                    return Err(message);
+                }
                 self.proxy.engine.commit_config_change();
                 Ok(Some(result))
             }
             Err(apply_error) => {
                 let proxy_rollback = self
-                    .apply_proxy_config_under_guard((*previous).clone(), timeout, persist)
+                    .rollback_proxy_dns_under_guard(previous.clone(), timeout, persist)
                     .await;
                 let app_rollback = if proxy_rollback.is_ok() {
                     reconciler.reconcile(previous).await
@@ -102,4 +134,23 @@ impl ProxyHandle {
             }
         }
     }
+
+    async fn rollback_proxy_dns_under_guard(
+        &self,
+        previous: Arc<RuntimeConfig>,
+        timeout: Duration,
+        persist: bool,
+    ) -> Result<(), String> {
+        self.proxy.resolver.discard_prepared_reload();
+        let result = self
+            .apply_proxy_config_under_guard((*previous).clone(), timeout, persist)
+            .await;
+        // The committed resolver was never replaced, so the rollback's
+        // prepared last-known-good candidate is redundant.
+        self.proxy.resolver.discard_prepared_reload();
+        result
+    }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/proxy/src/runtime/handle/configuration/tests.rs
+++ b/crates/proxy/src/runtime/handle/configuration/tests.rs
@@ -1,0 +1,139 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use zero_config::RuntimeConfig;
+use zero_engine::EngineHandle;
+use zero_traits::{DnsResolver, IpAddress};
+
+use super::{ConfigApplyReconciler, ConfigReconcileResult, ProxyHandle};
+use crate::runtime::Proxy;
+
+struct RejectChangedFakeIpPool {
+    calls: Mutex<Vec<String>>,
+}
+
+#[async_trait::async_trait]
+impl ConfigApplyReconciler for RejectChangedFakeIpPool {
+    fn validate(&self, _current: &RuntimeConfig, _candidate: &RuntimeConfig) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn reconcile(&self, target: Arc<RuntimeConfig>) -> Result<ConfigReconcileResult, String> {
+        let cidr = target
+            .runtime
+            .dns
+            .as_ref()
+            .and_then(|dns| dns.fake_ip())
+            .expect("Fake-IP config")
+            .cidr
+            .to_owned();
+        self.calls.lock().expect("calls lock").push(cidr.clone());
+        if cidr == "198.19.0.0/24" {
+            return Err("injected application reconcile failure".to_owned());
+        }
+        Ok(ConfigReconcileResult::default())
+    }
+}
+
+fn config(cidr: &str) -> RuntimeConfig {
+    RuntimeConfig::parse(&format!(
+        r#"{{
+            "runtime": {{
+                "dns": {{
+                    "servers": {{ "system": {{ "type": "system" }} }},
+                    "default_server": "system",
+                    "answer": {{
+                        "type": "fake_ip",
+                        "cidr": "{cidr}",
+                        "ttl_seconds": 3600,
+                        "max_entries": 16
+                    }}
+                }}
+            }},
+            "inbounds": [{{
+                "tag": "reload-test",
+                "listen": {{ "address": "127.0.0.1", "port": 0 }},
+                "protocol": {{ "type": "direct" }}
+            }}],
+            "route": {{ "rules": [], "final": {{ "type": "direct" }} }}
+        }}"#
+    ))
+    .expect("parse config")
+}
+
+#[tokio::test]
+async fn application_reconcile_failure_keeps_committed_fake_ip_mapping() {
+    let original = config("198.18.0.0/24");
+    let proxy = Proxy::new(original).expect("build proxy");
+    let resolver = proxy.resolver.clone();
+    assert_eq!(
+        DnsResolver::resolve(resolver.as_ref(), "cached.example")
+            .await
+            .expect("allocate committed mapping"),
+        vec![IpAddress::V4([198, 18, 0, 1])]
+    );
+    let reconciler = Arc::new(RejectChangedFakeIpPool {
+        calls: Mutex::new(Vec::new()),
+    });
+    let handle = ProxyHandle::new(EngineHandle::new(proxy.engine().clone()), proxy.clone())
+        .with_config_apply_reconciler(reconciler.clone());
+    let running = proxy.spawn();
+
+    let error = handle
+        .apply_config_and_wait(config("198.19.0.0/24"), Duration::from_secs(5))
+        .await
+        .expect_err("application failure must reject candidate");
+
+    assert!(
+        error.contains("restored last-known-good configuration"),
+        "{error}"
+    );
+    assert_eq!(
+        resolver
+            .lookup_fake_ip(&IpAddress::V4([198, 18, 0, 1]))
+            .await
+            .as_deref(),
+        Some("cached.example")
+    );
+    assert_eq!(
+        DnsResolver::resolve(resolver.as_ref(), "cached.example")
+            .await
+            .expect("resolve through restored allocator"),
+        vec![IpAddress::V4([198, 18, 0, 1])]
+    );
+    assert_eq!(
+        *reconciler.calls.lock().expect("calls lock"),
+        vec!["198.19.0.0/24".to_owned(), "198.18.0.0/24".to_owned()]
+    );
+
+    running.shutdown().await.expect("shutdown proxy");
+}
+
+#[tokio::test]
+async fn successful_apply_commits_prepared_fake_ip_pool() {
+    let proxy = Proxy::new(config("198.18.0.0/24")).expect("build proxy");
+    let resolver = proxy.resolver.clone();
+    DnsResolver::resolve(resolver.as_ref(), "old.example")
+        .await
+        .expect("allocate old mapping");
+    let handle = ProxyHandle::new(EngineHandle::new(proxy.engine().clone()), proxy.clone());
+    let running = proxy.spawn();
+
+    handle
+        .apply_config_and_wait(config("198.19.0.0/24"), Duration::from_secs(5))
+        .await
+        .expect("commit config");
+
+    assert!(resolver
+        .lookup_fake_ip(&IpAddress::V4([198, 18, 0, 1]))
+        .await
+        .is_none());
+    assert_eq!(
+        DnsResolver::resolve(resolver.as_ref(), "new.example")
+            .await
+            .expect("allocate committed replacement"),
+        vec![IpAddress::V4([198, 19, 0, 1])]
+    );
+
+    running.shutdown().await.expect("shutdown proxy");
+}

--- a/crates/proxy/src/runtime/handle/model.rs
+++ b/crates/proxy/src/runtime/handle/model.rs
@@ -83,6 +83,7 @@ impl ProxyHandle {
             Ok(Ok(result)) => result,
             Ok(Err(_)) => {
                 self.clear_pending_reload();
+                self.proxy.resolver.discard_prepared_reload();
                 self.rollback_unconfirmed_reload(previous, timeout, persist)
                     .await?;
                 Err(
@@ -92,6 +93,7 @@ impl ProxyHandle {
             }
             Err(_) => {
                 self.clear_pending_reload();
+                self.proxy.resolver.discard_prepared_reload();
                 self.rollback_unconfirmed_reload(previous, timeout, persist)
                     .await?;
                 Err("timed out waiting for proxy listener reconciliation; restored last-known-good config"
@@ -220,7 +222,7 @@ impl ProxyHandle {
             .begin_acknowledged_reload((*previous).clone(), persist)
             .map_err(|error| format!("failed to start last-known-good rollback: {error}"))?;
         let rollback_timeout = requested_timeout.max(std::time::Duration::from_secs(5));
-        match tokio::time::timeout(rollback_timeout, receiver).await {
+        let result = match tokio::time::timeout(rollback_timeout, receiver).await {
             Ok(Ok(Ok(()))) => Ok(()),
             Ok(Ok(Err(error))) => Err(format!(
                 "last-known-good rollback listener reconciliation failed: {error}"
@@ -230,6 +232,8 @@ impl ProxyHandle {
                 self.clear_pending_reload();
                 Err("timed out waiting for last-known-good rollback reconciliation".to_owned())
             }
-        }
+        };
+        self.proxy.resolver.discard_prepared_reload();
+        result
     }
 }

--- a/crates/proxy/src/runtime/orchestration/state.rs
+++ b/crates/proxy/src/runtime/orchestration/state.rs
@@ -116,7 +116,7 @@ impl OrchestrationState {
             .and_then(|dispatch| {
                 proxy
                     .resolver
-                    .reload_with_dispatch(new_config.runtime.dns.as_ref(), dispatch)
+                    .prepare_reload_with_dispatch(new_config.runtime.dns.as_ref(), dispatch)
             });
         if let Err(error) = dns_reload {
             warn!(%error, reason = "dns_reload_error", "failed to reload dns config");
@@ -168,6 +168,14 @@ impl OrchestrationState {
             self.reject_reload(proxy, &new_config, message).await;
             return;
         }
+        if !proxy.pending_reload_matches(&new_config) {
+            if let Err(error) = proxy.resolver.commit_prepared_reload() {
+                warn!(%error, reason = "dns_commit_error", "failed to commit dns config");
+                self.reject_reload(proxy, &new_config, error.to_string())
+                    .await;
+                return;
+            }
+        }
         listeners::reconcile_urltests(
             &candidate_urltest_runtime,
             &self.shutdown_rx,
@@ -183,6 +191,7 @@ impl OrchestrationState {
     }
 
     async fn reject_reload(&mut self, proxy: &Proxy, rejected: &RuntimeConfig, message: String) {
+        proxy.resolver.discard_prepared_reload();
         let persist = proxy.pending_reload_persists(rejected);
         let rollback = if persist {
             proxy.engine.stage_config((*self.applied_config).clone())
@@ -203,35 +212,21 @@ impl OrchestrationState {
             acknowledgement.push_str(&format!(
                 "; last-known-good config restore failed: {rollback_error}"
             ));
-        } else {
-            let dns_rollback = self
-                .applied_config
-                .compile_dns_dispatch()
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))
-                .and_then(|dispatch| {
-                    proxy
-                        .resolver
-                        .reload_with_dispatch(self.applied_config.runtime.dns.as_ref(), dispatch)
-                });
-            if let Err(error) = dns_rollback {
-                acknowledgement.push_str(&format!("; DNS rollback failed: {error}"));
-            }
-            if let Err(error) = proxy
-                .reconcile_configured_tun(
-                    self.applied_config.runtime.tun.as_ref(),
-                    self.applied_config.runtime.network.mtu,
-                )
-                .await
-            {
-                warn!(
-                    core_instance_id = proxy.core_instance_id(),
-                    config_revision = proxy.config_revision(),
-                    reason = "tun_reload_rollback_error",
-                    %error,
-                    "failed to restore last-known-good TUN after reload failure"
-                );
-                acknowledgement.push_str(&format!("; TUN rollback failed: {error}"));
-            }
+        } else if let Err(error) = proxy
+            .reconcile_configured_tun(
+                self.applied_config.runtime.tun.as_ref(),
+                self.applied_config.runtime.network.mtu,
+            )
+            .await
+        {
+            warn!(
+                core_instance_id = proxy.core_instance_id(),
+                config_revision = proxy.config_revision(),
+                reason = "tun_reload_rollback_error",
+                %error,
+                "failed to restore last-known-good TUN after reload failure"
+            );
+            acknowledgement.push_str(&format!("; TUN rollback failed: {error}"));
         }
         proxy.complete_reload(rejected, Err(acknowledgement));
     }

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -170,6 +170,12 @@ another domain; if every pool candidate is live or retired, allocation fails
 closed and an intercepted DNS query receives SERVFAIL. This intentionally
 prefers a visible lookup failure over cross-domain delivery through a stale
 client DNS cache.
+Acknowledged configuration changes prepare the candidate DNS snapshot without
+publishing it or rewriting the Fake-IP journal. The candidate becomes active
+only after TUN, listener, and application-service reconciliation succeeds. A
+rejected transaction therefore keeps both the in-memory mappings and the
+restart-persistent journal from the last committed configuration; a successful
+incompatible change intentionally starts the documented clean allocator.
 `diagnostics.fakeip_lookup` reports mapping counters, live capacity, and the
 current `retired_addresses` count.
 The admin command `fakeip.clear` manages the same allocator and persistent


### PR DESCRIPTION
Closes #73

Part of #33 and #52.

## Summary

- add a prepare/commit boundary for DNS reloads so candidate DNS/Fake-IP state is validated without becoming observable
- defer opening/replacing the persistent Fake-IP journal until proxy listener/TUN and application reconciliation have succeeded
- discard staged DNS state and keep the committed in-memory mapping plus journal when reconciliation fails or times out
- keep unacknowledged engine reloads committing DNS directly
- preserve command-driven TUN collision checks while allowing an already cross-validated declarative TUN + Fake-IP address move
- document the transactional reload contract

## Regression coverage

- an incompatible prepared pool remains invisible and does not change the journal before commit
- discarding the candidate preserves restart recovery of the committed mapping
- a late application reconciliation failure restores the previous config and Fake-IP mapping
- a successful apply commits the new incompatible pool
- command `tun.start` still rejects overlap against the committed Fake-IP pool

## Validation

- `cargo test -p zero-dns --features udp,doh,dot,doq --locked --jobs 1` — 54 passed
- `cargo test -p zero-proxy --features dns --lib --locked --jobs 1` — 140 passed
- `cargo test -p zero-proxy --features dns --test reload_reconcile --locked --jobs 1` — 11 passed
- `cargo clippy -p zero-dns --features udp,doh,dot,doq --all-targets --locked --jobs 1`
- `cargo clippy -p zero-proxy --features dns --lib --locked --jobs 1`
- `cargo fmt --all -- --check`
- `git diff --check`

The local `cargo check --workspace --locked --jobs 1` reached `zero-grpc` and was blocked only because this host has no `protoc`; CI owns the full workspace check with its protobuf toolchain.