### PR TITLE
ci(tun): make GitHub-hosted runners authoritative

### DIFF
--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -136,7 +136,9 @@ jobs:
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
       - name: Run direct UDP self-capture E2E
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run Fake-IP DoH underlay E2E
+      - name: Run Fake-IP DoH and open.bigmodel.cn multi-A fallback E2E
+        env:
+          ZERO_TUN_E2E_FAKE_IP_DOMAIN: open.bigmodel.cn
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run command-managed egress publication E2E
         run: cargo test --test tun_privileged_e2e privileged_command_managed_tun_publishes_egress_before_capture -- --ignored --exact --nocapture

--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -30,133 +30,15 @@ on:
           - hosted-linux
           - hosted-macos
           - hosted-windows
-          - self-hosted-all
-  issue_comment:
-    types: [created]
 
 concurrency:
   group: tun-e2e-${{ github.ref }}
   cancel-in-progress: false
 
-# The exact `/run-tun-e2e self-hosted-all` comment on issue #33 is an auditable
-# dispatch fallback for repository collaborators when workflow_dispatch is not
-# exposed by their GitHub integration. Public comments cannot start runners.
-#
-# The self-hosted jobs target dedicated runners. Each runner
-# must be disposable, have administrator/root networking privileges, and have
-# reachable configured STUN endpoints for each native address family being
-# tested. The offline dual-stack case does not require native IPv6 Internet.
-# The Windows runner must also have the matching Wintun DLL next to the test
-# binary or on PATH.
+# GitHub-hosted runners are the authoritative privileged validation environment.
+# The matrix uses deterministic local peers for dual-stack and fallback behavior
+# so it does not depend on a runner having public native IPv6 connectivity.
 jobs:
-  linux:
-    if: >-
-      inputs.target == 'self-hosted-all' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.number == 33 &&
-       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
-       (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
-    runs-on: [self-hosted, linux, x64, tun]
-    timeout-minutes: 30
-    env:
-      ZERO_TUN_E2E_DNS_ADDR: ${{ secrets.ZERO_TUN_E2E_DNS_ADDR }}
-      ZERO_TUN_E2E_STUN_ADDR: ${{ secrets.ZERO_TUN_E2E_STUN_ADDR }}
-      ZERO_TUN_E2E_STUN_ADDR_V6: ${{ secrets.ZERO_TUN_E2E_STUN_ADDR_V6 }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install build prerequisites
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler iproute2 nftables
-      - name: Run privileged TUN smoke test
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run direct UDP self-capture E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_DNS_ADDR=$ZERO_TUN_E2E_DNS_ADDR" cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run Fake-IP DoH underlay E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run native Linux route reconciliation E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_route_reconcile_linux_e2e linux_reconciles_runtime_egress_and_dns_exclusion_inside_network_namespace -- --ignored --exact --nocapture
-      - name: Run IPv4 privileged TUN E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_STUN_ADDR=$ZERO_TUN_E2E_STUN_ADDR" cargo test --test tun_privileged_e2e privileged_tun_ipv4_config_reload_stun_block_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run IPv6 privileged TUN E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_STUN_ADDR_V6=$ZERO_TUN_E2E_STUN_ADDR_V6" cargo test --test tun_privileged_e2e privileged_tun_ipv6_config_reload_stun_block_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run offline dual-stack privileged TUN E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
-
-  macos:
-    if: >-
-      inputs.target == 'self-hosted-all' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.number == 33 &&
-       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
-       (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
-    runs-on: [self-hosted, macOS, x64, tun]
-    timeout-minutes: 30
-    env:
-      ZERO_TUN_E2E_DNS_ADDR: ${{ secrets.ZERO_TUN_E2E_DNS_ADDR }}
-      ZERO_TUN_E2E_STUN_ADDR: ${{ secrets.ZERO_TUN_E2E_STUN_ADDR }}
-      ZERO_TUN_E2E_STUN_ADDR_V6: ${{ secrets.ZERO_TUN_E2E_STUN_ADDR_V6 }}
-      ZERO_TUN_E2E_MACOS_SECONDARY_GATEWAY: ${{ secrets.ZERO_TUN_E2E_MACOS_SECONDARY_GATEWAY }}
-      ZERO_TUN_E2E_MACOS_SECONDARY_INTERFACE: ${{ secrets.ZERO_TUN_E2E_MACOS_SECONDARY_INTERFACE }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Run privileged TUN smoke test
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run macOS loopback capture and crash-recovery E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_macos_tun_loopback_remains_reachable_across_crash_recovery -- --ignored --exact --nocapture
-      - name: Run direct UDP self-capture E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_DNS_ADDR=$ZERO_TUN_E2E_DNS_ADDR" cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run Fake-IP DoH underlay E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run native macOS route reconciliation E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_MACOS_SECONDARY_GATEWAY=$ZERO_TUN_E2E_MACOS_SECONDARY_GATEWAY" "ZERO_TUN_E2E_MACOS_SECONDARY_INTERFACE=$ZERO_TUN_E2E_MACOS_SECONDARY_INTERFACE" cargo test --test tun_route_reconcile_macos_e2e macos_reconciles_runtime_egress_and_dns_exclusion_without_restarting_tun -- --ignored --exact --nocapture
-      - name: Run IPv4 privileged TUN E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_STUN_ADDR=$ZERO_TUN_E2E_STUN_ADDR" cargo test --test tun_privileged_e2e privileged_tun_ipv4_config_reload_stun_block_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run IPv6 privileged TUN E2E
-        run: sudo env "PATH=$PATH" "ZERO_TUN_E2E_STUN_ADDR_V6=$ZERO_TUN_E2E_STUN_ADDR_V6" cargo test --test tun_privileged_e2e privileged_tun_ipv6_config_reload_stun_block_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run offline dual-stack privileged TUN E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
-
-  windows:
-    if: >-
-      inputs.target == 'self-hosted-all' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.number == 33 &&
-       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
-       (github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'COLLABORATOR'))
-    runs-on: [self-hosted, windows, x64, tun]
-    timeout-minutes: 30
-    env:
-      ZERO_TUN_E2E_DNS_ADDR: ${{ secrets.ZERO_TUN_E2E_DNS_ADDR }}
-      ZERO_TUN_E2E_STUN_ADDR: ${{ secrets.ZERO_TUN_E2E_STUN_ADDR }}
-      ZERO_TUN_E2E_STUN_ADDR_V6: ${{ secrets.ZERO_TUN_E2E_STUN_ADDR_V6 }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Run privileged TUN smoke test
-        run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run direct UDP self-capture E2E
-        run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run Fake-IP DoH underlay E2E
-        run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
-      - name: Run native Windows route reconciliation E2E
-        run: cargo test --test tun_route_reconcile_e2e windows_reconciles_runtime_egress_and_dns_exclusion_without_restarting_tun -- --ignored --exact --nocapture
-      - name: Run IPv4 privileged TUN E2E
-        run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_config_reload_stun_block_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run IPv6 privileged TUN E2E
-        run: cargo test --test tun_privileged_e2e privileged_tun_ipv6_config_reload_stun_block_and_crash_recovery -- --ignored --exact --nocapture
-      - name: Run offline dual-stack privileged TUN E2E
-        run: cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
-
   hosted-linux:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || inputs.target == 'hosted-all' || inputs.target == 'hosted-linux'
     runs-on: ubuntu-24.04
@@ -186,6 +68,10 @@ jobs:
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
         run: cargo test --target x86_64-unknown-linux-gnu --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
+      - name: Run command-managed egress publication E2E
+        env:
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
+        run: cargo test --target x86_64-unknown-linux-gnu --test tun_privileged_e2e privileged_command_managed_tun_publishes_egress_before_capture -- --ignored --exact --nocapture
       - name: Run offline dual-stack privileged TUN E2E
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
@@ -218,6 +104,8 @@ jobs:
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run Fake-IP DoH underlay E2E
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
+      - name: Run command-managed egress publication E2E
+        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_command_managed_tun_publishes_egress_before_capture -- --ignored --exact --nocapture
       - name: Run offline dual-stack privileged TUN E2E
         if: github.event_name != 'pull_request'
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
@@ -250,5 +138,11 @@ jobs:
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run Fake-IP DoH underlay E2E
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
+      - name: Run command-managed egress publication E2E
+        run: cargo test --test tun_privileged_e2e privileged_command_managed_tun_publishes_egress_before_capture -- --ignored --exact --nocapture
+      - name: Run native Windows route reconciliation E2E
+        run: cargo test --test tun_route_reconcile_e2e windows_reconciles_runtime_egress_and_dns_exclusion_without_restarting_tun -- --ignored --exact --nocapture
+      - name: Run IPv4-only trusted-domain fallback E2E
+        run: cargo test --test tun_privileged_e2e privileged_windows_ipv4_only_tun_falls_back_trusted_ipv6_domains -- --ignored --exact --nocapture
       - name: Run offline dual-stack privileged TUN E2E
         run: cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture

--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -33,7 +33,7 @@ on:
 
 concurrency:
   group: tun-e2e-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 # GitHub-hosted runners are the authoritative privileged validation environment.
 # The matrix uses deterministic local peers for dual-stack and fallback behavior

--- a/tests/tun_privileged_e2e.rs
+++ b/tests/tun_privileged_e2e.rs
@@ -256,6 +256,16 @@ fn privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture() {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn command_managed_tun_name() -> &'static str {
+    "utun77"
+}
+
+#[cfg(not(target_os = "macos"))]
+fn command_managed_tun_name() -> &'static str {
+    "ZeroTunCmd"
+}
+
 #[test]
 #[ignore = "requires administrator/root, a TUN backend, internet access, and reachable Cloudflare DoH"]
 fn privileged_command_managed_tun_publishes_egress_before_capture() {
@@ -276,7 +286,7 @@ fn privileged_command_managed_tun_publishes_egress_before_capture() {
                 "tun",
                 "start",
                 "--name",
-                "ZeroTunCmd",
+                command_managed_tun_name(),
                 "--addr",
                 "10.66.0.1/24",
                 "--mask",

--- a/tests/tun_privileged_e2e.rs
+++ b/tests/tun_privileged_e2e.rs
@@ -235,8 +235,10 @@ fn privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture() {
         let tun_name = assert_tun_os_configured(binary, &socket, false, false);
         #[cfg(target_os = "macos")]
         assert_macos_loopback_listener_reachable(binary, &socket, listen_port, &loopback_before);
-        assert_http_connect_domain_through_mixed_inbound(listen_port, "example.com");
-        assert_http_domain_through_fake_ip("example.com");
+        let domain = std::env::var("ZERO_TUN_E2E_FAKE_IP_DOMAIN")
+            .unwrap_or_else(|_| "example.com".to_owned());
+        assert_http_connect_domain_through_mixed_inbound(listen_port, &domain);
+        assert_http_domain_through_fake_ip(&domain);
         assert_dns_underlay_not_captured(binary, &socket);
 
         run_cli(


### PR DESCRIPTION
## Summary

Replace the unfulfillable dedicated self-hosted TUN dispatch with a GitHub-hosted-only validation matrix.

- remove the `self-hosted-all` workflow input, issue-comment dispatch, and Linux/macOS/Windows self-hosted jobs
- retain the privileged `ubuntu-24.04`, `macos-15-intel`, and `windows-2025` matrix as the authoritative environment
- use deterministic local peers for dual-stack behavior rather than requiring public native IPv6 on the runner
- add command-managed egress publication coverage on all three hosted platforms
- add native Windows route reconciliation and IPv4-only trusted-domain fallback coverage

This repository has no dedicated runner fleet, so queued self-hosted jobs cannot be an acceptance gate. The hosted matrix preserves real privileged TUN/Wintun execution while keeping address-family and fallback cases reproducible.

Part of #33

## Validation

Validation is delegated to this PR's GitHub-hosted CI and privileged TUN workflows. No local network, TUN, Rust build, or test was run.

## Final GitHub-hosted evidence

- [CI 33416234739](https://github.com/zerodenet/core/actions/runs/33416234739) passed on head `8ffdae7f`.
- [Privileged TUN E2E 33416234793](https://github.com/zerodenet/core/actions/runs/33416234793) passed on GitHub-hosted Windows, Linux, and macOS.
- Windows passed Wintun IPv4/IPv6 configuration, direct UDP anti-loop, command-managed egress publication, native route reconciliation, offline dual-stack capture, and trusted IPv6-domain to IPv4 fallback.
- The Windows Fake-IP/DoH TUN path recovered `open.bigmodel.cn` as a domain and completed direct HTTP sessions from both mixed-inbound and synthetic-address paths.
- Linux passed namespace route reconciliation and the hosted privileged TUN matrix.
- macOS passed PF_ROUTE lifecycle, loopback/crash recovery, Fake-IP/DoH, command-managed egress publication with a valid `utunN` name, and offline dual-stack capture.

No development-workstation network, TUN, Rust build, or Rust test was used as acceptance evidence.