### PR TITLE
ci(tun): add collaborator-only test-machine dispatch

### DIFF
--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -31,11 +31,17 @@ on:
           - hosted-macos
           - hosted-windows
           - self-hosted-all
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: tun-e2e-${{ github.ref }}
   cancel-in-progress: false
 
+# The exact `/run-tun-e2e self-hosted-all` comment on issue #33 is an auditable
+# dispatch fallback for repository collaborators when workflow_dispatch is not
+# exposed by their GitHub integration. Public comments cannot start runners.
+#
 # The self-hosted jobs target dedicated runners. Each runner
 # must be disposable, have administrator/root networking privileges, and have
 # reachable configured STUN endpoints for each native address family being
@@ -44,7 +50,14 @@ concurrency:
 # binary or on PATH.
 jobs:
   linux:
-    if: inputs.target == 'self-hosted-all'
+    if: >-
+      inputs.target == 'self-hosted-all' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 33 &&
+       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: [self-hosted, linux, x64, tun]
     timeout-minutes: 30
     env:
@@ -73,7 +86,14 @@ jobs:
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
 
   macos:
-    if: inputs.target == 'self-hosted-all'
+    if: >-
+      inputs.target == 'self-hosted-all' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 33 &&
+       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: [self-hosted, macOS, x64, tun]
     timeout-minutes: 30
     env:
@@ -104,7 +124,14 @@ jobs:
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
 
   windows:
-    if: inputs.target == 'self-hosted-all'
+    if: >-
+      inputs.target == 'self-hosted-all' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 33 &&
+       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: [self-hosted, windows, x64, tun]
     timeout-minutes: 30
     env:


### PR DESCRIPTION
Adds an auditable fallback for launching the dedicated self-hosted TUN matrix when an integration cannot call GitHub's workflow-dispatch API.

Security boundary:
- only a newly created comment on core #33 is considered;
- the body must exactly equal `/run-tun-e2e self-hosted-all`;
- the author association must be OWNER, MEMBER, or COLLABORATOR;
- public comments and all other issues/commands skip every self-hosted job;
- the jobs retain the existing `[self-hosted, <os>, x64, tun]` labels and never execute on the development workstation.

After merge, posting the exact command through the existing GitHub connector starts the Linux, macOS, and Windows dedicated-runner jobs. Hosted jobs remain unchanged.

Verification:
- `git diff --check` passed.
- No local build, test, TUN, DNS, browser, or network verification was performed.
- GitHub's PR workflow parser and hosted matrices are the acceptance gates.