### PR TITLE
fix(connector): bind webhook delivery to TUN underlay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,11 @@ trojan = ["zero-proxy/trojan"]
 vmess = ["zero-proxy/vmess"]
 mieru = ["zero-proxy/mieru"]
 status-api = []
-event-dispatcher = ["dep:zero-connector", "zero-connector/event-dispatcher"]
+event-dispatcher = [
+    "dep:zero-connector",
+    "dep:zero-platform-tokio",
+    "zero-connector/event-dispatcher",
+]
 sink-jsonl = ["event-dispatcher", "zero-connector/sink-jsonl"]
 connector = ["event-dispatcher", "zero-connector/webhook"]
 grpc-api = ["dep:zero-grpc"]
@@ -110,6 +114,7 @@ zero-api = { path = "crates/api" }
 zero-config = { path = "crates/config" }
 zero-engine = { path = "crates/engine", default-features = false }
 zero-logging = { path = "crates/logging" }
+zero-platform-tokio = { path = "crates/platform/tokio", optional = true }
 zero-proxy = { path = "crates/proxy", default-features = false }
 zero-connector = { path = "crates/connector", optional = true, default-features = false }
 zero-grpc = { path = "crates/grpc", optional = true }

--- a/crates/connector/Cargo.toml
+++ b/crates/connector/Cargo.toml
@@ -11,17 +11,40 @@ homepage.workspace = true
 default = []
 event-dispatcher = []
 sink-jsonl = ["event-dispatcher"]
-webhook = ["event-dispatcher", "dep:reqwest"]
+webhook = [
+    "event-dispatcher",
+    "dep:bytes",
+    "dep:http",
+    "dep:http-body-util",
+    "dep:hyper",
+    "dep:hyper-rustls",
+    "dep:hyper-util",
+    "dep:rustls",
+    "dep:tower-service",
+    "dep:webpki-roots",
+]
 
 [dependencies]
 async-trait = "0.1"
+bytes = { version = "1", optional = true }
 fs2.workspace = true
+http = { version = "1", optional = true }
+http-body-util = { version = "0.1", optional = true }
+hyper = { version = "1", default-features = false, features = ["client", "http1"], optional = true }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "ring", "tls12"], optional = true }
+hyper-util = { version = "0.1", default-features = false, features = ["client-legacy", "http1", "tokio"], optional = true }
+rustls = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tower-service = { version = "0.3", optional = true }
 tracing.workspace = true
+webpki-roots = { version = "1", optional = true }
 zero-api = { path = "../api" }
 zero-config = { path = "../config" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+
+[dev-dependencies]
+rcgen = "0.14"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }

--- a/crates/connector/src/dispatcher.rs
+++ b/crates/connector/src/dispatcher.rs
@@ -13,6 +13,7 @@ use zero_api::{
 };
 use zero_config::{ApiConfig, EventDispatcherConfig};
 
+use crate::network::EventDispatcherNetwork;
 use crate::registry::{build_event_sinks, resolve_path, ConfiguredEventSink};
 use crate::{ConnectorError, ConnectorResult};
 
@@ -155,7 +156,32 @@ pub fn spawn_event_dispatcher<S>(
 where
     S: EventSource + Send + Sync + 'static,
 {
-    spawn_event_dispatcher_inner(source, api, source_dir, options, false)
+    spawn_event_dispatcher_inner(
+        source,
+        api,
+        source_dir,
+        options,
+        EventDispatcherNetwork::system(),
+        false,
+    )
+}
+
+/// Start an event dispatcher with an explicitly supplied network boundary.
+///
+/// The Zero application uses this entrypoint to share the same physical-egress
+/// authority as proxy and DNS sockets. Standalone embeddings that cannot run a
+/// TUN data plane may continue to use [`spawn_event_dispatcher`].
+pub fn spawn_event_dispatcher_with_network<S>(
+    source: S,
+    api: ApiConfig,
+    source_dir: Option<PathBuf>,
+    options: EventDispatcherOptions,
+    network: EventDispatcherNetwork,
+) -> ConnectorResult<Option<EventDispatcherHandle>>
+where
+    S: EventSource + Send + Sync + 'static,
+{
+    spawn_event_dispatcher_inner(source, api, source_dir, options, network, false)
 }
 
 /// Start an event dispatcher and bootstrap the retained `engine.started`
@@ -174,7 +200,29 @@ pub fn spawn_event_dispatcher_with_engine_started<S>(
 where
     S: EventSource + Send + Sync + 'static,
 {
-    spawn_event_dispatcher_inner(source, api, source_dir, options, true)
+    spawn_event_dispatcher_inner(
+        source,
+        api,
+        source_dir,
+        options,
+        EventDispatcherNetwork::system(),
+        true,
+    )
+}
+
+/// Start an explicitly network-bound event dispatcher and bootstrap the
+/// retained `engine.started` fact.
+pub fn spawn_event_dispatcher_with_engine_started_and_network<S>(
+    source: S,
+    api: ApiConfig,
+    source_dir: Option<PathBuf>,
+    options: EventDispatcherOptions,
+    network: EventDispatcherNetwork,
+) -> ConnectorResult<Option<EventDispatcherHandle>>
+where
+    S: EventSource + Send + Sync + 'static,
+{
+    spawn_event_dispatcher_inner(source, api, source_dir, options, network, true)
 }
 
 fn spawn_event_dispatcher_inner<S>(
@@ -182,6 +230,7 @@ fn spawn_event_dispatcher_inner<S>(
     api: ApiConfig,
     source_dir: Option<PathBuf>,
     options: EventDispatcherOptions,
+    network: EventDispatcherNetwork,
     bootstrap_engine_started: bool,
 ) -> ConnectorResult<Option<EventDispatcherHandle>>
 where
@@ -201,7 +250,7 @@ where
     let stats_for_thread = sink_stats.clone();
 
     let task = tokio::task::spawn_blocking(move || {
-        let sinks = match build_event_sinks(&api, source_dir.as_deref()) {
+        let sinks = match build_event_sinks(&api, source_dir.as_deref(), &network) {
             Ok(sinks) => sinks,
             Err(error) => {
                 let _ = init_tx.send(Err(error));

--- a/crates/connector/src/lib.rs
+++ b/crates/connector/src/lib.rs
@@ -2,6 +2,8 @@
 mod dispatcher;
 mod error;
 #[cfg(feature = "event-dispatcher")]
+mod network;
+#[cfg(feature = "event-dispatcher")]
 mod registry;
 #[cfg(feature = "event-dispatcher")]
 mod state;
@@ -10,10 +12,15 @@ mod webhook;
 
 #[cfg(feature = "event-dispatcher")]
 pub use dispatcher::{
-    spawn_event_dispatcher, spawn_event_dispatcher_with_engine_started, EventDispatcherHandle,
-    EventDispatcherOptions, EventDispatcherStatusHandle,
+    spawn_event_dispatcher, spawn_event_dispatcher_with_engine_started,
+    spawn_event_dispatcher_with_engine_started_and_network, spawn_event_dispatcher_with_network,
+    EventDispatcherHandle, EventDispatcherOptions, EventDispatcherStatusHandle,
 };
 pub use error::{ConnectorError, ConnectorResult};
+#[cfg(feature = "event-dispatcher")]
+pub use network::{
+    EventDispatcherNetwork, EventSinkTcpConnectFuture, EventSinkTcpDialer, EventSinkTcpStream,
+};
 #[cfg(feature = "event-dispatcher")]
 pub use state::{
     inspect_persistent_state, ConnectorStateFile, ConnectorStateReport, ConnectorStateStatus,

--- a/crates/connector/src/network.rs
+++ b/crates/connector/src/network.rs
@@ -1,0 +1,67 @@
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub trait EventSinkTcpStream: AsyncRead + AsyncWrite + Unpin + Send + 'static {}
+
+impl<T> EventSinkTcpStream for T where T: AsyncRead + AsyncWrite + Unpin + Send + 'static {}
+
+pub type EventSinkTcpConnectFuture =
+    Pin<Box<dyn Future<Output = io::Result<Box<dyn EventSinkTcpStream>>> + Send + 'static>>;
+
+/// Narrow network boundary used by event delivery transports.
+///
+/// The standalone connector crate can use [`EventDispatcherNetwork::system`].
+/// The Zero application injects its shared TUN underlay-aware dialer instead so
+/// webhook sockets cannot re-enter the data plane.
+pub trait EventSinkTcpDialer: Send + Sync + 'static {
+    fn connect(&self, host: String, port: u16) -> EventSinkTcpConnectFuture;
+}
+
+#[derive(Clone)]
+pub struct EventDispatcherNetwork {
+    #[cfg_attr(not(feature = "webhook"), allow(dead_code))]
+    dialer: Arc<dyn EventSinkTcpDialer>,
+}
+
+impl EventDispatcherNetwork {
+    pub fn new(dialer: Arc<dyn EventSinkTcpDialer>) -> Self {
+        Self { dialer }
+    }
+
+    /// Explicit system-route network for standalone embedding and tests.
+    ///
+    /// The Zero binary does not use this path: it injects the proxy's shared
+    /// egress authority with `EventDispatcherNetwork::new`.
+    pub fn system() -> Self {
+        Self::new(Arc::new(SystemEventSinkTcpDialer))
+    }
+
+    #[cfg(feature = "webhook")]
+    pub(crate) fn dialer(&self) -> Arc<dyn EventSinkTcpDialer> {
+        self.dialer.clone()
+    }
+}
+
+impl std::fmt::Debug for EventDispatcherNetwork {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EventDispatcherNetwork")
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+struct SystemEventSinkTcpDialer;
+
+impl EventSinkTcpDialer for SystemEventSinkTcpDialer {
+    fn connect(&self, host: String, port: u16) -> EventSinkTcpConnectFuture {
+        Box::pin(async move {
+            let stream = tokio::net::TcpStream::connect((host.as_str(), port)).await?;
+            Ok(Box::new(stream) as Box<dyn EventSinkTcpStream>)
+        })
+    }
+}

--- a/crates/connector/src/registry.rs
+++ b/crates/connector/src/registry.rs
@@ -3,9 +3,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+#[cfg(feature = "sink-jsonl")]
 use zero_api::EventSink;
 use zero_config::{ApiConfig, EventSinkConfig};
 
+use crate::network::EventDispatcherNetwork;
 use crate::state::PersistentStateLease;
 use crate::{ConnectorError, ConnectorResult};
 
@@ -48,10 +50,12 @@ pub(crate) trait AsyncDeliverySink: Send + Sync {
     }
 }
 
+#[cfg(feature = "sink-jsonl")]
 struct BlockingEventSink {
     sink: Arc<dyn EventSink + Send + Sync>,
 }
 
+#[cfg(feature = "sink-jsonl")]
 #[async_trait]
 impl AsyncDeliverySink for BlockingEventSink {
     async fn publish(
@@ -73,6 +77,7 @@ impl AsyncDeliverySink for BlockingEventSink {
 pub(crate) fn build_event_sinks(
     api: &ApiConfig,
     source_dir: Option<&Path>,
+    network: &EventDispatcherNetwork,
 ) -> ConnectorResult<Vec<ConfiguredEventSink>> {
     api.event_sinks
         .iter()
@@ -81,6 +86,7 @@ pub(crate) fn build_event_sinks(
                 config,
                 source_dir,
                 std::time::Duration::from_millis(api.dispatcher.webhook_timeout_ms),
+                network,
             )
         })
         .collect()
@@ -90,6 +96,7 @@ fn build_event_sink(
     config: &EventSinkConfig,
     source_dir: Option<&Path>,
     webhook_timeout: std::time::Duration,
+    network: &EventDispatcherNetwork,
 ) -> ConnectorResult<ConfiguredEventSink> {
     match config {
         EventSinkConfig::JsonLines {
@@ -98,22 +105,7 @@ fn build_event_sink(
             events,
             source_id,
         } => build_json_line_sink(tag, path, events, source_id, source_dir),
-        EventSinkConfig::Webhook {
-            tag,
-            url,
-            events,
-            source_id,
-            headers,
-            allow_insecure,
-        } => build_webhook_sink(
-            tag,
-            url,
-            events,
-            source_id,
-            headers,
-            *allow_insecure,
-            webhook_timeout,
-        ),
+        EventSinkConfig::Webhook { .. } => build_webhook_sink(config, webhook_timeout, network),
     }
 }
 
@@ -167,23 +159,30 @@ fn build_json_line_sink(
 
 #[cfg(feature = "webhook")]
 fn build_webhook_sink(
-    tag: &str,
-    url: &str,
-    events: &[String],
-    source_id: &Option<String>,
-    headers: &std::collections::BTreeMap<String, String>,
-    allow_insecure: bool,
+    registration: &EventSinkConfig,
     timeout: std::time::Duration,
+    network: &EventDispatcherNetwork,
 ) -> ConnectorResult<ConfiguredEventSink> {
+    let EventSinkConfig::Webhook {
+        tag,
+        url,
+        events,
+        source_id,
+        headers,
+        allow_insecure,
+    } = registration
+    else {
+        unreachable!("webhook builder only receives webhook registrations")
+    };
     let mut config =
         crate::webhook::WebhookEventSinkConfig::new(url.to_owned()).with_timeout(timeout);
     for (name, value) in headers {
         config = config.with_header(name.clone(), value.clone());
     }
-    if allow_insecure {
+    if *allow_insecure {
         config = config.with_allow_insecure(true);
     }
-    let sink = crate::webhook::WebhookEventSink::with_config(config)?;
+    let sink = crate::webhook::WebhookEventSink::with_config(config, network)?;
 
     Ok(ConfiguredEventSink {
         tag: tag.to_owned(),
@@ -196,14 +195,13 @@ fn build_webhook_sink(
 
 #[cfg(not(feature = "webhook"))]
 fn build_webhook_sink(
-    tag: &str,
-    _url: &str,
-    _events: &[String],
-    _source_id: &Option<String>,
-    _headers: &std::collections::BTreeMap<String, String>,
-    _allow_insecure: bool,
+    registration: &EventSinkConfig,
     _timeout: std::time::Duration,
+    _network: &EventDispatcherNetwork,
 ) -> ConnectorResult<ConfiguredEventSink> {
+    let EventSinkConfig::Webhook { tag, .. } = registration else {
+        unreachable!("webhook builder only receives webhook registrations")
+    };
     Err(ConnectorError::FeatureDisabled {
         feature: "connector",
         sink_type: "webhook",

--- a/crates/connector/src/webhook.rs
+++ b/crates/connector/src/webhook.rs
@@ -1,15 +1,32 @@
 use std::collections::BTreeMap;
+use std::error::Error as StdError;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-use reqwest::Client;
-use reqwest::{StatusCode, Url};
+use bytes::Bytes;
+use http::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
+use http::{Method, Request, StatusCode, Uri};
+use http_body_util::Full;
+use hyper::rt::{Read, ReadBufCursor, Write};
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
+use hyper_util::client::legacy::connect::{Connected, Connection};
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tower_service::Service;
 use zero_api::{ApiError, ApiErrorCode, ApiResult, PublishResult, RawApiEvent};
 
+use crate::network::{EventDispatcherNetwork, EventSinkTcpDialer, EventSinkTcpStream};
 use crate::registry::AsyncDeliverySink;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+const JSON_CONTENT_TYPE: &str = "application/json";
+
+type WebhookHttpClient = Client<HttpsConnector<EgressHttpConnector>, Full<Bytes>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WebhookEventSinkConfig {
@@ -45,43 +62,71 @@ impl WebhookEventSinkConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct WebhookEventSink {
-    client: Client,
-    url: Url,
+    client: WebhookHttpClient,
+    uri: Uri,
     headers: HeaderMap,
+    timeout: Duration,
+}
+
+impl std::fmt::Debug for WebhookEventSink {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WebhookEventSink")
+            .field("uri", &self.uri)
+            .field("timeout", &self.timeout)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WebhookEventSink {
-    pub(crate) fn with_config(config: WebhookEventSinkConfig) -> ApiResult<Self> {
-        let url = parse_webhook_url(&config.url)?;
+    pub(crate) fn with_config(
+        config: WebhookEventSinkConfig,
+        network: &EventDispatcherNetwork,
+    ) -> ApiResult<Self> {
+        let uri = parse_webhook_uri(&config.url)?;
         let headers = parse_headers(&config.headers)?;
-        let mut builder = Client::builder()
-            .timeout(config.timeout)
-            .redirect(reqwest::redirect::Policy::none());
-        if config.allow_insecure {
-            builder = builder.danger_accept_invalid_certs(true);
-        }
-        let client = builder.build().map_err(client_error)?;
+        let tls = build_tls_config(config.allow_insecure)?;
+        let connector = HttpsConnectorBuilder::new()
+            .with_tls_config(tls)
+            .https_or_http()
+            .enable_http1()
+            .wrap_connector(EgressHttpConnector::new(network.dialer()));
+        let client = Client::builder(TokioExecutor::new()).build(connector);
 
         Ok(Self {
             client,
-            url,
+            uri,
             headers,
+            timeout: config.timeout,
         })
+    }
+
+    fn request(&self, event: &RawApiEvent) -> Result<Request<Full<Bytes>>, String> {
+        let body = serde_json::to_vec(event)
+            .map_err(|error| format!("serialize webhook event: {error}"))?;
+        let mut request = Request::builder()
+            .method(Method::POST)
+            .uri(self.uri.clone())
+            .header(CONTENT_TYPE, JSON_CONTENT_TYPE)
+            .body(Full::new(Bytes::from(body)))
+            .map_err(|error| format!("build webhook request: {error}"))?;
+        request.headers_mut().extend(self.headers.clone());
+        Ok(request)
     }
 }
 
 #[async_trait]
 impl AsyncDeliverySink for WebhookEventSink {
     async fn publish(&self, event: RawApiEvent) -> ApiResult<PublishResult> {
-        let mut request = self.client.post(self.url.clone()).json(&event);
-        if !self.headers.is_empty() {
-            request = request.headers(self.headers.clone());
-        }
+        let request = match self.request(&event) {
+            Ok(request) => request,
+            Err(error) => return Ok(request_failure(error)),
+        };
 
-        match request.send().await {
-            Ok(response) => {
+        match tokio::time::timeout(self.timeout, self.client.request(request)).await {
+            Ok(Ok(response)) => {
                 let status = response.status();
                 if status.is_success() {
                     Ok(PublishResult::delivered())
@@ -93,11 +138,14 @@ impl AsyncDeliverySink for WebhookEventSink {
                     })
                 }
             }
-            Err(error) => Ok(PublishResult {
-                delivered: false,
-                retryable: true,
-                message: Some(format!("webhook request failed: {error}")),
-            }),
+            Ok(Err(error)) => Ok(request_failure(format_error_chain(
+                "webhook request failed",
+                &error,
+            ))),
+            Err(_) => Ok(request_failure(format!(
+                "webhook request failed: request timed out after {} ms",
+                self.timeout.as_millis()
+            ))),
         }
     }
 
@@ -106,8 +154,103 @@ impl AsyncDeliverySink for WebhookEventSink {
     }
 }
 
-fn parse_webhook_url(raw_url: &str) -> ApiResult<Url> {
-    let url = Url::parse(raw_url).map_err(|error| ApiError {
+#[derive(Clone)]
+struct EgressHttpConnector {
+    dialer: Arc<dyn EventSinkTcpDialer>,
+}
+
+impl EgressHttpConnector {
+    fn new(dialer: Arc<dyn EventSinkTcpDialer>) -> Self {
+        Self { dialer }
+    }
+}
+
+impl Service<Uri> for EgressHttpConnector {
+    type Response = EventSinkConnection;
+    type Error = io::Error;
+    type Future = Pin<Box<dyn Future<Output = io::Result<EventSinkConnection>> + Send>>;
+
+    fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        let dialer = self.dialer.clone();
+        let host = match uri.host() {
+            Some(host) => host.to_owned(),
+            None => return Box::pin(async { Err(invalid_uri("webhook URI has no host")) }),
+        };
+        let port = match uri.port_u16().or_else(|| default_port(&uri)) {
+            Some(port) => port,
+            None => return Box::pin(async { Err(invalid_uri("webhook URI has no usable port")) }),
+        };
+        Box::pin(async move {
+            let stream = dialer.connect(host, port).await?;
+            Ok(EventSinkConnection::new(stream))
+        })
+    }
+}
+
+struct EventSinkConnection {
+    inner: TokioIo<Box<dyn EventSinkTcpStream>>,
+}
+
+impl EventSinkConnection {
+    fn new(stream: Box<dyn EventSinkTcpStream>) -> Self {
+        Self {
+            inner: TokioIo::new(stream),
+        }
+    }
+}
+
+impl Connection for EventSinkConnection {
+    fn connected(&self) -> Connected {
+        Connected::new()
+    }
+}
+
+impl Read for EventSinkConnection {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: ReadBufCursor<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(context, buffer)
+    }
+}
+
+impl Write for EventSinkConnection {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(context, buffer)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(context)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(context)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffers: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(context, buffers)
+    }
+}
+
+fn parse_webhook_uri(raw_url: &str) -> ApiResult<Uri> {
+    let uri = raw_url.parse::<Uri>().map_err(|error| ApiError {
         code: ApiErrorCode::InvalidArgument,
         message: "webhook url is invalid".to_owned(),
         field_path: Some("url".to_owned()),
@@ -115,13 +258,20 @@ fn parse_webhook_url(raw_url: &str) -> ApiResult<Url> {
         details: Vec::new(),
     })?;
 
-    match url.scheme() {
-        "http" | "https" => Ok(url),
-        scheme => Err(ApiError {
+    match uri.scheme_str() {
+        Some("http" | "https") if uri.host().is_some() => Ok(uri),
+        Some(scheme) if scheme != "http" && scheme != "https" => Err(ApiError {
             code: ApiErrorCode::InvalidArgument,
             message: "webhook url scheme must be http or https".to_owned(),
             field_path: Some("url".to_owned()),
             cause: Some(format!("unsupported scheme `{scheme}`")),
+            details: Vec::new(),
+        }),
+        _ => Err(ApiError {
+            code: ApiErrorCode::InvalidArgument,
+            message: "webhook url requires an http/https scheme and host".to_owned(),
+            field_path: Some("url".to_owned()),
+            cause: None,
             details: Vec::new(),
         }),
     }
@@ -149,14 +299,101 @@ fn parse_headers(headers: &BTreeMap<String, String>) -> ApiResult<HeaderMap> {
     Ok(parsed)
 }
 
+fn build_tls_config(allow_insecure: bool) -> ApiResult<rustls::ClientConfig> {
+    let provider = rustls::crypto::ring::default_provider();
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let builder = rustls::ClientConfig::builder_with_provider(Arc::new(provider))
+        .with_protocol_versions(&[&rustls::version::TLS13, &rustls::version::TLS12])
+        .map_err(tls_config_error)?;
+    let mut config = builder.with_root_certificates(roots).with_no_client_auth();
+    if allow_insecure {
+        config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(InsecureCertVerifier));
+    }
+    Ok(config)
+}
+
+#[derive(Debug)]
+struct InsecureCertVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &rustls::pki_types::CertificateDer<'_>,
+        _signature: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &rustls::pki_types::CertificateDer<'_>,
+        _signature: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn default_port(uri: &Uri) -> Option<u16> {
+    match uri.scheme_str() {
+        Some("http") => Some(80),
+        Some("https") => Some(443),
+        _ => None,
+    }
+}
+
+fn invalid_uri(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
 fn is_retryable_status(status: StatusCode) -> bool {
     status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
 }
 
-fn client_error(error: reqwest::Error) -> ApiError {
+fn request_failure(message: impl Into<String>) -> PublishResult {
+    PublishResult {
+        delivered: false,
+        retryable: true,
+        message: Some(message.into()),
+    }
+}
+
+fn format_error_chain(prefix: &str, error: &dyn StdError) -> String {
+    let mut message = format!("{prefix}: {error}");
+    let mut source = error.source();
+    while let Some(error) = source {
+        message.push_str(": ");
+        message.push_str(&error.to_string());
+        source = error.source();
+    }
+    message
+}
+
+fn tls_config_error(error: rustls::Error) -> ApiError {
     ApiError {
         code: ApiErrorCode::Internal,
-        message: "failed to build webhook event sink client".to_owned(),
+        message: "failed to build webhook event sink TLS client".to_owned(),
         field_path: None,
         cause: Some(error.to_string()),
         details: Vec::new(),

--- a/crates/connector/tests/webhook_dispatcher.rs
+++ b/crates/connector/tests/webhook_dispatcher.rs
@@ -2,16 +2,20 @@
 
 use std::collections::{BTreeMap, VecDeque};
 use std::io::{Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use serde_json::json;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use zero_api::{event_type, ApiEvent, EventFilter, EventSource, EventStream, RawApiEvent};
 use zero_config::{ApiConfig, EventDispatcherConfig, EventSinkConfig};
-use zero_connector::{spawn_event_dispatcher, EventDispatcherOptions};
+use zero_connector::{
+    spawn_event_dispatcher, spawn_event_dispatcher_with_network, EventDispatcherNetwork,
+    EventDispatcherOptions, EventSinkTcpConnectFuture, EventSinkTcpDialer, EventSinkTcpStream,
+};
 
 #[derive(Clone)]
 struct StaticEventSource {
@@ -26,6 +30,24 @@ struct StaticEventStream {
 struct CountingEventSource {
     events: Arc<Mutex<Vec<RawApiEvent>>>,
     replay_calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[derive(Clone)]
+struct RecordingDialer {
+    target: SocketAddr,
+    attempts: Arc<Mutex<Vec<(String, u16)>>>,
+}
+
+impl EventSinkTcpDialer for RecordingDialer {
+    fn connect(&self, host: String, port: u16) -> EventSinkTcpConnectFuture {
+        let target = self.target;
+        let attempts = self.attempts.clone();
+        Box::pin(async move {
+            attempts.lock().expect("dial attempts").push((host, port));
+            let stream = tokio::net::TcpStream::connect(target).await?;
+            Ok(Box::new(stream) as Box<dyn EventSinkTcpStream>)
+        })
+    }
 }
 
 impl EventSource for CountingEventSource {
@@ -190,6 +212,138 @@ async fn dispatcher_posts_events_to_registered_webhook_with_opaque_headers() {
     let value = serde_json::from_str::<serde_json::Value>(body).expect("event json");
     assert_eq!(value["event_id"], "event-1");
     assert_eq!(value["source_id"], "edge-test");
+}
+
+#[tokio::test]
+async fn dispatcher_uses_the_injected_network_dialer_for_webhook_connections() {
+    let (target, server) = spawn_single_http_server();
+    let attempts = Arc::new(Mutex::new(Vec::new()));
+    let network = EventDispatcherNetwork::new(Arc::new(RecordingDialer {
+        target,
+        attempts: attempts.clone(),
+    }));
+    let event = sequenced_event("event-injected-network", event_type::FLOW_COMPLETED, 1);
+    let port = target.port();
+    let dispatcher = spawn_event_dispatcher_with_network(
+        StaticEventSource {
+            events: Arc::new(Mutex::new(vec![event])),
+        },
+        webhook_api(format!("http://webhook.invalid:{port}/events"), None, 8),
+        None,
+        EventDispatcherOptions {
+            poll_interval: Duration::from_millis(10),
+            max_retry_attempts: 1,
+        },
+        network,
+    )
+    .expect("spawn network-bound dispatcher")
+    .expect("network-bound dispatcher");
+
+    let request = server.join().expect("injected network request");
+    dispatcher.shutdown().await;
+
+    assert!(request_body(&request).contains("event-injected-network"));
+    assert_eq!(
+        attempts.lock().expect("dial attempts").as_slice(),
+        &[("webhook.invalid".to_owned(), port)]
+    );
+}
+
+#[tokio::test]
+async fn https_verification_is_secure_by_default_and_allow_insecure_is_explicit() {
+    let (rejected_target, rejected_server) = spawn_tls_http_server().await;
+    let rejected_attempts = Arc::new(Mutex::new(Vec::new()));
+    let mut rejected_api = webhook_api(
+        format!("https://localhost:{}/events", rejected_target.port()),
+        None,
+        8,
+    );
+    match &mut rejected_api.event_sinks[0] {
+        EventSinkConfig::Webhook { allow_insecure, .. } => *allow_insecure = false,
+        _ => unreachable!("webhook config"),
+    }
+    let rejected = spawn_event_dispatcher_with_network(
+        StaticEventSource {
+            events: Arc::new(Mutex::new(vec![sequenced_event(
+                "event-reject-self-signed",
+                event_type::FLOW_COMPLETED,
+                1,
+            )])),
+        },
+        rejected_api,
+        None,
+        EventDispatcherOptions {
+            poll_interval: Duration::from_millis(10),
+            max_retry_attempts: 1,
+        },
+        EventDispatcherNetwork::new(Arc::new(RecordingDialer {
+            target: rejected_target,
+            attempts: rejected_attempts.clone(),
+        })),
+    )
+    .expect("spawn verified HTTPS dispatcher")
+    .expect("verified HTTPS dispatcher");
+    wait_for_sink_failures(&rejected.status_handle(), "receiver", 1).await;
+    let rejected_status = rejected
+        .sink_status()
+        .into_iter()
+        .find(|status| status.name == "receiver")
+        .expect("rejected HTTPS sink status");
+    assert!(
+        rejected_status
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("certificate") || error.contains("UnknownIssuer")),
+        "self-signed certificate failure must be observable: {:?}",
+        rejected_status.last_error
+    );
+    rejected.shutdown().await;
+    let rejected_server_result = tokio::time::timeout(Duration::from_secs(2), rejected_server)
+        .await
+        .expect("rejected TLS server completion")
+        .expect("rejected TLS server task");
+    assert!(rejected_server_result.is_err());
+    assert_eq!(
+        rejected_attempts.lock().expect("rejected attempts").len(),
+        1
+    );
+
+    let (allowed_target, allowed_server) = spawn_tls_http_server().await;
+    let allowed_attempts = Arc::new(Mutex::new(Vec::new()));
+    let allowed = spawn_event_dispatcher_with_network(
+        StaticEventSource {
+            events: Arc::new(Mutex::new(vec![sequenced_event(
+                "event-allow-self-signed",
+                event_type::FLOW_COMPLETED,
+                1,
+            )])),
+        },
+        webhook_api(
+            format!("https://localhost:{}/events", allowed_target.port()),
+            None,
+            8,
+        ),
+        None,
+        EventDispatcherOptions {
+            poll_interval: Duration::from_millis(10),
+            max_retry_attempts: 1,
+        },
+        EventDispatcherNetwork::new(Arc::new(RecordingDialer {
+            target: allowed_target,
+            attempts: allowed_attempts.clone(),
+        })),
+    )
+    .expect("spawn insecure-opt-in HTTPS dispatcher")
+    .expect("insecure-opt-in HTTPS dispatcher");
+    let allowed_request = tokio::time::timeout(Duration::from_secs(2), allowed_server)
+        .await
+        .expect("allowed TLS request timeout")
+        .expect("allowed TLS server task")
+        .expect("allowed TLS request");
+    allowed.shutdown().await;
+
+    assert!(request_body(&allowed_request).contains("event-allow-self-signed"));
+    assert_eq!(allowed_attempts.lock().expect("allowed attempts").len(), 1);
 }
 
 #[tokio::test]
@@ -1074,6 +1228,11 @@ async fn wait_for_outbox_recovery(
 }
 
 fn spawn_http_server() -> (String, JoinHandle<String>) {
+    let (address, handle) = spawn_single_http_server();
+    (format!("http://{address}/events"), handle)
+}
+
+fn spawn_single_http_server() -> (SocketAddr, JoinHandle<String>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local server");
     listener
         .set_nonblocking(true)
@@ -1110,7 +1269,83 @@ fn spawn_http_server() -> (String, JoinHandle<String>) {
         panic!("webhook request was not received");
     });
 
-    (format!("http://{address}/events"), handle)
+    (address, handle)
+}
+
+async fn spawn_tls_http_server() -> (SocketAddr, tokio::task::JoinHandle<Result<String, String>>) {
+    let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])
+        .expect("generate webhook test certificate");
+    let certificate = certified.cert.der().clone();
+    let key = rustls::pki_types::PrivatePkcs8KeyDer::from(certified.signing_key.serialize_der());
+    let server_tls = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("webhook server TLS versions")
+    .with_no_client_auth()
+    .with_single_cert(vec![certificate], key.into())
+    .expect("webhook server TLS certificate");
+    let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_tls));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind webhook TLS server");
+    let address = listener.local_addr().expect("webhook TLS server address");
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .map_err(|error| format!("accept webhook TLS TCP: {error}"))?;
+        let mut stream = acceptor
+            .accept(stream)
+            .await
+            .map_err(|error| format!("accept webhook TLS: {error}"))?;
+        let request = read_async_http_request(&mut stream).await?;
+        stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await
+            .map_err(|error| format!("write webhook TLS response: {error}"))?;
+        Ok(request)
+    });
+    (address, server)
+}
+
+async fn read_async_http_request<S>(stream: &mut S) -> Result<String, String>
+where
+    S: tokio::io::AsyncRead + Unpin,
+{
+    let mut received = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    let header_end = loop {
+        let read = stream
+            .read(&mut buffer)
+            .await
+            .map_err(|error| format!("read webhook TLS request: {error}"))?;
+        if read == 0 {
+            return Err("webhook TLS request closed before headers".to_owned());
+        }
+        received.extend_from_slice(&buffer[..read]);
+        if let Some(position) = received.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&received[..header_end]);
+    let content_length = headers
+        .lines()
+        .filter_map(|line| line.split_once(':'))
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+        .ok_or_else(|| "webhook TLS request has no content-length".to_owned())?;
+    while received.len() < header_end + content_length {
+        let read = stream
+            .read(&mut buffer)
+            .await
+            .map_err(|error| format!("read webhook TLS body: {error}"))?;
+        if read == 0 {
+            return Err("webhook TLS request closed before body".to_owned());
+        }
+        received.extend_from_slice(&buffer[..read]);
+    }
+    String::from_utf8(received).map_err(|error| format!("webhook TLS request UTF-8: {error}"))
 }
 
 fn spawn_stalled_http_server() -> (String, mpsc::Receiver<()>, mpsc::Sender<()>, JoinHandle<()>) {

--- a/crates/proxy/src/runtime.rs
+++ b/crates/proxy/src/runtime.rs
@@ -187,6 +187,15 @@ impl Proxy {
         &self.engine
     }
 
+    /// Shared physical-egress authority for application-owned network services.
+    ///
+    /// Connector webhook delivery is created by the root application rather
+    /// than the proxy runtime, but its sockets must observe the same TUN
+    /// underlay selection and generation changes as proxy and DNS sockets.
+    pub fn egress_interface_control(&self) -> zero_platform_tokio::EgressInterfaceControl {
+        self.egress_interface.clone()
+    }
+
     pub(crate) fn mark_orchestration_ready(&self) {
         self.orchestration_ready.send_replace(true);
     }

--- a/docs/project/connector-architecture.md
+++ b/docs/project/connector-architecture.md
@@ -46,6 +46,8 @@ Dispatcher actor 在 Connector 自己的专用执行线程上独占事件游标�
 
 `zero-api::EventSink` 保持同步、运行时中立，用于内核内的持久化钩子和通用文件 sink；Connector 在自身边界内把它适配到异步投递能力，不把 Tokio 或 HTTP 类型引入 Engine。配置重载或关闭时，已经写入 outbox 的在途 Webhook 可以取消并由下一次 Dispatcher 启动恢复；没有 outbox 的事实投递仍执行 graceful flush，不能以取消为由静默丢弃。
 
+Webhook 的 TCP 建连通过 Connector 定义的窄网络边界执行，Zero application 注入与 Proxy、DNS 共用的物理出口权威。每次新连接都会按解析候选的地址族读取最新出口 generation；TUN 活跃但对应地址族没有可信物理出口时必须失败关闭，不能退回默认 socket 重新进入 TUN。独立嵌入 Connector 且不运行 Zero TUN 时可以显式选择系统网络。HTTPS 默认验证公开根证书信任集；`allow_insecure` 只作为显式关闭证书验证的部署选项。
+
 应用进程第一次启动已配置的 delivery sink 时，先建立实时订阅，再从内核保留事件中补取该 engine 实例的 `engine.started`。实时流与补取结果按事件 `sequence` 去重，因此启动时序不会造成漏投或重复投递。配置热更新重建 dispatcher 时不会再次补发同一进程的启动事件；`flow.snapshot` 的订阅同步和常规游标回放语义保持不变。
 
 ## 禁止边界

--- a/src/application/run.rs
+++ b/src/application/run.rs
@@ -48,7 +48,7 @@ async fn run(
 
     let engine_handle = EngineHandle::new(engine.clone());
     let base_handle = ProxyHandle::new(engine_handle.clone(), proxy.clone());
-    let services = ApplicationServices::start(engine.clone(), ipc_hook_socket).await?;
+    let services = ApplicationServices::start_with_proxy(&proxy, ipc_hook_socket).await?;
     let ipc_handle = base_handle.with_config_apply_reconciler(services.clone());
 
     // Bridge tracing warn/error ->?engine.warning events.

--- a/src/application/services.rs
+++ b/src/application/services.rs
@@ -8,9 +8,17 @@ use zero_proxy::{ConfigApplyReconciler, ConfigReconcileResult};
 
 use crate::hooks;
 
+#[cfg(feature = "event-dispatcher")]
+mod network;
+
+#[cfg(feature = "event-dispatcher")]
+use network::ApplicationEventSinkTcpDialer;
+
 pub(super) struct ApplicationServices {
     engine: Engine,
     ipc_hook_socket: Option<String>,
+    #[cfg(feature = "event-dispatcher")]
+    event_network: zero_connector::EventDispatcherNetwork,
     state: Mutex<ApplicationServiceState>,
 }
 
@@ -26,14 +34,51 @@ struct ApplicationServiceState {
 }
 
 impl ApplicationServices {
+    #[cfg(all(test, feature = "sink-jsonl"))]
     pub(super) async fn start(
         engine: Engine,
         ipc_hook_socket: Option<&str>,
+    ) -> Result<Arc<Self>, Box<dyn Error>> {
+        #[cfg(feature = "event-dispatcher")]
+        let event_network = zero_connector::EventDispatcherNetwork::system();
+        Self::start_with_network(
+            engine,
+            ipc_hook_socket,
+            #[cfg(feature = "event-dispatcher")]
+            event_network,
+        )
+        .await
+    }
+
+    pub(super) async fn start_with_proxy(
+        proxy: &zero_proxy::Proxy,
+        ipc_hook_socket: Option<&str>,
+    ) -> Result<Arc<Self>, Box<dyn Error>> {
+        let engine = proxy.engine().clone();
+        #[cfg(feature = "event-dispatcher")]
+        let event_network = zero_connector::EventDispatcherNetwork::new(Arc::new(
+            ApplicationEventSinkTcpDialer::new(proxy.egress_interface_control()),
+        ));
+        Self::start_with_network(
+            engine,
+            ipc_hook_socket,
+            #[cfg(feature = "event-dispatcher")]
+            event_network,
+        )
+        .await
+    }
+
+    async fn start_with_network(
+        engine: Engine,
+        ipc_hook_socket: Option<&str>,
+        #[cfg(feature = "event-dispatcher")] event_network: zero_connector::EventDispatcherNetwork,
     ) -> Result<Arc<Self>, Box<dyn Error>> {
         let config = engine.config();
         let services = Arc::new(Self {
             engine,
             ipc_hook_socket: ipc_hook_socket.map(str::to_owned),
+            #[cfg(feature = "event-dispatcher")]
+            event_network,
             state: Mutex::new(ApplicationServiceState {
                 config: config.clone(),
                 installed: false,
@@ -116,18 +161,20 @@ impl ApplicationServices {
             let has_delivery_sinks = !target.api.event_sinks.is_empty();
             let bootstrap_engine_started = has_delivery_sinks && !state.engine_started_bootstrapped;
             state.dispatcher = if bootstrap_engine_started {
-                zero_connector::spawn_event_dispatcher_with_engine_started(
+                zero_connector::spawn_event_dispatcher_with_engine_started_and_network(
                     self.engine.clone(),
                     target.api.clone(),
                     target.source_dir.clone(),
                     zero_connector::EventDispatcherOptions::default(),
+                    self.event_network.clone(),
                 )
             } else {
-                zero_connector::spawn_event_dispatcher(
+                zero_connector::spawn_event_dispatcher_with_network(
                     self.engine.clone(),
                     target.api.clone(),
                     target.source_dir.clone(),
                     zero_connector::EventDispatcherOptions::default(),
+                    self.event_network.clone(),
                 )
             }
             .map_err(|error| error.to_string())?;

--- a/src/application/services/network.rs
+++ b/src/application/services/network.rs
@@ -1,0 +1,135 @@
+use std::collections::HashSet;
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use zero_connector::{EventSinkTcpConnectFuture, EventSinkTcpDialer, EventSinkTcpStream};
+use zero_platform_tokio::{EgressInterface, EgressInterfaceControl, TokioSocket};
+
+#[cfg(test)]
+mod tests;
+
+const CANDIDATE_DELAY: Duration = Duration::from_millis(250);
+const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(super) struct ApplicationEventSinkTcpDialer {
+    egress: EgressInterfaceControl,
+}
+
+impl ApplicationEventSinkTcpDialer {
+    pub(super) fn new(egress: EgressInterfaceControl) -> Self {
+        Self { egress }
+    }
+}
+
+impl EventSinkTcpDialer for ApplicationEventSinkTcpDialer {
+    fn connect(&self, host: String, port: u16) -> EventSinkTcpConnectFuture {
+        let egress = self.egress.clone();
+        Box::pin(async move {
+            let candidates = resolve_candidates(&host, port).await?;
+            let socket = connect_candidates(candidates, egress).await?;
+            Ok(Box::new(socket) as Box<dyn EventSinkTcpStream>)
+        })
+    }
+}
+
+async fn resolve_candidates(host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
+    let mut unique = HashSet::new();
+    let candidates = tokio::net::lookup_host((host, port))
+        .await?
+        .filter(|candidate| unique.insert(*candidate))
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("webhook host `{host}` resolved to no addresses"),
+        ));
+    }
+    Ok(candidates)
+}
+
+async fn connect_candidates(
+    candidates: Vec<SocketAddr>,
+    egress: EgressInterfaceControl,
+) -> io::Result<TokioSocket> {
+    let mut candidates = candidates.into_iter();
+    let first = candidates
+        .next()
+        .expect("resolved webhook candidates are non-empty");
+    let mut attempts = tokio::task::JoinSet::new();
+    attempts.spawn(connect_candidate(first, egress.clone()));
+    let mut last_error = None;
+
+    loop {
+        if let Some(candidate) = candidates.next() {
+            tokio::select! {
+                result = attempts.join_next() => {
+                    match completed_attempt(result) {
+                        Ok(socket) => return Ok(socket),
+                        Err(error) => {
+                            last_error = Some(error);
+                            attempts.spawn(connect_candidate(candidate, egress.clone()));
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(CANDIDATE_DELAY) => {
+                    attempts.spawn(connect_candidate(candidate, egress.clone()));
+                }
+            }
+            continue;
+        }
+
+        match attempts.join_next().await {
+            Some(result) => match completed_attempt(Some(result)) {
+                Ok(socket) => return Ok(socket),
+                Err(error) => last_error = Some(error),
+            },
+            None => {
+                return Err(last_error.unwrap_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "no webhook address candidate was connectable",
+                    )
+                }))
+            }
+        }
+    }
+}
+
+fn completed_attempt(
+    result: Option<Result<io::Result<TokioSocket>, tokio::task::JoinError>>,
+) -> io::Result<TokioSocket> {
+    match result.expect("at least one webhook dial attempt is active") {
+        Ok(result) => result,
+        Err(error) => Err(io::Error::other(format!(
+            "webhook dial task failed: {error}"
+        ))),
+    }
+}
+
+async fn connect_candidate(
+    candidate: SocketAddr,
+    egress: EgressInterfaceControl,
+) -> io::Result<TokioSocket> {
+    let interface = select_candidate_egress(candidate, &egress)?;
+    tokio::time::timeout(
+        CANDIDATE_TIMEOUT,
+        TokioSocket::connect_addr_on(candidate, interface.as_ref()),
+    )
+    .await
+    .map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("webhook TCP connect to {candidate} timed out"),
+        )
+    })?
+}
+
+fn select_candidate_egress(
+    candidate: SocketAddr,
+    egress: &EgressInterfaceControl,
+) -> io::Result<Option<EgressInterface>> {
+    let selection = egress.select_for_peer(candidate);
+    selection.ensure_connectable()?;
+    Ok(selection.interface().cloned())
+}

--- a/src/application/services/network/tests.rs
+++ b/src/application/services/network/tests.rs
@@ -1,0 +1,31 @@
+use super::select_candidate_egress;
+use zero_platform_tokio::EgressInterfaceControl;
+
+#[test]
+fn active_tun_without_physical_egress_fails_closed_for_each_family() {
+    let egress = EgressInterfaceControl::default();
+    egress.replace_tunnel_addresses([
+        "10.66.0.1".parse().expect("IPv4 TUN address"),
+        "fd66::1".parse().expect("IPv6 TUN address"),
+    ]);
+
+    for candidate in ["192.0.2.1:443", "[2001:db8::1]:443"] {
+        let candidate = candidate.parse().expect("test candidate");
+        let error = select_candidate_egress(candidate, &egress)
+            .expect_err("active TUN without matching physical egress must fail closed");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
+    }
+}
+
+#[test]
+fn each_connection_observes_the_latest_egress_generation() {
+    let egress = EgressInterfaceControl::default();
+    let candidate = "192.0.2.1:443".parse().expect("IPv4 candidate");
+
+    assert!(select_candidate_egress(candidate, &egress).is_ok());
+    let idle_generation = egress.generation();
+
+    egress.replace_tunnel_addresses(["10.66.0.1".parse().expect("IPv4 TUN address")]);
+    assert!(egress.generation() > idle_generation);
+    assert!(select_candidate_egress(candidate, &egress).is_err());
+}

--- a/tests/workspace_architecture.rs
+++ b/tests/workspace_architecture.rs
@@ -118,6 +118,25 @@ fn dns_owned_udp_and_dot_sockets_follow_the_shared_egress_authority() {
 }
 
 #[test]
+fn connector_webhooks_cross_the_application_egress_boundary() {
+    let connector = read(&workspace_root().join("crates/connector/src/webhook.rs"));
+    let services = read(&workspace_root().join("src/application/services.rs"));
+    let network = read(&workspace_root().join("src/application/services/network.rs"));
+    let proxy = read(&workspace_root().join("crates/proxy/src/runtime.rs"));
+
+    assert!(connector.contains("dialer.connect(host, port)"));
+    assert!(!connector.contains("reqwest"));
+    assert!(!connector.contains("TcpStream::connect"));
+    assert!(services.contains("start_with_proxy"));
+    assert!(services.contains("spawn_event_dispatcher_with_network"));
+    assert!(services.contains("spawn_event_dispatcher_with_engine_started_and_network"));
+    assert!(network.contains("select_for_peer"));
+    assert!(network.contains("ensure_connectable"));
+    assert!(network.contains("TokioSocket::connect_addr_on"));
+    assert!(proxy.contains("pub fn egress_interface_control"));
+}
+
+#[test]
 fn outbound_quic_node_resolution_stays_behind_the_runtime_dns_bridge() {
     let transport = read(&workspace_root().join("crates/transport/src/quic.rs"));
     let hysteria2 = read(&workspace_root().join("protocols/hysteria2/src/transport/connection.rs"));


### PR DESCRIPTION
Closes #85
Part of #25
Part of #52

## Summary
- inject a narrow Connector TCP dialer backed by the application shared TUN underlay egress authority
- resolve and race webhook address candidates while selecting the current per-family egress generation for every connection and failing closed when no trustworthy physical egress exists
- preserve HTTP/HTTPS delivery, TLS verification, retry/outbox, cancellation, and sink independence semantics with integration and architecture regression coverage

## Validation
- cargo fmt --all -- --check
- cargo check --features connector
- cargo check --workspace --exclude zero-grpc
- cargo test -p zero-connector --features webhook
- cargo test --features connector --bin zero application::services::network::tests:: -- --test-threads=1
- cargo test --features sink-jsonl --bin zero application::services::tests:: -- --test-threads=1
- RUST_MIN_STACK=8388608 cargo test --workspace --exclude zero-grpc --jobs 1 --quiet -- --test-threads=1
- cargo clippy --workspace --exclude zero-grpc --all-targets --jobs 1
- cargo clippy -p zero-connector --features webhook --all-targets --no-deps -- -D warnings
- cargo clippy -p zero-connector --features sink-jsonl --all-targets --no-deps -- -D warnings
- cargo clippy --features connector --all-targets --no-deps -- -D warnings

The local machine does not provide protoc, so zero-grpc is excluded from the local workspace commands; CI remains authoritative for that target.