### PR TITLE
fix(dns): validate trusted CNAME address owners

### DIFF
--- a/crates/dns/src/message/parse.rs
+++ b/crates/dns/src/message/parse.rs
@@ -1,9 +1,12 @@
+use std::collections::{HashMap, HashSet};
 use std::io;
 
 use zero_traits::IpAddress;
 
 use super::name::{decode_name, normalize_domain, skip_name};
 use super::{MAX_DNS_MESSAGE_SIZE, MAX_UDP_DNS_PAYLOAD, TYPE_A, TYPE_AAAA, TYPE_OPT};
+
+const TYPE_CNAME: u16 = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DnsQuestion {
@@ -103,25 +106,15 @@ pub(crate) fn parse_response(query: &[u8], response: &[u8]) -> io::Result<Parsed
     let authority_count = read_u16(response, 8)? as usize;
     let additional_count = read_u16(response, 10)? as usize;
     let mut offset = response_question_end;
-    let mut addresses = Vec::new();
     let mut min_ttl = None;
+    let mut answers = Vec::with_capacity(answer_count);
     for _ in 0..answer_count {
-        let (next, record_type, class, ttl, rdata) = record(response, offset)?;
-        if class == 1 {
-            min_ttl = Some(min_ttl.map_or(ttl, |current: u32| current.min(ttl)));
-            match (record_type, expected.query_type, rdata.len()) {
-                (TYPE_A, TYPE_A, 4) => {
-                    addresses.push(IpAddress::V4([rdata[0], rdata[1], rdata[2], rdata[3]]))
-                }
-                (TYPE_AAAA, TYPE_AAAA, 16) => {
-                    let mut octets = [0_u8; 16];
-                    octets.copy_from_slice(rdata);
-                    addresses.push(IpAddress::V6(octets));
-                }
-                _ => {}
-            }
+        let answer = named_record(response, offset)?;
+        if answer.class == 1 {
+            min_ttl = Some(min_ttl.map_or(answer.ttl, |current: u32| current.min(answer.ttl)));
         }
-        offset = next;
+        offset = answer.next;
+        answers.push(answer);
     }
     for _ in 0..authority_count {
         let (next, _, class, ttl, _) = record(response, offset)?;
@@ -136,11 +129,107 @@ pub(crate) fn parse_response(query: &[u8], response: &[u8]) -> io::Result<Parsed
     if offset != response.len() {
         return Err(invalid("DNS response has trailing bytes"));
     }
+    let terminal_name = trusted_cname_terminal(&expected.domain, response, &answers)?;
+    let mut addresses = Vec::new();
+    for answer in answers {
+        if answer.class != 1
+            || !matches!(
+                (answer.record_type, expected.query_type),
+                (TYPE_A, TYPE_A) | (TYPE_AAAA, TYPE_AAAA)
+            )
+            || normalize_response_name(&answer.owner)? != terminal_name
+        {
+            continue;
+        }
+        match (answer.record_type, answer.rdata.len()) {
+            (TYPE_A, 4) => addresses.push(IpAddress::V4([
+                answer.rdata[0],
+                answer.rdata[1],
+                answer.rdata[2],
+                answer.rdata[3],
+            ])),
+            (TYPE_AAAA, 16) => {
+                let mut octets = [0_u8; 16];
+                octets.copy_from_slice(answer.rdata);
+                addresses.push(IpAddress::V6(octets));
+            }
+            _ => {}
+        }
+    }
     Ok(ParsedDnsResponse {
         addresses,
         min_ttl_seconds: min_ttl,
         response_code: response[3] & 0x0f,
         truncated: response[2] & 0x02 != 0,
+    })
+}
+
+fn trusted_cname_terminal(
+    query_name: &str,
+    message: &[u8],
+    answers: &[ResourceRecord<'_>],
+) -> io::Result<String> {
+    let mut aliases = HashMap::new();
+    for answer in answers {
+        if answer.class != 1 || answer.record_type != TYPE_CNAME {
+            continue;
+        }
+        let owner = normalize_response_name(&answer.owner)?;
+        let (target, target_end) = decode_name(message, answer.rdata_start)?;
+        if target_end != answer.next {
+            return Err(invalid("DNS CNAME RDATA length is invalid"));
+        }
+        let target = normalize_response_name(&target)?;
+        if let Some(previous) = aliases.insert(owner, target.clone()) {
+            if previous != target {
+                return Err(invalid("DNS response contains conflicting CNAME targets"));
+            }
+        }
+    }
+
+    let mut current = query_name.to_owned();
+    let mut visited = HashSet::new();
+    loop {
+        if !visited.insert(current.clone()) {
+            return Err(invalid("DNS response contains a CNAME loop"));
+        }
+        let Some(target) = aliases.get(&current) else {
+            return Ok(current);
+        };
+        current = target.clone();
+    }
+}
+
+fn normalize_response_name(name: &str) -> io::Result<String> {
+    normalize_domain(name).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("DNS response contains an invalid name: {error}"),
+        )
+    })
+}
+
+struct ResourceRecord<'a> {
+    next: usize,
+    owner: String,
+    record_type: u16,
+    class: u16,
+    ttl: u32,
+    rdata_start: usize,
+    rdata: &'a [u8],
+}
+
+fn named_record(data: &[u8], offset: usize) -> io::Result<ResourceRecord<'_>> {
+    let (owner, _) = decode_name(data, offset)?;
+    let (next, record_type, class, ttl, rdata) = record(data, offset)?;
+    Ok(ResourceRecord {
+        next,
+        owner,
+        record_type,
+        class,
+        ttl,
+        rdata_start: next - rdata.len(),
+        rdata,
     })
 }
 

--- a/crates/dns/tests/cname_chain.rs
+++ b/crates/dns/tests/cname_chain.rs
@@ -1,0 +1,246 @@
+#![cfg(feature = "udp")]
+
+use std::io;
+
+use zero_config::{DnsCacheConfig, DnsReverseMappingConfig};
+use zero_dns::RealIpReverseLookup;
+use zero_traits::IpAddress;
+
+#[path = "cname_chain/support.rs"]
+mod support;
+
+use support::{
+    append_record, compression_pointer, config, encoded_name, resolve_once, response_header,
+    TYPE_A, TYPE_AAAA, TYPE_CNAME,
+};
+
+#[tokio::test]
+async fn direct_a_and_aaaa_answers_remain_valid() {
+    let ipv4 = resolve_once("direct.example", TYPE_A, |query| {
+        let mut response = response_header(query, 1);
+        append_record(
+            &mut response,
+            "direct.example",
+            TYPE_A,
+            60,
+            &[192, 0, 2, 10],
+        );
+        response
+    })
+    .await
+    .expect("resolve direct A answer");
+    assert_eq!(ipv4, vec![IpAddress::V4([192, 0, 2, 10])]);
+
+    let expected_v6 = [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10];
+    let ipv6 = resolve_once("direct.example", TYPE_AAAA, move |query| {
+        let mut response = response_header(query, 1);
+        append_record(&mut response, "direct.example", TYPE_AAAA, 60, &expected_v6);
+        response
+    })
+    .await
+    .expect("resolve direct AAAA answer");
+    assert_eq!(ipv6, vec![IpAddress::V6(expected_v6)]);
+}
+
+#[tokio::test]
+async fn unrelated_answer_owner_is_not_a_resolution_candidate() {
+    let result = resolve_once("victim.example", TYPE_A, |query| {
+        let mut response = response_header(query, 1);
+        append_record(
+            &mut response,
+            "unrelated.example",
+            TYPE_A,
+            60,
+            &[203, 0, 113, 99],
+        );
+        response
+    })
+    .await;
+
+    let error = result.expect_err("unrelated answer owner must not resolve the query");
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+}
+
+#[tokio::test]
+async fn unrelated_address_is_not_cached_or_reverse_mapped() {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind instrumented DNS server");
+    let port = socket.local_addr().expect("DNS endpoint").port();
+    let server = tokio::spawn(async move {
+        for (owner, address) in [
+            ("unrelated.example", [203, 0, 113, 99]),
+            ("victim.example", [192, 0, 2, 40]),
+        ] {
+            let mut request = [0_u8; 4096];
+            let (size, peer) = socket
+                .recv_from(&mut request)
+                .await
+                .expect("receive DNS query");
+            let mut response = response_header(&request[..size], 1);
+            append_record(&mut response, owner, TYPE_A, 60, &address);
+            socket
+                .send_to(&response, peer)
+                .await
+                .expect("send DNS response");
+        }
+    });
+
+    let mut dns_config = config(port);
+    dns_config.cache = Some(DnsCacheConfig {
+        max_entries: 16,
+        max_ttl_seconds: Some(60),
+    });
+    dns_config.reverse_mapping = Some(DnsReverseMappingConfig {
+        max_entries: 16,
+        max_domains_per_address: 4,
+        max_ttl_seconds: 60,
+    });
+    let egress = zero_platform_tokio::EgressInterfaceControl::default();
+    let dns = zero_dns::DnsSystem::build_with_egress(Some(&dns_config), egress.clone())
+        .expect("build DNS system");
+
+    let first = dns.resolve_real_type("victim.example", TYPE_A).await;
+    assert_eq!(
+        first.expect_err("unrelated answer must be NODATA").kind(),
+        io::ErrorKind::NotFound
+    );
+    assert_eq!(
+        dns.lookup_real_ip(&IpAddress::V4([203, 0, 113, 99])).await,
+        RealIpReverseLookup::Missing
+    );
+
+    // A topology generation change deliberately invalidates the short-lived
+    // query-coordinator failure cache, so this second lookup proves that no
+    // address-cache entry was written for the unrelated answer.
+    egress.replace_tunnel_addresses(["10.66.0.1".parse().expect("TUN address")]);
+    assert_eq!(
+        dns.resolve_real_type("victim.example", TYPE_A)
+            .await
+            .expect("second query reaches upstream"),
+        vec![IpAddress::V4([192, 0, 2, 40])]
+    );
+    assert_eq!(
+        dns.lookup_real_ip(&IpAddress::V4([192, 0, 2, 40])).await,
+        RealIpReverseLookup::Resolved("victim.example".to_owned())
+    );
+    server.await.expect("instrumented DNS server task");
+}
+
+#[tokio::test]
+async fn resolves_one_hop_cname_with_compressed_target() {
+    let addresses = resolve_once("alias.example", TYPE_A, |query| {
+        let mut response = response_header(query, 2);
+        let terminal_owner_offset = response.len();
+        append_record(
+            &mut response,
+            "canonical.example",
+            TYPE_A,
+            60,
+            &[192, 0, 2, 20],
+        );
+        let target = compression_pointer(terminal_owner_offset);
+        append_record(&mut response, "alias.example", TYPE_CNAME, 60, &target);
+        response
+    })
+    .await
+    .expect("resolve compressed CNAME target");
+
+    assert_eq!(addresses, vec![IpAddress::V4([192, 0, 2, 20])]);
+}
+
+#[tokio::test]
+async fn resolves_unordered_multi_hop_chain_and_ignores_unrelated_address() {
+    let addresses = resolve_once("root.example", TYPE_A, |query| {
+        let mut response = response_header(query, 4);
+        append_record(
+            &mut response,
+            "unrelated.example",
+            TYPE_A,
+            60,
+            &[203, 0, 113, 77],
+        );
+        append_record(
+            &mut response,
+            "terminal.example",
+            TYPE_A,
+            60,
+            &[192, 0, 2, 30],
+        );
+        append_record(
+            &mut response,
+            "middle.example",
+            TYPE_CNAME,
+            60,
+            &encoded_name("terminal.example"),
+        );
+        append_record(
+            &mut response,
+            "root.example",
+            TYPE_CNAME,
+            60,
+            &encoded_name("middle.example"),
+        );
+        response
+    })
+    .await
+    .expect("resolve unordered multi-hop CNAME chain");
+
+    assert_eq!(addresses, vec![IpAddress::V4([192, 0, 2, 30])]);
+}
+
+#[tokio::test]
+async fn invalid_trusted_cname_chains_fail_closed() {
+    let loop_error = resolve_once("loop.example", TYPE_A, |query| {
+        let mut response = response_header(query, 2);
+        append_record(
+            &mut response,
+            "loop.example",
+            TYPE_CNAME,
+            60,
+            &encoded_name("middle.example"),
+        );
+        append_record(
+            &mut response,
+            "middle.example",
+            TYPE_CNAME,
+            60,
+            &encoded_name("loop.example"),
+        );
+        response
+    })
+    .await
+    .expect_err("CNAME loop must fail closed");
+    assert_eq!(loop_error.kind(), io::ErrorKind::TimedOut);
+
+    let conflict_error = resolve_once("conflict.example", TYPE_A, |query| {
+        let mut response = response_header(query, 2);
+        append_record(
+            &mut response,
+            "conflict.example",
+            TYPE_CNAME,
+            60,
+            &encoded_name("one.example"),
+        );
+        append_record(
+            &mut response,
+            "conflict.example",
+            TYPE_CNAME,
+            60,
+            &encoded_name("two.example"),
+        );
+        response
+    })
+    .await
+    .expect_err("conflicting CNAME targets must fail closed");
+    assert_eq!(conflict_error.kind(), io::ErrorKind::TimedOut);
+
+    let malformed_error = resolve_once("malformed.example", TYPE_A, |query| {
+        let mut response = response_header(query, 1);
+        append_record(&mut response, "malformed.example", TYPE_CNAME, 60, &[0xc0]);
+        response
+    })
+    .await
+    .expect_err("malformed CNAME RDATA must fail closed");
+    assert_eq!(malformed_error.kind(), io::ErrorKind::TimedOut);
+}

--- a/crates/dns/tests/cname_chain/support.rs
+++ b/crates/dns/tests/cname_chain/support.rs
@@ -1,0 +1,115 @@
+use std::collections::BTreeMap;
+use std::io;
+
+use zero_config::{DnsAnswerConfig, DnsConfig, DnsPolicyConfig, DnsServerConfig};
+use zero_traits::IpAddress;
+
+pub(super) const TYPE_A: u16 = 1;
+pub(super) const TYPE_CNAME: u16 = 5;
+pub(super) const TYPE_AAAA: u16 = 28;
+
+pub(super) async fn resolve_once(
+    domain: &str,
+    query_type: u16,
+    build_response: impl FnOnce(&[u8]) -> Vec<u8> + Send + 'static,
+) -> io::Result<Vec<IpAddress>> {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind instrumented DNS server");
+    let port = socket.local_addr().expect("DNS endpoint").port();
+    let server = tokio::spawn(async move {
+        let mut request = [0_u8; 4096];
+        let (size, peer) = socket
+            .recv_from(&mut request)
+            .await
+            .expect("receive DNS query");
+        let response = build_response(&request[..size]);
+        socket
+            .send_to(&response, peer)
+            .await
+            .expect("send DNS response");
+    });
+
+    let dns = zero_dns::DnsSystem::build(Some(&config(port))).expect("build DNS system");
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        dns.resolve_real_type(domain, query_type),
+    )
+    .await
+    .expect("DNS resolution timed out");
+    server.await.expect("instrumented DNS server task");
+    result
+}
+
+pub(super) fn config(port: u16) -> DnsConfig {
+    DnsConfig {
+        servers: BTreeMap::from([(
+            "local".to_owned(),
+            DnsServerConfig::Udp {
+                host: "127.0.0.1".to_owned(),
+                port,
+                bootstrap: Vec::new(),
+                detour: None,
+            },
+        )]),
+        default_server: "local".to_owned(),
+        dispatch: Vec::new(),
+        cache: None,
+        reverse_mapping: None,
+        answer: DnsAnswerConfig::Real,
+        policy: DnsPolicyConfig {
+            timeout_ms: 250,
+            ..Default::default()
+        },
+    }
+}
+
+pub(super) fn response_header(query: &[u8], answer_count: u16) -> Vec<u8> {
+    zero_dns::udp::parse_dns_question(query).expect("parse DNS question");
+    let question_end = question_end(query);
+    let mut response = Vec::new();
+    response.extend_from_slice(&query[..2]);
+    response.extend_from_slice(&[0x81, 0x80]);
+    response.extend_from_slice(&1_u16.to_be_bytes());
+    response.extend_from_slice(&answer_count.to_be_bytes());
+    response.extend_from_slice(&0_u16.to_be_bytes());
+    response.extend_from_slice(&0_u16.to_be_bytes());
+    response.extend_from_slice(&query[12..question_end]);
+    response
+}
+
+pub(super) fn append_record(response: &mut Vec<u8>, owner: &str, kind: u16, ttl: u32, data: &[u8]) {
+    encode_name(owner, response);
+    response.extend_from_slice(&kind.to_be_bytes());
+    response.extend_from_slice(&1_u16.to_be_bytes());
+    response.extend_from_slice(&ttl.to_be_bytes());
+    response.extend_from_slice(&(data.len() as u16).to_be_bytes());
+    response.extend_from_slice(data);
+}
+
+pub(super) fn encoded_name(name: &str) -> Vec<u8> {
+    let mut output = Vec::new();
+    encode_name(name, &mut output);
+    output
+}
+
+pub(super) fn compression_pointer(offset: usize) -> [u8; 2] {
+    assert!(offset <= 0x3fff, "DNS compression pointer offset");
+    [0xc0 | ((offset >> 8) as u8), offset as u8]
+}
+
+fn question_end(message: &[u8]) -> usize {
+    let mut offset = 12;
+    while message[offset] != 0 {
+        offset += usize::from(message[offset]) + 1;
+    }
+    offset + 5
+}
+
+fn encode_name(name: &str, output: &mut Vec<u8>) {
+    for label in name.split('.') {
+        output.push(label.len() as u8);
+        output.extend_from_slice(label.as_bytes());
+    }
+    output.push(0);
+}

--- a/docs/testing/dns-e2e.md
+++ b/docs/testing/dns-e2e.md
@@ -127,6 +127,14 @@ two families, and starts later candidates after a bounded delay. Each candidate
 performs its own TUN egress selection and interface binding; a failed first DNS
 answer therefore does not prevent a reachable answer from being used.
 
+Address candidates are accepted only when the A/AAAA owner is the queried name
+or the terminal canonical name of a valid query-rooted CNAME chain. Compressed
+and unordered CNAME answers are supported. Unrelated answer owners are retained
+only in the raw forwarded DNS message; they never enter the address cache,
+reverse mapping, or outbound candidate set. A malformed, conflicting, or cyclic
+trusted CNAME chain is rejected as a malformed upstream response. Additional-
+section glue is not promoted to a trusted address candidate.
+
 When `reverse_mapping` is present, successful real A/AAAA answers also populate
 a bounded IP-to-domain index owned by `zero-dns`. Transparent TUN sessions may
 recover an unambiguous logical domain from that index while retaining the


### PR DESCRIPTION
Closes #79
Part of #33
Part of #52

## Summary

- restrict resolved A/AAAA candidates to the query owner or the terminal owner of a query-rooted CNAME chain
- support compressed and dependency-unordered one-hop/multi-hop CNAME answers
- reject conflicting, cyclic, and malformed CNAME chains before they can affect resolution
- keep unrelated answer records in the raw forwarded message while excluding them from address cache, reverse mapping, and outbound candidates
- document that additional-section glue is not promoted to a trusted target

## Regression evidence

Before the implementation, the focused regression returned:

```text
unrelated answer owner must not resolve the query: [V4([203, 0, 113, 99])]
```

New integration coverage proves:

- direct A and AAAA remain valid
- compressed one-hop CNAME works
- unordered multi-hop CNAME works
- unrelated records cannot win by answer order
- unrelated addresses are neither cached nor reverse-mapped
- CNAME loops, conflicting targets, and malformed compressed RDATA fail closed

## Validation

- `cargo test -p zero-dns --features udp --test cname_chain --locked`
- `cargo test -p zero-dns --all-features --locked --jobs 1`
- `cargo clippy -p zero-dns --all-features --all-targets --locked --jobs 1`
- `cargo check -p zero-dns --no-default-features --locked --jobs 1`
- `cargo check -p zero-proxy --all-features --locked --jobs 1`
- `cargo fmt --all -- --check`
- `git diff --check`
