### PR TITLE
fix(dns): age cached wire response TTLs

### DIFF
--- a/crates/dns/src/cache.rs
+++ b/crates/dns/src/cache.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 use zero_config::DnsCacheConfig;
 use zero_traits::IpAddress;
 
+use crate::message;
 use crate::message::normalize_domain;
 use crate::DnsQueryRole;
 
@@ -22,6 +23,7 @@ struct CacheEntry {
     addresses: Vec<IpAddress>,
     raw_query: Option<Vec<u8>>,
     raw_response: Option<Vec<u8>>,
+    stored_at: Instant,
     expires_at: Instant,
     last_used: u64,
 }
@@ -115,15 +117,37 @@ impl DnsCache {
         }
         state.clock = state.clock.wrapping_add(1);
         let clock = state.clock;
-        let entry = state.entries.get_mut(&key)?;
-        let cached_query = entry.raw_query.as_deref()?;
-        if cached_query.get(2..)? != query.get(2..)? {
+        let (mut response, elapsed_seconds, remaining_seconds) = {
+            let entry = state.entries.get(&key)?;
+            let cached_query = entry.raw_query.as_deref()?;
+            if cached_query.get(2..)? != query.get(2..)? {
+                return None;
+            }
+            (
+                entry.raw_response.clone()?,
+                now.saturating_duration_since(entry.stored_at)
+                    .as_secs()
+                    .min(u64::from(u32::MAX)) as u32,
+                duration_seconds_ceiling(entry.expires_at.saturating_duration_since(now)),
+            )
+        };
+        if message::rewrite_response_ttls(&mut response, elapsed_seconds, Some(remaining_seconds))
+            .is_err()
+        {
+            state.entries.remove(&key);
             return None;
         }
-        let mut response = entry.raw_response.clone()?;
         response.get_mut(..2)?.copy_from_slice(query.get(..2)?);
-        entry.last_used = clock;
+        state.entries.get_mut(&key)?.last_used = clock;
         Some(response)
+    }
+
+    pub(crate) fn cap_response_ttls(&self, response: &mut [u8]) -> std::io::Result<()> {
+        let Some(max_ttl) = self.inner.max_ttl else {
+            return Ok(());
+        };
+        let ttl_cap = max_ttl.as_secs().min(u64::from(u32::MAX)) as u32;
+        message::rewrite_response_ttls(response, 0, Some(ttl_cap))
     }
 
     pub(crate) async fn inspect(&self, domain: &str) -> Option<(Vec<IpAddress>, u64)> {
@@ -254,21 +278,18 @@ impl DnsCache {
         }
         state.clock = state.clock.wrapping_add(1);
         let clock = state.clock;
-        let existing_response = state
-            .entries
-            .get(&key)
-            .and_then(|entry| entry.raw_response.clone());
-        let existing_query = state
-            .entries
-            .get(&key)
-            .and_then(|entry| entry.raw_query.clone());
+        // Address-only refreshes must not carry forward raw wire bytes: doing
+        // so would restart a response's age without receiving a fresh wire
+        // response from the backend.
+        let now = Instant::now();
         state.entries.insert(
             key,
             CacheEntry {
                 addresses,
-                raw_query: raw_query.or(existing_query),
-                raw_response: raw_response.or(existing_response),
-                expires_at: Instant::now() + effective_ttl,
+                raw_query,
+                raw_response,
+                stored_at: now,
+                expires_at: now + effective_ttl,
                 last_used: clock,
             },
         );
@@ -278,6 +299,13 @@ impl DnsCache {
 fn remove_expired(state: &mut CacheState) {
     let now = Instant::now();
     state.entries.retain(|_, entry| entry.expires_at > now);
+}
+
+fn duration_seconds_ceiling(duration: Duration) -> u32 {
+    let seconds = duration
+        .as_secs()
+        .saturating_add(u64::from(duration.subsec_nanos() != 0));
+    seconds.min(u64::from(u32::MAX)) as u32
 }
 
 #[cfg(test)]

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -843,7 +843,13 @@ impl DnsSystem {
                 false,
             )),
         };
-        match result.and_then(|response| {
+        match result.and_then(|mut response| {
+            if let Some(cache) = snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.cache.as_ref())
+            {
+                cache.cap_response_ttls(&mut response)?;
+            }
             let parsed = message::parse_response(query, &response)?;
             Ok((response, parsed))
         }) {

--- a/crates/dns/src/message/mod.rs
+++ b/crates/dns/src/message/mod.rs
@@ -13,6 +13,14 @@ pub use parse::DnsQuestion;
 pub(crate) use parse::{parse_question, parse_response, ParsedDnsResponse};
 pub(crate) use policy::{apply_response_address_policy, ResponseAddressPolicy};
 
+pub(crate) fn rewrite_response_ttls(
+    response: &mut [u8],
+    elapsed_seconds: u32,
+    ttl_cap: Option<u32>,
+) -> std::io::Result<()> {
+    parse::rewrite_response_ttls(response, elapsed_seconds, ttl_cap)
+}
+
 pub(crate) const TYPE_A: u16 = 1;
 pub(crate) const TYPE_SVCB: u16 = 64;
 pub(crate) const TYPE_HTTPS: u16 = 65;

--- a/crates/dns/src/message/parse.rs
+++ b/crates/dns/src/message/parse.rs
@@ -124,7 +124,11 @@ pub(crate) fn parse_response(query: &[u8], response: &[u8]) -> io::Result<Parsed
         offset = next;
     }
     for _ in 0..additional_count {
-        offset = skip_record(response, offset)?.0;
+        let (next, record_type, class, ttl, _) = record(response, offset)?;
+        if record_type != TYPE_OPT && class == 1 {
+            min_ttl = Some(min_ttl.map_or(ttl, |current: u32| current.min(ttl)));
+        }
+        offset = next;
     }
     if offset != response.len() {
         return Err(invalid("DNS response has trailing bytes"));
@@ -231,6 +235,62 @@ fn named_record(data: &[u8], offset: usize) -> io::Result<ResourceRecord<'_>> {
         rdata_start: next - rdata.len(),
         rdata,
     })
+}
+
+/// Cap and age cacheable resource-record TTLs in a complete DNS response.
+///
+/// OPT uses the resource-record TTL field for EDNS metadata, so it must remain
+/// byte-for-byte unchanged. The caller supplies total whole seconds elapsed
+/// since the response entered the cache; applying that age to a fresh clone
+/// avoids compounding TTL loss across repeated cache hits.
+pub(crate) fn rewrite_response_ttls(
+    response: &mut [u8],
+    elapsed_seconds: u32,
+    ttl_cap: Option<u32>,
+) -> io::Result<()> {
+    if response.len() < 12 || response.len() > MAX_DNS_MESSAGE_SIZE {
+        return Err(invalid("DNS response length is invalid"));
+    }
+
+    let question_count = usize::from(read_u16(response, 4)?);
+    let record_count = usize::from(read_u16(response, 6)?)
+        + usize::from(read_u16(response, 8)?)
+        + usize::from(read_u16(response, 10)?);
+    let mut offset = 12;
+    for _ in 0..question_count {
+        offset = skip_name(response, offset)?
+            .checked_add(4)
+            .ok_or_else(|| invalid("DNS question length overflow"))?;
+        if offset > response.len() {
+            return Err(invalid("incomplete DNS question"));
+        }
+    }
+
+    for _ in 0..record_count {
+        let name_end = skip_name(response, offset)?;
+        if name_end + 10 > response.len() {
+            return Err(invalid("truncated DNS resource record"));
+        }
+        let record_type = read_u16(response, name_end)?;
+        let length = usize::from(read_u16(response, name_end + 8)?);
+        let next = name_end
+            .checked_add(10)
+            .and_then(|start| start.checked_add(length))
+            .ok_or_else(|| invalid("DNS resource data length overflow"))?;
+        if next > response.len() {
+            return Err(invalid("truncated DNS resource data"));
+        }
+        if record_type != TYPE_OPT {
+            let ttl = read_u32(response, name_end + 4)?.saturating_sub(elapsed_seconds);
+            let capped = ttl_cap.map_or(ttl, |cap| ttl.min(cap));
+            response[name_end + 4..name_end + 8].copy_from_slice(&capped.to_be_bytes());
+        }
+        offset = next;
+    }
+    if offset != response.len() {
+        return Err(invalid("DNS response has trailing bytes"));
+    }
+    Ok(())
 }
 
 fn record(data: &[u8], offset: usize) -> io::Result<(usize, u16, u16, u32, &[u8])> {

--- a/crates/dns/tests/cache_ttl.rs
+++ b/crates/dns/tests/cache_ttl.rs
@@ -1,0 +1,242 @@
+#![cfg(feature = "udp")]
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use zero_config::{DnsAnswerConfig, DnsCacheConfig, DnsConfig, DnsServerConfig};
+
+const CACHE_TTL_CAP: u64 = 5;
+const OPT_METADATA: u32 = 0x0100_8000;
+
+#[tokio::test]
+async fn wire_cache_caps_and_ages_resource_record_ttls_without_touching_opt() {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind instrumented DNS server");
+    let port = socket.local_addr().expect("DNS server address").port();
+    let query_count = Arc::new(AtomicUsize::new(0));
+    let server_query_count = Arc::clone(&query_count);
+    let server = tokio::spawn(async move {
+        let mut request = [0_u8; 4096];
+        loop {
+            let (size, peer) = socket
+                .recv_from(&mut request)
+                .await
+                .expect("receive DNS query");
+            server_query_count.fetch_add(1, Ordering::SeqCst);
+            let response = response_with_mixed_ttls(&request[..size]);
+            socket
+                .send_to(&response, peer)
+                .await
+                .expect("send DNS response");
+        }
+    });
+    let dns = zero_dns::DnsSystem::build(Some(&config(port))).expect("build DNS runtime");
+
+    let first_query = query(0x4217);
+    let first = dns
+        .answer_udp_query(&first_query)
+        .await
+        .expect("answer first intercepted query");
+    let first_records = records(&first);
+
+    assert_eq!(&first[..2], &0x4217_u16.to_be_bytes());
+    assert_eq!(
+        first_records,
+        vec![(1, 5), (6, 5), (1, 5), (16, 4), (41, OPT_METADATA)]
+    );
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+
+    let second_query = query(0x9911);
+    let second = dns
+        .answer_tcp_query(&second_query)
+        .await
+        .expect("answer cached intercepted query");
+    let second_records = records(&second);
+
+    assert_eq!(&second[..2], &0x9911_u16.to_be_bytes());
+    assert_eq!(
+        second_records
+            .iter()
+            .map(|record| record.0)
+            .collect::<Vec<_>>(),
+        vec![1, 6, 1, 16, 41]
+    );
+    for (first, second) in first_records.iter().zip(&second_records) {
+        if first.0 == 41 {
+            assert_eq!(second.1, OPT_METADATA, "EDNS OPT metadata was rewritten");
+        } else {
+            assert!(
+                second.1 < first.1,
+                "cached TTL did not age: first={first:?}, second={second:?}"
+            );
+            assert!(
+                second.1 <= 3,
+                "cached TTL exceeded the remaining whole-response lifetime: {second:?}"
+            );
+        }
+    }
+
+    let third_query = query(0xa255);
+    let third = dns
+        .answer_udp_query(&third_query)
+        .await
+        .expect("answer repeated cache hit");
+    assert_eq!(&third[..2], &0xa255_u16.to_be_bytes());
+    assert_eq!(
+        records(&third),
+        second_records,
+        "cache-hit aging compounded instead of using total elapsed time"
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        query_count.load(Ordering::SeqCst),
+        1,
+        "cache hit unexpectedly queried the upstream DNS server"
+    );
+    server.abort();
+}
+
+fn config(port: u16) -> DnsConfig {
+    DnsConfig {
+        servers: BTreeMap::from([(
+            "local".to_owned(),
+            DnsServerConfig::Udp {
+                host: "127.0.0.1".to_owned(),
+                port,
+                bootstrap: Vec::new(),
+                detour: None,
+            },
+        )]),
+        default_server: "local".to_owned(),
+        dispatch: Vec::new(),
+        cache: Some(DnsCacheConfig {
+            max_entries: 8,
+            max_ttl_seconds: Some(CACHE_TTL_CAP),
+        }),
+        reverse_mapping: None,
+        answer: DnsAnswerConfig::Real,
+        policy: Default::default(),
+    }
+}
+
+fn query(id: u16) -> Vec<u8> {
+    let mut query = Vec::from(id.to_be_bytes());
+    query.extend_from_slice(&[
+        0x01, 0x00, // standard recursive query
+        0x00, 0x01, // one question
+        0x00, 0x00, // no answers
+        0x00, 0x00, // no authority records
+        0x00, 0x01, // one OPT pseudo-record
+    ]);
+    for label in ["cache", "example"] {
+        query.push(label.len() as u8);
+        query.extend_from_slice(label.as_bytes());
+    }
+    query.push(0);
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    append_record_with_owner(&mut query, &[0], 41, 1232, 0, &[]);
+    query
+}
+
+fn response_with_mixed_ttls(query: &[u8]) -> Vec<u8> {
+    zero_dns::udp::parse_dns_question(query).expect("parse test query");
+    let mut response = Vec::new();
+    response.extend_from_slice(&query[..2]);
+    response.extend_from_slice(&[
+        0x81, 0x80, // standard successful recursive response
+        0x00, 0x01, // one question
+        0x00, 0x01, // one answer
+        0x00, 0x01, // one authority record
+        0x00, 0x03, // three additional records
+    ]);
+    response.extend_from_slice(&query[12..question_end(query)]);
+    append_record(&mut response, 1, 1, 120, &[192, 0, 2, 1]);
+    append_record(
+        &mut response,
+        6,
+        1,
+        90,
+        &[
+            0, 0, // root MNAME and RNAME
+            0, 0, 0, 1, // serial
+            0, 0, 0, 60, // refresh
+            0, 0, 0, 60, // retry
+            0, 0, 0, 60, // expire
+            0, 0, 0, 60, // minimum
+        ],
+    );
+    append_record(&mut response, 1, 1, 75, &[192, 0, 2, 2]);
+    append_record(&mut response, 16, 1, 4, &[1, b'x']);
+    append_record_with_owner(&mut response, &[0], 41, 1232, OPT_METADATA, &[]);
+    response
+}
+
+fn append_record(response: &mut Vec<u8>, record_type: u16, class: u16, ttl: u32, data: &[u8]) {
+    append_record_with_owner(response, &[0xc0, 0x0c], record_type, class, ttl, data);
+}
+
+fn append_record_with_owner(
+    response: &mut Vec<u8>,
+    owner: &[u8],
+    record_type: u16,
+    class: u16,
+    ttl: u32,
+    data: &[u8],
+) {
+    response.extend_from_slice(owner);
+    response.extend_from_slice(&record_type.to_be_bytes());
+    response.extend_from_slice(&class.to_be_bytes());
+    response.extend_from_slice(&ttl.to_be_bytes());
+    response.extend_from_slice(&(data.len() as u16).to_be_bytes());
+    response.extend_from_slice(data);
+}
+
+fn records(response: &[u8]) -> Vec<(u16, u32)> {
+    let count = usize::from(u16::from_be_bytes([response[6], response[7]]))
+        + usize::from(u16::from_be_bytes([response[8], response[9]]))
+        + usize::from(u16::from_be_bytes([response[10], response[11]]));
+    let mut offset = question_end(response);
+    let mut records = Vec::new();
+    for _ in 0..count {
+        let name_end = skip_name(response, offset);
+        let record_type = u16::from_be_bytes([response[name_end], response[name_end + 1]]);
+        let ttl = u32::from_be_bytes([
+            response[name_end + 4],
+            response[name_end + 5],
+            response[name_end + 6],
+            response[name_end + 7],
+        ]);
+        let length = usize::from(u16::from_be_bytes([
+            response[name_end + 8],
+            response[name_end + 9],
+        ]));
+        records.push((record_type, ttl));
+        offset = name_end + 10 + length;
+    }
+    assert_eq!(offset, response.len());
+    records
+}
+
+fn question_end(message: &[u8]) -> usize {
+    skip_name(message, 12) + 4
+}
+
+fn skip_name(message: &[u8], mut offset: usize) -> usize {
+    loop {
+        let length = message[offset];
+        if length & 0xc0 == 0xc0 {
+            return offset + 2;
+        }
+        offset += 1;
+        if length == 0 {
+            return offset;
+        }
+        offset += usize::from(length);
+    }
+}

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -134,6 +134,15 @@ unusable instead of forwarding a malformed or policy-violating record. Raw
 cache entries contain the already-filtered response, so a cache hit cannot
 restore a suppressed family.
 
+When the raw wire cache is enabled, `cache.max_ttl_seconds` caps the TTLs
+advertised in the first forwarded response as well as the internal retention
+time. Cache hits subtract the elapsed whole seconds from every answer,
+authority, and additional record, so a replay cannot renew the client-side
+cache beyond Zero's remaining lifetime. Shorter upstream TTLs are never raised.
+EDNS OPT metadata is preserved because its TTL-shaped field carries extended
+RCODE, version, and flags rather than a cache lifetime. UDP and TCP interception
+share this behavior.
+
 Real address resolution starts A and AAAA lookups concurrently. TCP direct and
 upstream dialing preserves the answer order within each family, interleaves the
 two families, and starts later candidates after a bounded delay. Each candidate


### PR DESCRIPTION
## Summary

- enforce `dns.cache.max_ttl_seconds` on the first forwarded DNS wire response instead of only on internal retention
- age answer, authority, and additional resource-record TTLs from the original cache insertion time on every cache hit
- bound cached replies by the remaining whole-response lifetime and include non-OPT additional records in that lifetime
- preserve EDNS OPT extended RCODE/version/flags, which occupy the TTL-shaped field but are not cache TTL data
- discard raw wire bytes on address-only replacement so unrelated cache refreshes cannot restart response age
- preserve exact-query matching and transaction-ID rewriting across UDP/TCP interception
- document the stable wire-cache TTL contract without changing public schema

## Regression coverage

The instrumented wire test first reproduces the old 120/90/75-second leak under a 5-second cap, then proves:

- the first UDP reply is capped
- a TCP cache hit after one second has lower TTLs and makes no upstream query
- answer, authority, and additional records are all bounded
- a shorter upstream TTL is not increased
- OPT metadata remains byte-for-byte unchanged
- an immediate repeated UDP hit does not compound TTL aging
- transaction IDs remain caller-specific

## Validation

- `cargo test -p zero-dns --all-features --locked --jobs 1`
- `cargo clippy -p zero-dns --all-features --all-targets --locked --jobs 1`
- `cargo check -p zero-dns --no-default-features --locked --jobs 1`
- `cargo check -p zero-proxy --all-features --locked --jobs 1`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #77
Part of #33
Part of #52