### PR TITLE
fix(direct): retry trusted recovered target candidates

### DIFF
--- a/crates/proxy/src/runtime/udp_dispatch/operation/direct.rs
+++ b/crates/proxy/src/runtime/udp_dispatch/operation/direct.rs
@@ -63,7 +63,7 @@ async fn execute_direct_udp_operation(
         }
     };
     let (sent, target_addr) = dispatch
-        .send_new_direct_packet(&session.target, &candidates.candidates, payload)
+        .send_new_direct_packet(&session.target, candidates.udp_candidates(), payload)
         .await
         .map_err(|error| FlowFailure {
             stage: "udp_direct_send",

--- a/crates/proxy/src/transport/direct.rs
+++ b/crates/proxy/src/transport/direct.rs
@@ -13,6 +13,9 @@ use zero_platform_tokio::{
 use zero_traits::IpAddress;
 
 use super::direct_dial::{dial_tcp_candidates, TcpDialAttempt, TcpDialFailure};
+use candidates::{append_recovered_ipv4_candidates, literal_direct_target};
+
+pub(super) mod candidates;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct DirectConnector;
@@ -32,8 +35,22 @@ pub(crate) struct DirectTcpConnectFailure {
 #[derive(Debug, Clone)]
 pub(crate) struct DirectTargetResolution {
     pub(crate) candidates: Vec<SocketAddr>,
+    udp_original_candidate: Option<SocketAddr>,
     address_family_policy: &'static str,
     fallback: Option<DirectAddressFamilyFallback>,
+}
+
+impl DirectTargetResolution {
+    /// Keep connectionless transparent traffic on the client-selected
+    /// endpoint. DNS-enriched alternatives exist so TCP can recover from a
+    /// failed connect, but UDP has no equivalent failure signal that makes an
+    /// automatic destination change safe.
+    pub(crate) fn udp_candidates(&self) -> &[SocketAddr] {
+        self.udp_original_candidate
+            .as_ref()
+            .map(std::slice::from_ref)
+            .unwrap_or(&self.candidates)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -256,8 +273,12 @@ impl DirectConnector {
             )
             .await?
         };
+        let candidates = append_recovered_ipv4_candidates(session, resolver, candidates).await;
+        let udp_original_candidate =
+            literal_direct_target(session).filter(|original| candidates.contains(original));
         Ok(DirectTargetResolution {
             candidates,
+            udp_original_candidate,
             address_family_policy: resolver.address_family_policy().as_str(),
             fallback,
         })

--- a/crates/proxy/src/transport/direct/candidates.rs
+++ b/crates/proxy/src/transport/direct/candidates.rs
@@ -1,0 +1,87 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use zero_core::{Address, Network, Session};
+use zero_dns::DnsSystem;
+use zero_traits::IpAddress;
+
+use super::socket_addr_from_ip;
+
+pub(in crate::transport) const MAX_RECOVERED_DIRECT_CANDIDATES: usize = 8;
+
+/// Enrich a transparent IPv4 direct target with the current real-DNS answers
+/// for its recovered domain. The captured endpoint remains first, and DNS
+/// failure is deliberately non-fatal because that endpoint is still a valid
+/// literal target.
+pub(super) async fn append_recovered_ipv4_candidates(
+    session: &Session,
+    resolver: &DnsSystem,
+    mut candidates: Vec<SocketAddr>,
+) -> Vec<SocketAddr> {
+    if session.network != Network::Tcp {
+        return candidates;
+    }
+    let (Address::Domain(domain), Some(host_source), Some(Address::Ipv4(original_address))) = (
+        &session.target,
+        session.target_host_source,
+        session.direct_target.as_ref(),
+    ) else {
+        return candidates;
+    };
+    let original = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(*original_address)), session.port);
+    if candidates.first() != Some(&original) {
+        return candidates;
+    }
+
+    match resolver.resolve_direct(domain).await {
+        Ok(resolved) => {
+            append_unique_resolved_candidates(&mut candidates, resolved, session.port);
+            tracing::debug!(
+                original_target = %original,
+                domain,
+                host_source = host_source.as_str(),
+                candidate_count = candidates.len(),
+                "enriched transparent direct target with trusted DNS candidates"
+            );
+        }
+        Err(error) => {
+            tracing::debug!(
+                original_target = %original,
+                domain,
+                host_source = host_source.as_str(),
+                error = %error,
+                "trusted-domain candidate refresh failed; retaining original direct target"
+            );
+        }
+    }
+    candidates
+}
+
+pub(in crate::transport) fn append_unique_resolved_candidates(
+    candidates: &mut Vec<SocketAddr>,
+    resolved: Vec<IpAddress>,
+    port: u16,
+) {
+    for address in resolved {
+        if candidates.len() >= MAX_RECOVERED_DIRECT_CANDIDATES {
+            break;
+        }
+        let candidate = socket_addr_from_ip(address, port);
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+}
+
+pub(super) fn literal_direct_target(session: &Session) -> Option<SocketAddr> {
+    match session.direct_target.as_ref()? {
+        Address::Ipv4(address) => Some(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::from(*address)),
+            session.port,
+        )),
+        Address::Ipv6(address) => Some(SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::from(*address)),
+            session.port,
+        )),
+        Address::Domain(_) => None,
+    }
+}

--- a/crates/proxy/src/transport/tests.rs
+++ b/crates/proxy/src/transport/tests.rs
@@ -1,6 +1,7 @@
 use zero_core::{Address, Network, ProtocolType, Session, TargetHostSource};
 
 use super::{
+    direct::candidates::{append_unique_resolved_candidates, MAX_RECOVERED_DIRECT_CANDIDATES},
     direct_dial::{
         dial_tcp_candidates, interleave_address_families, MAX_RECORDED_CONNECTION_ATTEMPTS,
     },
@@ -65,6 +66,47 @@ fn tcp_dial_candidates_interleave_families_and_remove_duplicates() {
         interleave_address_families(vec![v6_a, v6_b, v4_a, v4_b]),
         vec![v6_a, v4_a, v6_b, v4_b]
     );
+}
+
+#[test]
+fn recovered_candidates_preserve_order_and_remove_dns_duplicates() {
+    let original = "192.0.2.1:443".parse().unwrap();
+    let mut candidates = vec![original];
+
+    append_unique_resolved_candidates(
+        &mut candidates,
+        vec![
+            zero_traits::IpAddress::V4([192, 0, 2, 1]),
+            zero_traits::IpAddress::V4([192, 0, 2, 2]),
+            zero_traits::IpAddress::V4([192, 0, 2, 2]),
+            zero_traits::IpAddress::V6([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+        ],
+        443,
+    );
+
+    assert_eq!(
+        candidates,
+        vec![
+            original,
+            "192.0.2.2:443".parse().unwrap(),
+            "[::1]:443".parse().unwrap()
+        ]
+    );
+}
+
+#[test]
+fn recovered_candidate_enrichment_is_bounded() {
+    let original = "192.0.2.1:443".parse().unwrap();
+    let mut candidates = vec![original];
+    let resolved = (2..=32)
+        .map(|last| zero_traits::IpAddress::V4([192, 0, 2, last]))
+        .collect();
+
+    append_unique_resolved_candidates(&mut candidates, resolved, 443);
+
+    assert_eq!(candidates.len(), MAX_RECOVERED_DIRECT_CANDIDATES);
+    assert_eq!(candidates[0], original);
+    assert_eq!(candidates[7], "192.0.2.8:443".parse().unwrap());
 }
 
 #[tokio::test]
@@ -160,6 +202,118 @@ async fn tcp_dial_failure_attempt_observations_are_ordered_and_bounded() {
             && attempt.error_kind.is_some()
             && attempt.os_error.is_none()
     }));
+}
+
+#[tokio::test]
+async fn recovered_ipv4_target_uses_trusted_dns_candidates_after_original_fails() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let reachable = listener.local_addr().unwrap();
+    let original = Address::Ipv4([127, 0, 0, 2]);
+    let mut session = tls_sni_session(original);
+    session.target = Address::Domain("localhost".to_owned());
+    session.sni = Some("localhost".to_owned());
+    session.port = reachable.port();
+    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let egress = zero_platform_tokio::EgressInterfaceControl::default();
+
+    let connection = DirectConnector
+        .connect(&session, &resolver, &egress)
+        .await
+        .unwrap_or_else(|failure| {
+            panic!("trusted DNS candidate should connect: {}", failure.error)
+        });
+
+    let captured = std::net::SocketAddr::new("127.0.0.2".parse().unwrap(), reachable.port());
+    assert_eq!(connection.network.resolved_candidates[0].host, "127.0.0.2");
+    assert_eq!(connection.remote, reachable);
+    assert!(connection
+        .network
+        .resolved_candidates
+        .iter()
+        .any(|candidate| candidate.host == "127.0.0.1"));
+    assert_eq!(
+        connection
+            .network
+            .resolved_candidates
+            .iter()
+            .filter(|candidate| candidate.host == captured.ip().to_string())
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn recovered_ipv4_dns_failure_retains_the_original_candidate() {
+    let original = Address::Ipv4([192, 0, 2, 10]);
+    let mut session = tls_sni_session(original);
+    session.target = Address::Domain("invalid\0domain".to_owned());
+    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+
+    let resolution = DirectConnector
+        .resolve_target_addrs(
+            &session,
+            &resolver,
+            &zero_platform_tokio::EgressInterfaceControl::default(),
+        )
+        .await
+        .expect("literal target remains valid when DNS refresh fails");
+
+    assert_eq!(
+        resolution.candidates,
+        vec!["192.0.2.10:443".parse().unwrap()]
+    );
+    assert_eq!(resolution.udp_candidates(), resolution.candidates);
+}
+
+#[tokio::test]
+async fn recovered_ipv4_without_host_source_remains_literal_only() {
+    let original = Address::Ipv4([127, 0, 0, 2]);
+    let mut session = tls_sni_session(original);
+    session.target = Address::Domain("localhost".to_owned());
+    session.target_host_source = None;
+    session.sni = None;
+    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+
+    let resolution = DirectConnector
+        .resolve_target_addrs(
+            &session,
+            &resolver,
+            &zero_platform_tokio::EgressInterfaceControl::default(),
+        )
+        .await
+        .expect("untrusted recovered host must not replace literal semantics");
+
+    assert_eq!(
+        resolution.candidates,
+        vec!["127.0.0.2:443".parse().unwrap()]
+    );
+}
+
+#[tokio::test]
+async fn recovered_ipv4_udp_remains_pinned_to_the_original_candidate() {
+    let original = Address::Ipv4([127, 0, 0, 2]);
+    let mut session = tls_sni_session(original);
+    session.target = Address::Domain("localhost".to_owned());
+    session.network = Network::Udp;
+    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+
+    let resolution = DirectConnector
+        .resolve_target_addrs(
+            &session,
+            &resolver,
+            &zero_platform_tokio::EgressInterfaceControl::default(),
+        )
+        .await
+        .expect("UDP should retain the usable literal target");
+
+    assert_eq!(
+        resolution.candidates,
+        vec!["127.0.0.2:443".parse().unwrap()]
+    );
+    assert_eq!(
+        resolution.udp_candidates(),
+        &["127.0.0.2:443".parse().unwrap()]
+    );
 }
 
 #[tokio::test]

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -151,12 +151,18 @@ section glue is not promoted to a trusted address candidate.
 When `reverse_mapping` is present, successful real A/AAAA answers also populate
 a bounded IP-to-domain index owned by `zero-dns`. Transparent TUN sessions may
 recover an unambiguous logical domain from that index while retaining the
-client-selected IP as their direct socket target. Explicit SOCKS/HTTP IP targets
-are never rewritten. Shared CDN addresses with multiple live domain candidates
-remain IP targets instead of guessing; TLS/HTTP/QUIC sniffing may still recover
-a stronger application-layer name. The index is TTL-capped, address-LRU bounded,
-preserved across compatible hot reloads, and intentionally not persisted across
-process restarts.
+client-selected IP as their authoritative direct socket target. For TCP, an
+explicitly recovered domain also contributes current real-DNS candidates after
+that original endpoint; the bounded candidate dialer can therefore recover from
+a stale captured IPv4 address without guessing a name for IP-only traffic. DNS
+refresh failure retains the original literal candidate. Connectionless direct
+UDP remains pinned to the usable client-selected endpoint because it has no TCP-
+style connect failure that safely authorizes retargeting. Explicit SOCKS/HTTP IP
+targets are never rewritten. Shared CDN addresses with multiple live domain
+candidates remain IP targets instead of guessing; TLS/HTTP/QUIC sniffing may
+still recover a stronger application-layer name. The index is TTL-capped,
+address-LRU bounded, preserved across compatible hot reloads, and intentionally
+not persisted across process restarts.
 
 Fake-IP names are IDNA-normalized, lower-cased, and trailing-dot insensitive.
 Mappings expire in both directions, are bounded by `max_entries`, and use


### PR DESCRIPTION
## Summary

- keep a transparent TCP flow's captured IPv4 endpoint as the authoritative first direct candidate
- when a trusted logical hostname was recovered, append current real-DNS candidates with stable de-duplication and an eight-candidate total bound
- retain the literal endpoint when DNS refresh fails and never infer a domain for IP-only traffic
- keep connectionless direct UDP pinned to the captured endpoint because it has no safe TCP-style connection failure signal
- expose the full attempted candidate set and selected winner through the existing network observation fields
- document the recovered-target behavior without adding public configuration or API schema

## Validation

- `cargo test -p zero-proxy --features dns --lib --locked --jobs 1` — 144 passed
- `cargo clippy -p zero-proxy --features dns --lib --tests --locked --jobs 1`
- `cargo check -p zero-proxy --no-default-features --locked --jobs 1`
- `cargo check -p zero-proxy --all-features --locked --jobs 1`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #75
Part of #33
Part of #52