### PR TITLE
qualify(connector): expose scheduler state and slow-sink gates

### DIFF
--- a/.github/workflows/connector-qualification.yml
+++ b/.github/workflows/connector-qualification.yml
@@ -1,0 +1,74 @@
+name: Connector Qualification
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - ".github/workflows/connector-qualification.yml"
+      - "crates/api/**"
+      - "crates/config/**"
+      - "crates/connector/**"
+      - "crates/engine/**"
+      - "src/application/**"
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - ".github/workflows/connector-qualification.yml"
+      - "crates/api/**"
+      - "crates/config/**"
+      - "crates/connector/**"
+      - "crates/engine/**"
+      - "src/application/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  receiver-outage:
+    name: Receiver outage recovery (Linux)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Deliver durable backlog after receiver recovery
+        env:
+          ZERO_CONNECTOR_OUTAGE_EVENTS: "10000"
+          ZERO_CONNECTOR_SOAK_TIMEOUT_SECONDS: "900"
+        run: >-
+          cargo test -p zero-connector --features webhook
+          --test qualification_outage
+          connector_backlog_recovers_after_receiver_outage_without_losing_events
+          -- --ignored --exact --nocapture
+
+  durable-restart-soak:
+    name: Durable restart soak (Linux)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Sustain delivery across dispatcher restarts
+        env:
+          ZERO_CONNECTOR_SOAK_EVENTS: "25000"
+          ZERO_CONNECTOR_SOAK_RESTARTS: "5"
+          ZERO_CONNECTOR_SOAK_MIN_SECONDS: "60"
+          ZERO_CONNECTOR_SOAK_TIMEOUT_SECONDS: "900"
+        run: >-
+          cargo test -p zero-connector --features sink-jsonl
+          --test qualification_soak
+          connector_outbox_survives_sustained_delivery_and_restarts_without_loss
+          -- --ignored --exact --nocapture

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -44,8 +44,8 @@ pub use query::{
 pub use response::{ApiResponse, EnvelopeError, RawResponse};
 pub use sink::{
     CallbackEventSink, DeadLetterSink, JsonLineEventSink, MemorySink, OutboxCorruptionClass,
-    OutboxRecoveryState, OutboxRecoveryStatus, OutboxStorageStatus, RotatingFileSink, SinkManager,
-    SinkStatus,
+    OutboxRecoveryState, OutboxRecoveryStatus, OutboxStorageStatus, RotatingFileSink,
+    SinkDeliveryStatus, SinkManager, SinkStatus,
 };
 pub use snapshot::{
     AddressSnapshot, AuthSnapshot, CompletedFlowSnapshot, ConfigSnapshot, FlowSnapshot,

--- a/crates/api/src/sink.rs
+++ b/crates/api/src/sink.rs
@@ -182,6 +182,10 @@ pub struct SinkStatus {
     /// Current durable/in-memory backlog waiting for delivery or ACK.
     #[serde(default)]
     pub pending: u64,
+    /// Current dispatcher-owned delivery lifecycle. This object is additive
+    /// to the V1 status contract and is absent on older cores.
+    #[serde(default, skip_serializing_if = "SinkDeliveryStatus::is_idle")]
+    pub delivery: SinkDeliveryStatus,
     pub total_delivered: u64,
     pub total_failed: u64,
     /// Number of detected event-sequence gaps. Unlike `last_error`, this
@@ -198,6 +202,37 @@ pub struct SinkStatus {
     /// successful deliveries so operators can reconcile preserved facts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub outbox_recovery: Option<OutboxRecoveryStatus>,
+}
+
+/// Per-sink delivery lifecycle owned by the asynchronous Connector
+/// dispatcher. The fields intentionally remain independent because a durable
+/// backlog may coexist with one in-flight request and another scheduled
+/// retry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SinkDeliveryStatus {
+    /// The per-sink worker currently owns one delivery request.
+    #[serde(default)]
+    pub in_flight: bool,
+    /// Deliveries that have already failed at least once and remain queued for
+    /// another publish attempt.
+    #[serde(default)]
+    pub retry_pending: u64,
+    /// Successfully published deliveries whose durable outbox ACK must be
+    /// retried.
+    #[serde(default)]
+    pub ack_retry_pending: u64,
+    /// Outstanding entries currently owned by the durable outbox.
+    #[serde(default)]
+    pub durable_pending: u64,
+    /// Earliest publish or ACK retry deadline, as Unix milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_retry_at_unix_ms: Option<u64>,
+}
+
+impl SinkDeliveryStatus {
+    fn is_idle(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -322,6 +357,7 @@ impl SinkManager {
             .map(|(managed, stat)| SinkStatus {
                 name: managed.sink.name().to_owned(),
                 pending: 0,
+                delivery: SinkDeliveryStatus::default(),
                 total_delivered: stat.delivered.load(Ordering::Relaxed),
                 total_failed: stat.failed.load(Ordering::Relaxed),
                 replay_gaps: 0,

--- a/crates/api/tests/sink_status_contract.rs
+++ b/crates/api/tests/sink_status_contract.rs
@@ -1,0 +1,52 @@
+use zero_api::{SinkDeliveryStatus, SinkStatus};
+
+#[test]
+fn older_sink_status_without_delivery_state_remains_compatible() {
+    let status: SinkStatus = serde_json::from_str(
+        r#"{
+            "name": "receiver",
+            "pending": 0,
+            "total_delivered": 4,
+            "total_failed": 1,
+            "replay_gaps": 0,
+            "last_success_at_unix_ms": 10,
+            "last_failure_at_unix_ms": 9,
+            "last_error": null
+        }"#,
+    )
+    .expect("deserialize pre-delivery-state sink status");
+
+    assert_eq!(status.delivery, SinkDeliveryStatus::default());
+    let exported = serde_json::to_value(status).expect("serialize idle sink status");
+    assert!(exported.get("delivery").is_none());
+}
+
+#[test]
+fn sink_status_exports_independent_delivery_lifecycle_facts() {
+    let status: SinkStatus = serde_json::from_str(
+        r#"{
+            "name": "receiver",
+            "pending": 5,
+            "delivery": {
+                "in_flight": true,
+                "retry_pending": 2,
+                "ack_retry_pending": 1,
+                "durable_pending": 5,
+                "next_retry_at_unix_ms": 1234
+            },
+            "total_delivered": 7,
+            "total_failed": 3,
+            "replay_gaps": 1,
+            "last_success_at_unix_ms": 10,
+            "last_failure_at_unix_ms": 11,
+            "last_error": "receiver unavailable"
+        }"#,
+    )
+    .expect("deserialize delivery lifecycle");
+
+    assert!(status.delivery.in_flight);
+    assert_eq!(status.delivery.retry_pending, 2);
+    assert_eq!(status.delivery.ack_retry_pending, 1);
+    assert_eq!(status.delivery.durable_pending, 5);
+    assert_eq!(status.delivery.next_retry_at_unix_ms, Some(1234));
+}

--- a/crates/connector/src/dispatcher.rs
+++ b/crates/connector/src/dispatcher.rs
@@ -9,7 +9,8 @@ use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 use zero_api::{
     event_type, DeadLetterSink, EventFilter, EventSink, EventSource, EventStream,
-    EventStreamReceive, OutboxRecoveryStatus, OutboxStorageStatus, RawApiEvent, SinkStatus,
+    EventStreamReceive, OutboxRecoveryStatus, OutboxStorageStatus, RawApiEvent, SinkDeliveryStatus,
+    SinkStatus,
 };
 use zero_config::{ApiConfig, EventDispatcherConfig};
 
@@ -50,6 +51,7 @@ struct PerSinkStats {
     total_delivered: AtomicU64,
     total_failed: AtomicU64,
     replay_gaps: AtomicU64,
+    delivery: Mutex<SinkDeliveryStatus>,
     last_success_ms: Mutex<Option<u64>>,
     last_failure_ms: Mutex<Option<u64>>,
     last_error: Mutex<Option<String>>,
@@ -64,6 +66,7 @@ impl PerSinkStats {
             total_delivered: AtomicU64::new(0),
             total_failed: AtomicU64::new(0),
             replay_gaps: AtomicU64::new(0),
+            delivery: Mutex::new(SinkDeliveryStatus::default()),
             last_success_ms: Mutex::new(None),
             last_failure_ms: Mutex::new(None),
             last_error: Mutex::new(None),
@@ -92,6 +95,7 @@ impl PerSinkStats {
         SinkStatus {
             name,
             pending: self.pending.load(Ordering::Relaxed),
+            delivery: *self.delivery.lock().expect("sink stats"),
             total_delivered: self.total_delivered.load(Ordering::Relaxed),
             total_failed: self.total_failed.load(Ordering::Relaxed),
             replay_gaps: self.replay_gaps.load(Ordering::Relaxed),
@@ -721,11 +725,14 @@ fn refresh_pending_stats(
     workers: &[SinkWorker],
     outbox: Option<&DeliveryOutbox>,
 ) {
+    let now = Instant::now();
+    let now_unix_ms = now_unix_ms();
     let storage_status = outbox.map(DeliveryOutbox::storage_status);
     let recovery_status = outbox.and_then(DeliveryOutbox::recovery_status);
     let shared = stats.lock().expect("sink stats");
     for (_, stat) in shared.iter() {
         stat.set_pending(0);
+        *stat.delivery.lock().expect("sink stats") = SinkDeliveryStatus::default();
         *stat.outbox_recovery.lock().expect("sink stats") = recovery_status.clone();
         *stat.outbox_storage.lock().expect("sink stats") = match &storage_status {
             Some(Ok(status)) => Some(*status),
@@ -740,22 +747,51 @@ fn refresh_pending_stats(
         for (sink_tag, count) in outbox.pending_counts() {
             if let Some((_, stat)) = shared.iter().find(|(tag, _)| tag == &sink_tag) {
                 stat.set_pending(count);
+                stat.delivery.lock().expect("sink stats").durable_pending = count as u64;
             }
         }
-        return;
     }
     for delivery in pending {
         if let Some((_, stat)) = shared.iter().find(|(tag, _)| tag == &delivery.sink_tag) {
-            stat.pending.fetch_add(1, Ordering::Relaxed);
+            if outbox.is_none() {
+                stat.pending.fetch_add(1, Ordering::Relaxed);
+            }
+            let mut status = stat.delivery.lock().expect("sink stats");
+            if delivery.awaiting_ack {
+                status.ack_retry_pending = status.ack_retry_pending.saturating_add(1);
+                record_retry_deadline(&mut status, now, now_unix_ms, delivery.next_due);
+            } else if delivery.attempts > 0 {
+                status.retry_pending = status.retry_pending.saturating_add(1);
+                record_retry_deadline(&mut status, now, now_unix_ms, delivery.next_due);
+            }
         }
     }
     for worker in workers {
         if worker.in_flight.is_some() {
             if let Some((_, stat)) = shared.iter().find(|(tag, _)| tag == &worker.tag) {
-                stat.pending.fetch_add(1, Ordering::Relaxed);
+                if outbox.is_none() {
+                    stat.pending.fetch_add(1, Ordering::Relaxed);
+                }
+                stat.delivery.lock().expect("sink stats").in_flight = true;
             }
         }
     }
+}
+
+fn record_retry_deadline(
+    status: &mut SinkDeliveryStatus,
+    now: Instant,
+    now_unix_ms: u64,
+    due: Instant,
+) {
+    let delay_ms =
+        u64::try_from(due.saturating_duration_since(now).as_millis()).unwrap_or(u64::MAX);
+    let deadline = now_unix_ms.saturating_add(delay_ms);
+    status.next_retry_at_unix_ms = Some(
+        status
+            .next_retry_at_unix_ms
+            .map_or(deadline, |current| current.min(deadline)),
+    );
 }
 
 fn fill_pending_from_outbox(

--- a/crates/connector/tests/webhook_dispatcher.rs
+++ b/crates/connector/tests/webhook_dispatcher.rs
@@ -507,16 +507,61 @@ async fn stalled_webhook_does_not_spin_the_dispatcher() {
     )
     .expect("spawn no-spin dispatcher")
     .expect("no-spin dispatcher");
+    let status = dispatcher.status_handle();
 
     received
         .recv_timeout(Duration::from_secs(2))
         .expect("stalled request received");
+    let stalled = wait_for_sink_status(&status, "receiver", |sink| sink.delivery.in_flight).await;
+    assert_eq!(stalled.delivery.retry_pending, 0);
+    assert_eq!(stalled.delivery.ack_retry_pending, 0);
     tokio::time::sleep(Duration::from_millis(350)).await;
     let calls = replay_calls.load(std::sync::atomic::Ordering::Relaxed);
     assert!(calls <= 12, "dispatcher replayed {calls} times while idle");
 
     release.send(()).expect("release stalled webhook");
     server.join().expect("stalled server");
+    dispatcher.shutdown().await;
+}
+
+#[tokio::test]
+async fn retryable_webhook_failure_reports_the_scheduled_retry_deadline() {
+    const SERVICE_UNAVAILABLE: &[u8] =
+        b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    let (url, server) = spawn_scripted_http_server(vec![SERVICE_UNAVAILABLE]);
+    let mut api = webhook_api(url, None, 8);
+    api.dispatcher.retry_initial_delay_ms = 5_000;
+    api.dispatcher.retry_max_delay_ms = 5_000;
+    let dispatcher = spawn_event_dispatcher(
+        StaticEventSource {
+            events: Arc::new(Mutex::new(vec![sequenced_event(
+                "event-retry-status",
+                event_type::ENGINE_WARNING,
+                1,
+            )])),
+        },
+        api,
+        None,
+        EventDispatcherOptions {
+            poll_interval: Duration::from_millis(10),
+            max_retry_attempts: 2,
+        },
+    )
+    .expect("spawn retry-status dispatcher")
+    .expect("retry-status dispatcher");
+    let status = dispatcher.status_handle();
+
+    assert_eq!(server.join().expect("retry-status request").len(), 1);
+    let retry = wait_for_sink_status(&status, "receiver", |sink| {
+        sink.delivery.retry_pending == 1
+            && sink.delivery.next_retry_at_unix_ms.is_some()
+            && !sink.delivery.in_flight
+    })
+    .await;
+    assert_eq!(retry.total_failed, 1);
+    assert_eq!(retry.delivery.ack_retry_pending, 0);
+    assert_eq!(retry.delivery.durable_pending, 0);
+
     dispatcher.shutdown().await;
 }
 
@@ -541,10 +586,16 @@ async fn durable_stalled_webhook_is_cancelled_on_shutdown_and_recovered() {
     )
     .expect("spawn cancellable dispatcher")
     .expect("cancellable dispatcher");
+    let status = dispatcher.status_handle();
 
     stalled_received
         .recv_timeout(Duration::from_secs(2))
         .expect("stalled webhook received durable delivery");
+    let stalled = wait_for_sink_status(&status, "receiver", |sink| {
+        sink.delivery.in_flight && sink.delivery.durable_pending == 1
+    })
+    .await;
+    assert_eq!(stalled.pending, 1);
     tokio::time::timeout(Duration::from_secs(1), dispatcher.shutdown())
         .await
         .expect("durable webhook shutdown must cancel the request");
@@ -1190,6 +1241,24 @@ async fn wait_for_sink_pending(
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     panic!("sink `{sink}` pending count did not become {expected}");
+}
+
+async fn wait_for_sink_status(
+    status: &zero_connector::EventDispatcherStatusHandle,
+    sink: &str,
+    predicate: impl Fn(&zero_api::SinkStatus) -> bool,
+) -> zero_api::SinkStatus {
+    for _ in 0..200 {
+        if let Some(status) = status
+            .sink_status()
+            .into_iter()
+            .find(|item| item.name == sink && predicate(item))
+        {
+            return status;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("sink `{sink}` did not reach the expected delivery state");
 }
 
 async fn wait_for_sink_failures(

--- a/docs/project/api.md
+++ b/docs/project/api.md
@@ -344,6 +344,8 @@ sink 的共同要求：
   - 返回运行时统计、活动 flow、最近完成 flow 和 policy 状态
 - `stats.get`
   - 返回轻量统计，不包含完整 flow 列表
+- `sinks.get`
+  - 返回各事件 sink 的投递状态；兼容的 `pending` 为总 backlog，新内核通过可选 `delivery` 对象区分在途请求、投递重试、ACK 重试、持久 backlog 和最早重试时间，并由 `outbox_storage`、`outbox_recovery`、`replay_gaps` 补充磁盘阻塞、恢复和事件缺口事实
 - `principal_flows.get`
   - 返回当前内核实例的权威 Principal 活跃 flow 完整快照；HTTP 路径为 `GET /api/v1/principal_flows`
 - `flows.list_active`

--- a/docs/project/connector-architecture.md
+++ b/docs/project/connector-architecture.md
@@ -44,6 +44,8 @@ Connector 所维护的“保活”仅指投递任务持续运行、失败重试�
 
 Dispatcher actor 在 Connector 自己的专用执行线程上独占事件游标、outbox 和重试状态，并通过事件到达、投递完成、重试截止时间或关闭信号唤醒，不以在途请求作为轮询条件。每个 sink 使用独立、单并发的异步投递任务；Webhook 使用可取消的异步 HTTP，JSONL 等同步 sink 通过 blocking adapter 执行。一个 URL 超时不会阻塞其他注册地址，sink 任务也不能直接修改 outbox。请求超时、退避、重试阈值和耗尽策略全部来自 `api.dispatcher`，不存在隐藏的固定三次删除策略。
 
+`sinks.get` 的每个 `SinkStatus` 保留兼容的总 `pending` 计数，并通过可选 `delivery` 对象公开调度器当前生命周期：`in_flight`、`retry_pending`、`ack_retry_pending`、`durable_pending` 和 `next_retry_at_unix_ms`。这些状态彼此独立；例如一个 sink 可以同时有一条在途请求和多条持久 backlog。磁盘保留空间阻塞继续由 `outbox_storage.write_blocked` 表达，历史恢复和事件缺口分别由 `outbox_recovery` 与 `replay_gaps` 表达。旧内核没有 `delivery` 时，消费者必须按未知状态处理，不能根据 `pending` 猜测是在途还是重试。
+
 `zero-api::EventSink` 保持同步、运行时中立，用于内核内的持久化钩子和通用文件 sink；Connector 在自身边界内把它适配到异步投递能力，不把 Tokio 或 HTTP 类型引入 Engine。配置重载或关闭时，已经写入 outbox 的在途 Webhook 可以取消并由下一次 Dispatcher 启动恢复；没有 outbox 的事实投递仍执行 graceful flush，不能以取消为由静默丢弃。
 
 Webhook 的 TCP 建连通过 Connector 定义的窄网络边界执行，Zero application 注入与 Proxy、DNS 共用的物理出口权威。每次新连接都会按解析候选的地址族读取最新出口 generation；TUN 活跃但对应地址族没有可信物理出口时必须失败关闭，不能退回默认 socket 重新进入 TUN。独立嵌入 Connector 且不运行 Zero TUN 时可以显式选择系统网络。HTTPS 默认验证公开根证书信任集；`allow_insecure` 只作为显式关闭证书验证的部署选项。
@@ -73,3 +75,7 @@ Zero 不得在 Connector 中：
 - `grpc-api`：可选 gRPC 控制入口。
 
 `connector` 不隐式启用 `status-api` 或 `grpc-api`。节点仍是一个进程，Feature 只控制编译裁剪，不引入第二个部署程序。
+
+## 生产资格验证
+
+`.github/workflows/connector-qualification.yml` 在 Connector、API 或相关配置边界变化时运行两项 Linux 门禁：接收端离线后恢复并完整清空 10,000 条持久 backlog；25,000 条事件跨 5 次 Dispatcher 重启并持续至少 60 秒，验证没有丢失或已 ACK 事件重投。普通测试中的 stalled-webhook 用例使用可计数事件源约束调度器唤醒/回放次数，避免用 CI 主机瞬时 CPU 百分比作为唯一判据。事件规模按同步持久化路径的实测吞吐设置，确保每次相关 PR 都能执行而不是依赖偶发的超长人工任务。


### PR DESCRIPTION
## Summary

- expose independent per-sink delivery lifecycle facts through the additive `SinkStatus.delivery` contract
- verify stalled requests and scheduled retries deterministically without CPU-timing assertions
- add Linux qualification gates for receiver outage recovery and durable restart soak
- document the control-plane status and production qualification boundary

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --jobs 1`
- `cargo test --workspace --jobs 1 -- --test-threads=1`
- `cargo clippy --workspace --all-targets --jobs 1`
- focused strict Clippy for `zero-api` and `zero-connector`
- local reduced qualification runs: 1,000-event outage recovery; 10,000 events across 3 restarts without loss or acknowledged redelivery

Closes #87
Part of #18
Part of #52