### PR TITLE
fix(direct): defer recovered candidate refresh

### DIFF
--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -154,7 +154,6 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
         run: cargo test --target x86_64-unknown-linux-gnu --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run Fake-IP DoH underlay E2E
-        if: github.event_name != 'pull_request'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
         run: cargo test --target x86_64-unknown-linux-gnu --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
@@ -221,7 +220,6 @@ jobs:
       - name: Run direct UDP self-capture E2E
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run Fake-IP DoH underlay E2E
-        if: github.event_name != 'pull_request'
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run offline dual-stack privileged TUN E2E
         if: github.event_name != 'pull_request'

--- a/crates/proxy/src/protocol_registry/context/tcp.rs
+++ b/crates/proxy/src/protocol_registry/context/tcp.rs
@@ -89,7 +89,7 @@ impl TcpRuntimeServices {
             .direct_connector()
             .connect(
                 session,
-                self.upstream.resolver.as_ref(),
+                &self.upstream.resolver,
                 &self.upstream.egress_interface,
             )
             .await

--- a/crates/proxy/src/transport/direct.rs
+++ b/crates/proxy/src/transport/direct.rs
@@ -1,4 +1,5 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
 
 use zero_core::{Address, Error, Session};
 use zero_dns::DnsSystem;
@@ -12,8 +13,13 @@ use zero_platform_tokio::{
 };
 use zero_traits::IpAddress;
 
-use super::direct_dial::{dial_tcp_candidates, TcpDialAttempt, TcpDialFailure};
-use candidates::{append_recovered_ipv4_candidates, literal_direct_target};
+use super::direct_dial::{
+    dial_tcp_candidates, dial_tcp_fallback_candidates, TcpDialAttempt, TcpDialFailure,
+};
+use candidates::{
+    literal_direct_target, recovered_ipv4_candidate_refresh, refresh_recovered_ipv4_candidates,
+    RecoveredDirectCandidateRefresh,
+};
 
 pub(super) mod candidates;
 
@@ -36,6 +42,7 @@ pub(crate) struct DirectTcpConnectFailure {
 pub(crate) struct DirectTargetResolution {
     pub(crate) candidates: Vec<SocketAddr>,
     udp_original_candidate: Option<SocketAddr>,
+    recovered_candidate_refresh: Option<RecoveredDirectCandidateRefresh>,
     address_family_policy: &'static str,
     fallback: Option<DirectAddressFamilyFallback>,
 }
@@ -76,10 +83,13 @@ impl DirectConnector {
     pub(crate) async fn connect(
         &self,
         session: &Session,
-        resolver: &DnsSystem,
+        resolver: &Arc<DnsSystem>,
         egress: &EgressInterfaceControl,
     ) -> Result<DirectTcpConnection, DirectTcpConnectFailure> {
-        let resolution = match self.resolve_target_addrs(session, resolver, egress).await {
+        let resolution = match self
+            .resolve_target_addrs(session, resolver.as_ref(), egress)
+            .await
+        {
             Ok(resolution) => resolution,
             Err(error) => {
                 return Err(DirectTcpConnectFailure {
@@ -92,7 +102,21 @@ impl DirectConnector {
             }
         };
 
-        match dial_tcp_candidates(resolution.candidates.clone(), egress).await {
+        let dial = match dial_tcp_candidates(resolution.candidates.clone(), egress).await {
+            Ok(success) => Ok(success),
+            Err(failure) => {
+                Box::pin(self.retry_recovered_candidates(
+                    session,
+                    resolver,
+                    egress,
+                    &resolution,
+                    failure,
+                ))
+                .await
+            }
+        };
+
+        match dial {
             Ok(success) => {
                 let socket = success.socket;
                 let local = socket.local_addr().ok();
@@ -273,15 +297,88 @@ impl DirectConnector {
             )
             .await?
         };
-        let candidates = append_recovered_ipv4_candidates(session, resolver, candidates).await;
+        let recovered_candidate_refresh = recovered_ipv4_candidate_refresh(session, &candidates);
         let udp_original_candidate =
             literal_direct_target(session).filter(|original| candidates.contains(original));
         Ok(DirectTargetResolution {
             candidates,
             udp_original_candidate,
+            recovered_candidate_refresh,
             address_family_policy: resolver.address_family_policy().as_str(),
             fallback,
         })
+    }
+
+    async fn retry_recovered_candidates(
+        &self,
+        session: &Session,
+        resolver: &Arc<DnsSystem>,
+        egress: &EgressInterfaceControl,
+        resolution: &DirectTargetResolution,
+        failure: Box<TcpDialFailure>,
+    ) -> Result<super::direct_dial::TcpDialSuccess, Box<TcpDialFailure>> {
+        let Some(refresh) = resolution.recovered_candidate_refresh.as_ref() else {
+            return Err(failure);
+        };
+        // Poll configured DNS from a fresh task stack. Keeping this under the
+        // TUN direct-connect future recursively embeds the DNS underlay path
+        // and can exhaust Tokio's worker stack under transparent flow load.
+        // JoinSet also aborts the refresh if the owning connection is dropped.
+        let mut refresh_tasks = tokio::task::JoinSet::new();
+        {
+            let refresh = refresh.clone();
+            let resolver = Arc::clone(resolver);
+            let port = session.port;
+            let candidates = resolution.candidates.clone();
+            refresh_tasks.spawn(async move {
+                refresh_recovered_ipv4_candidates(&refresh, resolver.as_ref(), port, candidates)
+                    .await
+            });
+        }
+        let candidates = match refresh_tasks
+            .join_next()
+            .await
+            .expect("one trusted-domain refresh task is registered")
+        {
+            Ok(Ok(candidates)) => candidates,
+            Ok(Err(error)) => {
+                tracing::debug!(
+                    domain = refresh.domain,
+                    host_source = refresh.host_source,
+                    error = %error,
+                    "trusted-domain candidate refresh failed; retaining original direct failure"
+                );
+                return Err(failure);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    domain = refresh.domain,
+                    host_source = refresh.host_source,
+                    error = %error,
+                    "trusted-domain candidate refresh task failed; retaining original direct failure"
+                );
+                return Err(failure);
+            }
+        };
+        let additional_candidates = candidates
+            .into_iter()
+            .skip(resolution.candidates.len())
+            .collect::<Vec<_>>();
+        if additional_candidates.is_empty() {
+            tracing::debug!(
+                domain = refresh.domain,
+                host_source = refresh.host_source,
+                "trusted-domain candidate refresh returned no new direct endpoint"
+            );
+            return Err(failure);
+        }
+        tracing::debug!(
+            domain = refresh.domain,
+            host_source = refresh.host_source,
+            candidate_count = resolution.candidates.len() + additional_candidates.len(),
+            "original direct endpoint failed; retrying trusted DNS candidates"
+        );
+        dial_tcp_fallback_candidates(failure, additional_candidates, egress).await
     }
 
     pub(crate) fn udp_network_observation(

--- a/crates/proxy/src/transport/direct/candidates.rs
+++ b/crates/proxy/src/transport/direct/candidates.rs
@@ -8,52 +8,51 @@ use super::socket_addr_from_ip;
 
 pub(in crate::transport) const MAX_RECOVERED_DIRECT_CANDIDATES: usize = 8;
 
-/// Enrich a transparent IPv4 direct target with the current real-DNS answers
-/// for its recovered domain. The captured endpoint remains first, and DNS
-/// failure is deliberately non-fatal because that endpoint is still a valid
-/// literal target.
-pub(super) async fn append_recovered_ipv4_candidates(
+#[derive(Debug, Clone)]
+pub(super) struct RecoveredDirectCandidateRefresh {
+    pub(super) domain: String,
+    pub(super) host_source: &'static str,
+}
+
+/// Identify a transparent TCP target that may use trusted real-DNS answers
+/// only after its authoritative captured IPv4 endpoint fails to connect.
+pub(super) fn recovered_ipv4_candidate_refresh(
     session: &Session,
-    resolver: &DnsSystem,
-    mut candidates: Vec<SocketAddr>,
-) -> Vec<SocketAddr> {
+    candidates: &[SocketAddr],
+) -> Option<RecoveredDirectCandidateRefresh> {
     if session.network != Network::Tcp {
-        return candidates;
+        return None;
     }
     let (Address::Domain(domain), Some(host_source), Some(Address::Ipv4(original_address))) = (
         &session.target,
         session.target_host_source,
         session.direct_target.as_ref(),
     ) else {
-        return candidates;
+        return None;
     };
     let original = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(*original_address)), session.port);
     if candidates.first() != Some(&original) {
-        return candidates;
+        return None;
     }
 
-    match resolver.resolve_direct(domain).await {
-        Ok(resolved) => {
-            append_unique_resolved_candidates(&mut candidates, resolved, session.port);
-            tracing::debug!(
-                original_target = %original,
-                domain,
-                host_source = host_source.as_str(),
-                candidate_count = candidates.len(),
-                "enriched transparent direct target with trusted DNS candidates"
-            );
-        }
-        Err(error) => {
-            tracing::debug!(
-                original_target = %original,
-                domain,
-                host_source = host_source.as_str(),
-                error = %error,
-                "trusted-domain candidate refresh failed; retaining original direct target"
-            );
-        }
-    }
-    candidates
+    Some(RecoveredDirectCandidateRefresh {
+        domain: domain.clone(),
+        host_source: host_source.as_str(),
+    })
+}
+
+/// Append current real-DNS answers after the captured candidate has failed.
+/// DNS failure is returned to the caller so it can retain the original socket
+/// failure and its platform error as the authoritative result.
+pub(super) async fn refresh_recovered_ipv4_candidates(
+    refresh: &RecoveredDirectCandidateRefresh,
+    resolver: &DnsSystem,
+    port: u16,
+    mut candidates: Vec<SocketAddr>,
+) -> std::io::Result<Vec<SocketAddr>> {
+    let resolved = resolver.resolve_direct(&refresh.domain).await?;
+    append_unique_resolved_candidates(&mut candidates, resolved, port);
+    Ok(candidates)
 }
 
 pub(in crate::transport) fn append_unique_resolved_candidates(

--- a/crates/proxy/src/transport/direct_dial.rs
+++ b/crates/proxy/src/transport/direct_dial.rs
@@ -51,13 +51,62 @@ pub(super) async fn dial_tcp_candidates(
     egress: &EgressInterfaceControl,
 ) -> Result<TcpDialSuccess, Box<TcpDialFailure>> {
     let resolved_candidates = interleave_address_families(candidates);
-    let mut next_candidate = resolved_candidates.iter().copied().enumerate();
+    dial_tcp_candidates_with_history(
+        resolved_candidates.clone(),
+        egress,
+        0,
+        resolved_candidates,
+        Vec::new(),
+    )
+    .await
+}
+
+/// Continue one failed dial with newly discovered candidates without retrying
+/// any endpoint that already completed. The returned observation remains one
+/// deterministic candidate/attempt timeline across both phases.
+pub(super) async fn dial_tcp_fallback_candidates(
+    previous: Box<TcpDialFailure>,
+    candidates: Vec<SocketAddr>,
+    egress: &EgressInterfaceControl,
+) -> Result<TcpDialSuccess, Box<TcpDialFailure>> {
+    let mut resolved_candidates = previous.resolved_candidates.clone();
+    let fallback_candidates = interleave_address_families(candidates)
+        .into_iter()
+        .filter(|candidate| !resolved_candidates.contains(candidate))
+        .collect::<Vec<_>>();
+    if fallback_candidates.is_empty() {
+        return Err(previous);
+    }
+
+    let candidate_index_offset = resolved_candidates.len();
+    resolved_candidates.extend(fallback_candidates.iter().copied());
+    dial_tcp_candidates_with_history(
+        fallback_candidates,
+        egress,
+        candidate_index_offset,
+        resolved_candidates,
+        previous.attempts,
+    )
+    .await
+}
+
+async fn dial_tcp_candidates_with_history(
+    candidates: Vec<SocketAddr>,
+    egress: &EgressInterfaceControl,
+    candidate_index_offset: usize,
+    resolved_candidates: Vec<SocketAddr>,
+    mut completed_attempts: Vec<TcpDialAttempt>,
+) -> Result<TcpDialSuccess, Box<TcpDialFailure>> {
+    let mut next_candidate = candidates
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(index, candidate)| (candidate_index_offset + index, candidate));
     let (first_index, first) = next_candidate
         .next()
         .expect("dial candidates are non-empty");
     let mut attempts = FuturesUnordered::new();
     attempts.push(dial_tcp_candidate(first_index, first, egress.clone()));
-    let mut completed_attempts = Vec::new();
     let mut last_failure = None;
 
     loop {

--- a/crates/proxy/src/transport/tests.rs
+++ b/crates/proxy/src/transport/tests.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use zero_core::{Address, Network, ProtocolType, Session, TargetHostSource};
 
 use super::{
     direct::candidates::{append_unique_resolved_candidates, MAX_RECOVERED_DIRECT_CANDIDATES},
     direct_dial::{
-        dial_tcp_candidates, interleave_address_families, MAX_RECORDED_CONNECTION_ATTEMPTS,
+        dial_tcp_candidates, dial_tcp_fallback_candidates, interleave_address_families,
+        MAX_RECORDED_CONNECTION_ATTEMPTS,
     },
     DirectConnector,
 };
@@ -168,6 +171,27 @@ async fn tcp_dial_failure_records_the_platform_socket_error() {
 }
 
 #[tokio::test]
+async fn tcp_fallback_candidates_do_not_redial_completed_endpoints() {
+    let first = "[2001:db8::1]:443".parse().unwrap();
+    let second = "[2001:db8::2]:443".parse().unwrap();
+    let egress = zero_platform_tokio::EgressInterfaceControl::default();
+    egress.mark_unavailable_for(true, "no physical IPv6 default route");
+    egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
+
+    let initial = dial_tcp_candidates(vec![first], &egress)
+        .await
+        .expect_err("initial endpoint must fail");
+    let failure = dial_tcp_fallback_candidates(initial, vec![first, second], &egress)
+        .await
+        .expect_err("fallback endpoint must fail");
+
+    assert_eq!(failure.resolved_candidates, vec![first, second]);
+    assert_eq!(failure.attempts.len(), 2);
+    assert_eq!(failure.attempts[0].remote, first);
+    assert_eq!(failure.attempts[1].remote, second);
+}
+
+#[tokio::test]
 async fn tcp_dial_failure_attempt_observations_are_ordered_and_bounded() {
     let egress = zero_platform_tokio::EgressInterfaceControl::default();
     egress.mark_unavailable_for(true, "no physical IPv6 default route");
@@ -213,7 +237,7 @@ async fn recovered_ipv4_target_uses_trusted_dns_candidates_after_original_fails(
     session.target = Address::Domain("localhost".to_owned());
     session.sni = Some("localhost".to_owned());
     session.port = reachable.port();
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
     let egress = zero_platform_tokio::EgressInterfaceControl::default();
 
     let connection = DirectConnector
@@ -240,29 +264,128 @@ async fn recovered_ipv4_target_uses_trusted_dns_candidates_after_original_fails(
             .count(),
         1
     );
+    assert_eq!(
+        connection.network.connection_attempts[0]
+            .remote_address
+            .host,
+        captured.ip().to_string()
+    );
+    assert_eq!(
+        connection
+            .network
+            .connection_attempts
+            .last()
+            .unwrap()
+            .outcome,
+        "connected"
+    );
 }
 
 #[tokio::test]
 async fn recovered_ipv4_dns_failure_retains_the_original_candidate() {
-    let original = Address::Ipv4([192, 0, 2, 10]);
+    let reservation = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let unavailable = reservation.local_addr().unwrap();
+    drop(reservation);
+    let original = Address::Ipv4([127, 0, 0, 1]);
     let mut session = tls_sni_session(original);
     session.target = Address::Domain("invalid\0domain".to_owned());
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    session.port = unavailable.port();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
-    let resolution = DirectConnector
-        .resolve_target_addrs(
+    let failure = match DirectConnector
+        .connect(
             &session,
             &resolver,
             &zero_platform_tokio::EgressInterfaceControl::default(),
         )
         .await
-        .expect("literal target remains valid when DNS refresh fails");
+    {
+        Ok(_) => panic!("closed original endpoint and invalid refresh domain must fail"),
+        Err(failure) => failure,
+    };
 
+    assert_eq!(failure.stage, "connect_direct");
+    assert_eq!(failure.network.resolved_candidates.len(), 1);
     assert_eq!(
-        resolution.candidates,
-        vec!["192.0.2.10:443".parse().unwrap()]
+        failure.network.resolved_candidates[0].host,
+        unavailable.ip().to_string()
     );
-    assert_eq!(resolution.udp_candidates(), resolution.candidates);
+    assert_eq!(failure.network.connection_attempts.len(), 1);
+    assert_eq!(
+        failure.network.connection_attempts[0].remote_address.host,
+        unavailable.ip().to_string()
+    );
+    assert!(failure.network.connection_attempts[0].os_error.is_some());
+}
+
+#[tokio::test]
+async fn recovered_ipv4_success_does_not_refresh_trusted_dns() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let dns = Arc::new(tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap());
+    let dns_addr = dns.local_addr().unwrap();
+    let query_count = Arc::new(AtomicUsize::new(0));
+    let server = {
+        let dns = Arc::clone(&dns);
+        let query_count = Arc::clone(&query_count);
+        tokio::spawn(async move {
+            let mut query = [0_u8; 2048];
+            while let Ok(Ok((size, peer))) =
+                tokio::time::timeout(std::time::Duration::from_secs(2), dns.recv_from(&mut query))
+                    .await
+            {
+                query_count.fetch_add(1, Ordering::SeqCst);
+                let mut response = query[..size].to_vec();
+                response[2] |= 0x80;
+                response[3] |= 0x80;
+                response[6..12].fill(0);
+                dns.send_to(&response, peer).await.unwrap();
+            }
+        })
+    };
+    let config = zero_config::RuntimeConfig::parse(&format!(
+        r#"{{
+            "runtime": {{
+                "dns": {{
+                    "servers": {{
+                        "test": {{ "type": "udp", "host": "127.0.0.1", "port": {} }}
+                    }},
+                    "default_server": "test",
+                    "policy": {{ "address_family": "ipv4_only" }}
+                }}
+            }},
+            "route": {{ "rules": [], "final": {{ "type": "direct" }} }}
+        }}"#,
+        dns_addr.port()
+    ))
+    .unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(config.runtime.dns.as_ref()).unwrap());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let original = listener.local_addr().unwrap();
+    let mut session = tls_sni_session(Address::Ipv4([127, 0, 0, 1]));
+    session.target = Address::Domain("refresh.invalid".to_owned());
+    session.sni = Some("refresh.invalid".to_owned());
+    session.port = original.port();
+
+    let connection = match DirectConnector
+        .connect(
+            &session,
+            &resolver,
+            &zero_platform_tokio::EgressInterfaceControl::default(),
+        )
+        .await
+    {
+        Ok(connection) => connection,
+        Err(failure) => panic!(
+            "usable original endpoint must connect before DNS refresh: {}",
+            failure.error
+        ),
+    };
+
+    assert_eq!(connection.remote, original);
+    assert_eq!(connection.network.resolved_candidates.len(), 1);
+    assert_eq!(connection.network.connection_attempts.len(), 1);
+    assert_eq!(query_count.load(Ordering::SeqCst), 0);
+    server.abort();
 }
 
 #[tokio::test]
@@ -272,7 +395,7 @@ async fn recovered_ipv4_without_host_source_remains_literal_only() {
     session.target = Address::Domain("localhost".to_owned());
     session.target_host_source = None;
     session.sni = None;
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let resolution = DirectConnector
         .resolve_target_addrs(
@@ -295,7 +418,7 @@ async fn recovered_ipv4_udp_remains_pinned_to_the_original_candidate() {
     let mut session = tls_sni_session(original);
     session.target = Address::Domain("localhost".to_owned());
     session.network = Network::Udp;
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let resolution = DirectConnector
         .resolve_target_addrs(
@@ -326,7 +449,7 @@ async fn unavailable_tun_ipv6_egress_reresolves_a_trusted_domain_to_ipv4() {
     let egress = zero_platform_tokio::EgressInterfaceControl::default();
     egress.mark_unavailable_for(true, "no physical IPv6 default route");
     egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let resolution = DirectConnector
         .resolve_target_addrs(&session, &resolver, &egress)
@@ -377,7 +500,7 @@ async fn unreachable_native_ipv6_candidate_races_one_trusted_ipv4_fallback() {
         Some(zero_platform_tokio::EgressInterface::new("loopback", 1).unwrap()),
     );
     egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let started = std::time::Instant::now();
     let connection = match DirectConnector.connect(&session, &resolver, &egress).await {
@@ -410,7 +533,7 @@ async fn unavailable_tun_ipv6_egress_applies_to_recovered_fake_ip_domains() {
     let egress = zero_platform_tokio::EgressInterfaceControl::default();
     egress.mark_unavailable_for(true, "no physical IPv6 default route");
     egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let resolution = DirectConnector
         .resolve_target_addrs(&session, &resolver, &egress)
@@ -436,7 +559,7 @@ async fn failed_ipv4_reresolution_keeps_the_fallback_diagnostics() {
     let egress = zero_platform_tokio::EgressInterfaceControl::default();
     egress.mark_unavailable_for(true, "no physical IPv6 default route");
     egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let failure = match DirectConnector.connect(&session, &resolver, &egress).await {
         Ok(_) => panic!("invalid fallback domain must not connect"),
@@ -466,7 +589,7 @@ async fn failed_ipv4_reresolution_keeps_the_fallback_diagnostics() {
 async fn direct_ipv6_is_preserved_without_an_active_tun_capture() {
     let original = Address::Ipv6([0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
     let session = tls_sni_session(original.clone());
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let resolution = DirectConnector
         .resolve_target_addrs(
@@ -490,7 +613,7 @@ async fn literal_ipv6_without_a_recovered_domain_is_not_converted() {
     let egress = zero_platform_tokio::EgressInterfaceControl::default();
     egress.mark_unavailable_for(true, "no physical IPv6 default route");
     egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
-    let resolver = zero_dns::DnsSystem::build(None).unwrap();
+    let resolver = Arc::new(zero_dns::DnsSystem::build(None).unwrap());
 
     let resolution = DirectConnector
         .resolve_target_addrs(&session, &resolver, &egress)


### PR DESCRIPTION
## Summary

- dial the captured transparent IPv4 endpoint before attempting any trusted-domain DNS refresh
- refresh recovered candidates only after the original dial has failed, and continue one bounded/deduplicated attempt timeline
- poll DNS refresh in a cancellable fresh Tokio task so the TUN direct-connect worker stack no longer recursively embeds the DNS underlay path
- run the FakeIP + DoH privileged TUN regression on Linux and Windows pull requests; macOS remains tracked separately in #90

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked --offline --jobs 1`
- `cargo test -p zero-proxy --features dns --lib --locked --offline --jobs 1` — 164 passed
- `cargo clippy -p zero-proxy --all-features --lib --locked --offline --jobs 1 --no-deps -- -D warnings`
- `cargo test --workspace --locked --offline --jobs 1` — all executed tests passed except one Windows loopback TCP/UDP same-port bind returned transient WSAEACCES 10013; the exact `truncated_upstream_udp_response_falls_back_to_tcp` test passed 1/1 on rerun
- local elevated A/B of `privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture`: the post-#76 Tokio worker stack overflow is eliminated; this host still cannot reach Cloudflare DoH, so hosted Linux/Windows jobs are the authoritative end-to-end gate

Closes #89
Part of #25
Part of #33
Part of #52