### PR TITLE
fix(tun): allow degraded cross-family route carriers

### DIFF
--- a/crates/tun/src/route.rs
+++ b/crates/tun/src/route.rs
@@ -275,5 +275,21 @@ fn family_exclusions(excluded: &[IpAddr], ipv6: bool) -> Vec<IpAddr> {
     excluded
 }
 
+/// Keep explicit host bypasses only while this address family has a native
+/// physical egress. A cross-family carrier can install the TUN capture routes,
+/// but it cannot carry a same-family host route for an otherwise unreachable
+/// DNS/bootstrap endpoint.
+fn family_exclusions_for_egress(
+    excluded: &[IpAddr],
+    ipv6: bool,
+    family_egress: &FamilyEgressState,
+) -> Vec<IpAddr> {
+    if family_egress.available_interface().is_some() {
+        family_exclusions(excluded, ipv6)
+    } else {
+        Vec::new()
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/tun/src/route/linux.rs
+++ b/crates/tun/src/route/linux.rs
@@ -6,8 +6,8 @@ use ipnet::IpNet;
 
 use super::reconcile::{reconcile_route_state, with_rollback_error, RouteReconcileState};
 use super::{
-    command_error, family_exclusions, host_prefix, EgressUnavailableReason, FamilyEgressState,
-    RouteInterface, RouteJournal, RouteLease,
+    command_error, family_exclusions_for_egress, host_prefix, EgressUnavailableReason,
+    FamilyEgressState, RouteInterface, RouteJournal, RouteLease,
 };
 
 #[derive(Debug)]
@@ -68,12 +68,11 @@ impl SystemRouteGuard {
         let ipv6 = address.is_ipv6();
         let lease = RouteLease::acquire(recovery_key, ipv6)?;
         recover_stale_routes(&lease, ipv6)?;
-        let has_family_exclusions = excluded.iter().any(|peer| peer.is_ipv6() == ipv6);
-        let selected = select_physical_egress(ipv6, tun_name, !has_family_exclusions)?;
+        let selected = select_physical_egress(ipv6, tun_name)?;
         let egress = selected.carrier;
         let gateway = selected.gateway;
         let journal = RouteJournal::new(lease, tun_name, ipv6, 0, egress.clone(), gateway.clone())?;
-        let desired_exclusions = family_exclusions(excluded, ipv6);
+        let desired_exclusions = family_exclusions_for_egress(excluded, ipv6, &selected.family);
         let mut guard = Self {
             egress,
             family_egress: selected.family,
@@ -111,9 +110,9 @@ impl SystemRouteGuard {
     /// Re-resolve the preferred physical interface and reconcile explicit
     /// bypass routes without replacing the TUN device or split default routes.
     pub fn reconcile(&mut self, excluded: &[IpAddr]) -> io::Result<bool> {
-        let desired_exclusions = family_exclusions(excluded, self.ipv6);
-        let has_family_exclusions = !desired_exclusions.is_empty();
-        let selected = select_physical_egress(self.ipv6, &self.tun_name, !has_family_exclusions)?;
+        let selected = select_physical_egress(self.ipv6, &self.tun_name)?;
+        let desired_exclusions =
+            family_exclusions_for_egress(excluded, self.ipv6, &selected.family);
         let family_changed = self.family_egress != selected.family;
         let changed =
             reconcile_route_state(self, selected.carrier, selected.gateway, desired_exclusions)?;
@@ -201,18 +200,14 @@ impl SystemRouteGuard {
     }
 }
 
-fn select_physical_egress(
-    ipv6: bool,
-    tun_name: &str,
-    allow_cross_family_carrier: bool,
-) -> io::Result<LinuxEgressSelection> {
+fn select_physical_egress(ipv6: bool, tun_name: &str) -> io::Result<LinuxEgressSelection> {
     match default_interface(ipv6, tun_name) {
         Ok((carrier, gateway)) => Ok(LinuxEgressSelection {
             family: FamilyEgressState::Available(carrier.clone()),
             carrier,
             gateway,
         }),
-        Err(error) if allow_cross_family_carrier => {
+        Err(error) => {
             let (carrier, gateway) = default_interface(!ipv6, tun_name).map_err(|fallback| {
                 io::Error::new(
                     fallback.kind(),
@@ -227,7 +222,6 @@ fn select_physical_egress(
                 family: FamilyEgressState::Unavailable(EgressUnavailableReason::NoDefaultRoute),
             })
         }
-        Err(error) => Err(error),
     }
 }
 

--- a/crates/tun/src/route/macos.rs
+++ b/crates/tun/src/route/macos.rs
@@ -6,8 +6,8 @@ use ipnet::IpNet;
 
 use super::reconcile::{reconcile_route_state, with_rollback_error, RouteReconcileState};
 use super::{
-    command_error, family_exclusions, EgressUnavailableReason, FamilyEgressState, RouteInterface,
-    RouteJournal, RouteLease,
+    command_error, family_exclusions_for_egress, EgressUnavailableReason, FamilyEgressState,
+    RouteInterface, RouteJournal, RouteLease,
 };
 
 mod scoped;
@@ -68,8 +68,7 @@ impl SystemRouteGuard {
         let ipv6 = address.is_ipv6();
         let lease = RouteLease::acquire(recovery_key, ipv6)?;
         recover_stale_routes(&lease, ipv6)?;
-        let has_family_exclusions = excluded.iter().any(|peer| peer.is_ipv6() == ipv6);
-        let selected = select_physical_egress(ipv6, tun_name, !has_family_exclusions)?;
+        let selected = select_physical_egress(ipv6, tun_name)?;
         let egress = selected.carrier;
         let gateway = selected.gateway;
         let tun_gateway = match address {
@@ -77,7 +76,7 @@ impl SystemRouteGuard {
             IpAddr::V6(_) => None,
         };
         let journal = RouteJournal::new(lease, tun_name, ipv6, 0, egress.clone(), gateway.clone())?;
-        let desired_exclusions = family_exclusions(excluded, ipv6);
+        let desired_exclusions = family_exclusions_for_egress(excluded, ipv6, &selected.family);
         let mut guard = Self {
             egress,
             family_egress: selected.family,
@@ -117,9 +116,9 @@ impl SystemRouteGuard {
     /// Re-resolve the preferred physical interface and reconcile explicit
     /// bypass routes without replacing the TUN device or split default routes.
     pub fn reconcile(&mut self, excluded: &[IpAddr]) -> io::Result<bool> {
-        let desired_exclusions = family_exclusions(excluded, self.ipv6);
-        let has_family_exclusions = !desired_exclusions.is_empty();
-        let selected = select_physical_egress(self.ipv6, &self.tun_name, !has_family_exclusions)?;
+        let selected = select_physical_egress(self.ipv6, &self.tun_name)?;
+        let desired_exclusions =
+            family_exclusions_for_egress(excluded, self.ipv6, &selected.family);
         let family_changed = self.family_egress != selected.family;
         let changed =
             reconcile_route_state(self, selected.carrier, selected.gateway, desired_exclusions)?;
@@ -226,18 +225,14 @@ impl SystemRouteGuard {
     }
 }
 
-fn select_physical_egress(
-    ipv6: bool,
-    tun_name: &str,
-    allow_cross_family_carrier: bool,
-) -> io::Result<MacosEgressSelection> {
+fn select_physical_egress(ipv6: bool, tun_name: &str) -> io::Result<MacosEgressSelection> {
     match default_interface(ipv6, tun_name) {
         Ok((carrier, gateway)) => Ok(MacosEgressSelection {
             family: FamilyEgressState::Available(carrier.clone()),
             carrier,
             gateway,
         }),
-        Err(error) if allow_cross_family_carrier => {
+        Err(error) => {
             let (carrier, gateway) = default_interface(!ipv6, tun_name).map_err(|fallback| {
                 io::Error::new(
                     fallback.kind(),
@@ -252,7 +247,6 @@ fn select_physical_egress(
                 family: FamilyEgressState::Unavailable(EgressUnavailableReason::NoDefaultRoute),
             })
         }
-        Err(error) => Err(error),
     }
 }
 

--- a/crates/tun/src/route/tests.rs
+++ b/crates/tun/src/route/tests.rs
@@ -1,8 +1,8 @@
 use std::net::{IpAddr, Ipv4Addr};
 
 use super::{
-    capture_route_prefixes, capture_route_prefixes_with_exclusions, RouteInterface, RouteJournal,
-    RouteLease,
+    capture_route_prefixes, capture_route_prefixes_with_exclusions, family_exclusions_for_egress,
+    EgressUnavailableReason, FamilyEgressState, RouteInterface, RouteJournal, RouteLease,
 };
 
 #[test]
@@ -133,6 +133,24 @@ fn recovery_journal_accepts_legacy_entries_without_gateway() {
     .expect("deserialize legacy route journal");
     assert!(recovered.gateway.is_none());
     assert!(!recovered.scoped_bypass);
+}
+
+#[test]
+fn host_exclusions_require_native_family_egress() {
+    let excluded = [
+        "2001:db8::53".parse().unwrap(),
+        "192.0.2.53".parse().unwrap(),
+    ];
+    let available =
+        FamilyEgressState::Available(RouteInterface::new("physical6".to_owned(), 6).unwrap());
+    assert_eq!(
+        family_exclusions_for_egress(&excluded, true, &available),
+        vec!["2001:db8::53".parse::<IpAddr>().unwrap()]
+    );
+
+    let unavailable = FamilyEgressState::Unavailable(EgressUnavailableReason::NoDefaultRoute);
+    assert!(family_exclusions_for_egress(&excluded, true, &unavailable).is_empty());
+    assert!(family_exclusions_for_egress(&excluded, true, &FamilyEgressState::Unknown).is_empty());
 }
 
 #[test]

--- a/crates/tun/src/route/windows.rs
+++ b/crates/tun/src/route/windows.rs
@@ -17,8 +17,8 @@ use windows_sys::Win32::Networking::WinSock::{
 
 use super::reconcile::{reconcile_route_state, with_rollback_error, RouteReconcileState};
 use super::{
-    family_exclusions, host_prefix, EgressUnavailableReason, FamilyEgressState, RouteInterface,
-    RouteJournal, RouteLease,
+    family_exclusions_for_egress, host_prefix, EgressUnavailableReason, FamilyEgressState,
+    RouteInterface, RouteJournal, RouteLease,
 };
 
 #[derive(Debug)]
@@ -80,11 +80,10 @@ impl SystemRouteGuard {
         recover_stale_routes(&lease, address.is_ipv6())?;
         let tun_index = interface_by_name(tun_name)?;
         let ipv6 = address.is_ipv6();
-        let has_family_exclusions = excluded.iter().any(|peer| peer.is_ipv6() == ipv6);
-        let selected = select_physical_egress(ipv6, tun_index, !has_family_exclusions)?;
+        let selected = select_physical_egress(ipv6, tun_index)?;
         let egress = selected.carrier;
         let gateway = selected.gateway;
-        let desired_exclusions = family_exclusions(excluded, ipv6);
+        let desired_exclusions = family_exclusions_for_egress(excluded, ipv6, &selected.family);
         let journal = RouteJournal::new(
             lease,
             tun_name,
@@ -131,9 +130,9 @@ impl SystemRouteGuard {
     /// Re-resolve the preferred physical interface and reconcile explicit
     /// bypass routes without replacing the TUN device or split default routes.
     pub fn reconcile(&mut self, excluded: &[IpAddr]) -> io::Result<bool> {
-        let desired_exclusions = family_exclusions(excluded, self.ipv6);
-        let has_family_exclusions = !desired_exclusions.is_empty();
-        let selected = select_physical_egress(self.ipv6, self.tun_index, !has_family_exclusions)?;
+        let selected = select_physical_egress(self.ipv6, self.tun_index)?;
+        let desired_exclusions =
+            family_exclusions_for_egress(excluded, self.ipv6, &selected.family);
         let family_changed = self.family_egress != selected.family;
         let changed =
             reconcile_route_state(self, selected.carrier, selected.gateway, desired_exclusions)?;
@@ -315,11 +314,7 @@ fn interface_by_name(name: &str) -> io::Result<u32> {
     Ok(index)
 }
 
-fn select_physical_egress(
-    ipv6: bool,
-    tun_index: u32,
-    allow_cross_family_carrier: bool,
-) -> io::Result<WindowsEgressSelection> {
+fn select_physical_egress(ipv6: bool, tun_index: u32) -> io::Result<WindowsEgressSelection> {
     match default_interface(ipv6, tun_index) {
         Ok(physical) => {
             let carrier =
@@ -356,7 +351,7 @@ fn select_physical_egress(
                 family,
             })
         }
-        Err(native_error) if allow_cross_family_carrier => {
+        Err(native_error) => {
             let physical = default_interface(!ipv6, tun_index).map_err(|fallback| {
                 io::Error::new(
                     fallback.kind(),
@@ -383,7 +378,6 @@ fn select_physical_egress(
                 family: FamilyEgressState::Unavailable(EgressUnavailableReason::NoDefaultRoute),
             })
         }
-        Err(error) => Err(error),
     }
 }
 

--- a/tests/tun_privileged_e2e.rs
+++ b/tests/tun_privileged_e2e.rs
@@ -759,6 +759,11 @@ fn config_json_with_dns(
     config["runtime"]["dns"]["servers"]["test"]["host"] =
         serde_json::Value::String(dns.ip().to_string());
     config["runtime"]["dns"]["servers"]["test"]["port"] = serde_json::Value::from(dns.port());
+    // Keep an unreachable IPv6 bootstrap candidate in the exact IPv4-only
+    // environment covered by this E2E. Its required host exclusion must not
+    // prevent the dual-stack TUN from starting through an IPv4 route carrier.
+    config["runtime"]["dns"]["servers"]["test"]["bootstrap"] =
+        serde_json::json!([dns.ip(), "2001:db8::53"]);
     serde_json::to_string_pretty(&config).unwrap()
 }
 


### PR DESCRIPTION
## Summary

- allow split-default TUN routes to use the other address family's physical carrier when native family egress is unavailable, even when DNS/bootstrap host exclusions exist
- install explicit host bypasses only while native same-family egress is available, then reconcile them automatically when that egress returns
- cover the policy with a unit regression and extend the Windows IPv4-only privileged E2E with an unreachable IPv6 bootstrap candidate

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- Cargo compilation and privileged TUN execution were not run locally because this Windows host is constrained to non-compiling checks; hosted privileged TUN jobs remain authoritative