### PR TITLE
test(dns): cover FakeIPv6 egress fallback

### DIFF
--- a/crates/proxy/src/runtime/target/tests.rs
+++ b/crates/proxy/src/runtime/target/tests.rs
@@ -10,6 +10,9 @@ use zero_traits::{DnsResolver, IpAddress};
 
 use super::resolve_dns_target;
 
+#[cfg(feature = "dns")]
+mod fake_ipv6_fallback;
+
 #[tokio::test]
 async fn recovers_only_transparent_real_ip_targets_and_preserves_direct_ip() {
     let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")

--- a/crates/proxy/src/runtime/target/tests/fake_ipv6_fallback.rs
+++ b/crates/proxy/src/runtime/target/tests/fake_ipv6_fallback.rs
@@ -1,0 +1,154 @@
+use std::collections::BTreeMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use zero_config::{
+    DnsAddressFamilyPolicy, DnsAnswerConfig, DnsConfig, DnsPolicyConfig, DnsServerConfig,
+};
+use zero_core::{Address, FakeIpReverseStatus, Network, ProtocolType, Session, TargetHostSource};
+use zero_traits::IpAddress;
+
+use crate::runtime::target::resolve_dns_target;
+use crate::transport::DirectConnector;
+
+#[tokio::test]
+async fn mapped_fake_ipv6_recovers_without_sniffing_and_uses_every_ipv4_candidate() {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind DNS");
+    let port = socket.local_addr().expect("DNS local address").port();
+    let server = tokio::spawn(async move {
+        let mut request = [0_u8; 4096];
+        let (size, peer) = socket
+            .recv_from(&mut request)
+            .await
+            .expect("receive A query");
+        let question = zero_dns::udp::parse_dns_question(&request[..size])
+            .expect("parse direct fallback query");
+        assert_eq!(
+            question.query_type, 1,
+            "IPv6 egress fallback must use a real A query"
+        );
+        let addresses = [
+            IpAddress::V4([192, 0, 2, 1]),
+            IpAddress::V4([192, 0, 2, 2]),
+            IpAddress::V4([192, 0, 2, 3]),
+        ];
+        let response = zero_dns::udp::build_dns_response(&request[..size], &addresses);
+        socket
+            .send_to(&response, peer)
+            .await
+            .expect("send A response");
+    });
+    let dns = fake_dns(port);
+
+    let response = dns
+        .answer_udp_query(&dns_query("mapped.example", 28))
+        .await
+        .expect("allocate synthetic AAAA mapping");
+    let synthetic = Address::Ipv6(
+        response[response.len() - 16..]
+            .try_into()
+            .expect("sixteen-byte AAAA response"),
+    );
+
+    let mut recovered_tcp = None;
+    for (id, network) in [(1, Network::Tcp), (2, Network::Udp)] {
+        let mut session = Session::new(id, synthetic.clone(), 443, network, ProtocolType::UNKNOWN);
+        session.transparent_target = true;
+
+        resolve_dns_target(&dns, &mut session)
+            .await
+            .expect("restore mapped FakeIPv6 domain");
+
+        assert_eq!(session.target, Address::Domain("mapped.example".to_owned()));
+        assert_eq!(session.original_target, Some(synthetic.clone()));
+        assert!(session.direct_target.is_none());
+        assert_eq!(session.target_host_source, Some(TargetHostSource::FakeIp));
+        assert_eq!(
+            session.fake_ip_reverse_status,
+            Some(FakeIpReverseStatus::Resolved)
+        );
+        assert!(session.sni.is_none());
+
+        if network == Network::Tcp {
+            recovered_tcp = Some(session);
+        }
+    }
+
+    let egress = zero_platform_tokio::EgressInterfaceControl::default();
+    egress.mark_unavailable_for(true, "no physical IPv6 default route");
+    egress.replace_tunnel_addresses(["10.66.0.1".parse().unwrap(), "fd66::1".parse().unwrap()]);
+    let session = recovered_tcp.expect("recovered TCP session");
+    let resolution = DirectConnector
+        .resolve_target_addrs(&session, &dns, &egress)
+        .await
+        .expect("trusted Fake-IP domain should resolve through IPv4");
+
+    assert_eq!(
+        resolution.candidates,
+        [
+            Ipv4Addr::new(192, 0, 2, 1),
+            Ipv4Addr::new(192, 0, 2, 2),
+            Ipv4Addr::new(192, 0, 2, 3),
+        ]
+        .map(|ip| SocketAddr::new(IpAddr::V4(ip), 443))
+    );
+    let network =
+        DirectConnector.udp_network_observation(&resolution, resolution.candidates[0], &egress);
+    let fallback = network
+        .address_family_fallback
+        .expect("IPv6-to-IPv4 fallback should be observable");
+    assert_eq!(fallback.from, "ipv6");
+    assert_eq!(fallback.to, "ipv4");
+    assert_eq!(fallback.reason, "tun_ipv6_egress_unavailable");
+    assert_eq!(
+        fallback.unavailable_reason.as_deref(),
+        Some("no physical IPv6 default route")
+    );
+
+    server.await.expect("DNS server task");
+}
+
+fn fake_dns(port: u16) -> zero_dns::DnsSystem {
+    zero_dns::DnsSystem::build(Some(&DnsConfig {
+        servers: BTreeMap::from([(
+            "local".to_owned(),
+            DnsServerConfig::Udp {
+                host: "127.0.0.1".to_owned(),
+                port,
+                bootstrap: Vec::new(),
+                detour: None,
+            },
+        )]),
+        default_server: "local".to_owned(),
+        dispatch: Vec::new(),
+        cache: None,
+        reverse_mapping: None,
+        answer: DnsAnswerConfig::FakeIp {
+            cidr: "198.18.0.0/24".to_owned(),
+            ipv6_cidr: Some("fd00::/120".to_owned()),
+            ttl_seconds: 60,
+            max_entries: Some(16),
+            exclude_domains: Vec::new(),
+        },
+        policy: DnsPolicyConfig {
+            address_family: DnsAddressFamilyPolicy::PreferIpv4,
+            ..Default::default()
+        },
+    }))
+    .expect("build dual-stack Fake-IP DNS")
+}
+
+fn dns_query(domain: &str, query_type: u16) -> Vec<u8> {
+    let mut query = vec![
+        0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    for label in domain.split('.') {
+        query.push(label.len() as u8);
+        query.extend_from_slice(label.as_bytes());
+    }
+    query.push(0);
+    query.extend_from_slice(&query_type.to_be_bytes());
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    query
+}


### PR DESCRIPTION
## Summary

- add a cross-module acceptance test that allocates a synthetic AAAA mapping and restores the same domain for transparent TCP and UDP sessions without SNI/sniffing
- prove an active dual-stack TUN with unavailable native IPv6 egress re-resolves the trusted Fake-IP domain using a real A query
- prove all three returned A candidates remain available in resolver order and the IPv6-to-IPv4 fallback is observable
- gate the acceptance module on the DNS feature while preserving the existing bare IPv6 fail-closed coverage

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p zero-proxy --lib --features dns mapped_fake_ipv6_recovers_without_sniffing_and_uses_every_ipv4_candidate -j 1`

Closes #96
Part of #33
Part of #52