### PR TITLE
fix(tun): stabilize DNS bootstrap and node probes

### DIFF
--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -31,11 +31,17 @@ on:
           - hosted-macos
           - hosted-windows
           - self-hosted-all
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: tun-e2e-${{ github.ref }}
   cancel-in-progress: false
 
+# The exact `/run-tun-e2e self-hosted-all` comment on issue #33 is an auditable
+# dispatch fallback for repository collaborators when workflow_dispatch is not
+# exposed by their GitHub integration. Public comments cannot start runners.
+#
 # The self-hosted jobs target dedicated runners. Each runner
 # must be disposable, have administrator/root networking privileges, and have
 # reachable configured STUN endpoints for each native address family being
@@ -44,7 +50,14 @@ concurrency:
 # binary or on PATH.
 jobs:
   linux:
-    if: inputs.target == 'self-hosted-all'
+    if: >-
+      inputs.target == 'self-hosted-all' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 33 &&
+       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: [self-hosted, linux, x64, tun]
     timeout-minutes: 30
     env:
@@ -73,7 +86,14 @@ jobs:
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
 
   macos:
-    if: inputs.target == 'self-hosted-all'
+    if: >-
+      inputs.target == 'self-hosted-all' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 33 &&
+       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: [self-hosted, macOS, x64, tun]
     timeout-minutes: 30
     env:
@@ -104,7 +124,14 @@ jobs:
         run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
 
   windows:
-    if: inputs.target == 'self-hosted-all'
+    if: >-
+      inputs.target == 'self-hosted-all' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.number == 33 &&
+       github.event.comment.body == '/run-tun-e2e self-hosted-all' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: [self-hosted, windows, x64, tun]
     timeout-minutes: 30
     env:

--- a/crates/dns/src/backends.rs
+++ b/crates/dns/src/backends.rs
@@ -271,7 +271,20 @@ async fn connect_tcp(
         return connector.connect(outbound.to_owned(), addr).await;
     }
 
-    let interface = egress.try_current_for_peer(addr)?;
+    let selection = egress.select_for_peer(addr);
+    selection.ensure_connectable()?;
+    let interface = selection.interface().cloned();
+    tracing::debug!(
+        peer = %addr,
+        tun_active = selection.tun_active(),
+        egress_generation = selection.generation(),
+        binding_reason = selection.binding_reason().as_str(),
+        route_lookup = selection.route_lookup_status().as_str(),
+        route_source = ?selection.route_source(),
+        interface_name = interface.as_ref().map(|value| value.name()),
+        interface_index = interface.as_ref().map(|value| value.index()),
+        "selected DNS physical egress"
+    );
     zero_platform_tokio::TokioSocket::connect_addr_on(addr, interface.as_ref())
         .await
         .map(zero_platform_tokio::TcpRelayStream::from)

--- a/crates/dns/src/backends/doh.rs
+++ b/crates/dns/src/backends/doh.rs
@@ -110,7 +110,15 @@ impl DohDnsResolver {
             self.exchange_with_timeout(addr, query, detour, connector),
         )
         .await
-        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "DoH request timeout"))?
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "DoH request to {addr} timed out after {}ms",
+                    DNS_TIMEOUT.as_millis()
+                ),
+            )
+        })?
     }
 
     async fn exchange_with_timeout(

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -274,6 +274,12 @@ impl Proxy {
             }
         };
         let dns_hijack = prepared_network.dns_hijack;
+        tracing::info!(
+            dns_hijack,
+            route_exclusion_count = prepared_network.route_exclusions.len(),
+            route_exclusions = ?prepared_network.route_exclusions,
+            "prepared TUN DNS physical-route exclusions"
+        );
 
         let device = zero_tun::create(name).map_err(EngineError::Io)?;
         let address_pairs = interface_addresses

--- a/crates/proxy/src/runtime/handle/command/diagnostics.rs
+++ b/crates/proxy/src/runtime/handle/command/diagnostics.rs
@@ -1,6 +1,4 @@
-use crate::runtime::outbound_probe::{
-    OutboundProbeRequest, OutboundProbeRuntime, OUTBOUND_PROBE_TIMEOUT_MS,
-};
+use crate::runtime::outbound_probe::{OutboundProbeRequest, OutboundProbeRuntime};
 use crate::runtime::route_runtime::route_trace_for_session;
 use tracing::info;
 use zero_core::{Network, ProtocolType, Session};
@@ -270,6 +268,8 @@ pub(super) fn execute_diagnostics_probe_outbound(
         .latency_test_url_or(cmd.url.as_deref())
         .to_owned();
     let services = proxy.tcp_runtime_services_for_snapshot(snapshot);
+    let probe_runtime = OutboundProbeRuntime::new(services);
+    let timeout_ms = probe_runtime.probe_timeout_ms();
 
     with_current_runtime(
         "no tokio runtime available for probe_outbound command",
@@ -288,16 +288,12 @@ pub(super) fn execute_diagnostics_probe_outbound(
                     target_tag,
                     url,
                     started_at_unix_ms,
-                    timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                    timeout_ms,
                     "outbound diagnostic probe started"
                 );
                 let request = OutboundProbeRequest::parse(&url);
                 let result = match request {
-                    Ok(request) => {
-                        OutboundProbeRuntime::new(services)
-                            .probe_target_tag(&target_tag, &request)
-                            .await
-                    }
+                    Ok(request) => probe_runtime.probe_target_tag(&target_tag, &request).await,
                     Err(error) => Err(error),
                 };
                 let completed_at_unix_ms = unix_timestamp_ms();
@@ -317,7 +313,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                             started_at_unix_ms,
                             completed_at_unix_ms,
                             duration_ms,
-                            timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                            timeout_ms,
                             terminal_status = "succeeded",
                             reachable = true,
                             affects_policy_selection = false,
@@ -342,7 +338,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                                 "affects_outbound_health": false,
                                 "bypasses_outbound_health_quarantine": true,
                                 "latency_ms": latency_ms,
-                                "timeout_ms": OUTBOUND_PROBE_TIMEOUT_MS,
+                                "timeout_ms": timeout_ms,
                                 "started_at_unix_ms": started_at_unix_ms,
                                 "completed_at_unix_ms": completed_at_unix_ms,
                                 "duration_ms": duration_ms,
@@ -363,7 +359,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                             started_at_unix_ms,
                             completed_at_unix_ms,
                             duration_ms,
-                            timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                            timeout_ms,
                             terminal_status = "failed",
                             reachable = false,
                             affects_policy_selection = false,
@@ -389,7 +385,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                                 "affects_outbound_health": false,
                                 "bypasses_outbound_health_quarantine": true,
                                 "latency_ms": null,
-                                "timeout_ms": OUTBOUND_PROBE_TIMEOUT_MS,
+                                "timeout_ms": timeout_ms,
                                 "error_code": error.code(),
                                 "error": error.message(),
                                 "started_at_unix_ms": started_at_unix_ms,

--- a/crates/proxy/src/runtime/outbound_probe.rs
+++ b/crates/proxy/src/runtime/outbound_probe.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -17,7 +17,8 @@ mod model;
 pub(crate) use model::{OutboundProbeError, OutboundProbeRequest};
 
 pub(crate) const MAX_CONCURRENT_OUTBOUND_PROBES: usize = 8;
-pub(crate) const OUTBOUND_PROBE_TIMEOUT_MS: u64 = 5_000;
+const OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS: u64 = 5_000;
+const OUTBOUND_PROBE_MAX_TIMEOUT_MS: u64 = 60_000;
 
 type SharedProbeFuture = Shared<BoxFuture<'static, Result<u64, OutboundProbeError>>>;
 
@@ -50,6 +51,11 @@ impl OutboundProbeRuntime {
             .lock()
             .expect("shared outbound probe lock poisoned")
             .clear();
+    }
+
+    /// Total probe deadline, including the complete node-DNS fallback chain.
+    pub(crate) fn probe_timeout_ms(&self) -> u64 {
+        probe_timeout_ms_for_dns(self.services.snapshot().config().runtime.dns.as_ref())
     }
 
     pub(crate) async fn probe_target_tag(
@@ -162,7 +168,8 @@ impl OutboundProbeRuntime {
             ));
         }
 
-        match timeout(Duration::from_millis(OUTBOUND_PROBE_TIMEOUT_MS), async {
+        let timeout_ms = self.probe_timeout_ms();
+        match timeout(Duration::from_millis(timeout_ms), async {
             let started_at = Instant::now();
             let session = Session::new(
                 0,
@@ -205,7 +212,7 @@ impl OutboundProbeRuntime {
             Ok(result) => result.map_err(OutboundProbeError::from_engine),
             Err(_) => Err(OutboundProbeError::new(
                 "probe_timeout",
-                format!("outbound latency probe timed out after {OUTBOUND_PROBE_TIMEOUT_MS} ms"),
+                format!("outbound latency probe timed out after {timeout_ms} ms"),
             )),
         }
     }
@@ -224,6 +231,34 @@ impl OutboundProbeRuntime {
             .engine()
             .target_tag_in_snapshot(self.services.snapshot(), target_id)
     }
+}
+
+fn probe_timeout_ms_for_dns(dns: Option<&zero_config::DnsConfig>) -> u64 {
+    let Some(dns) = dns else {
+        return OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS;
+    };
+    let policy = &dns.policy;
+    let mut tags = Vec::new();
+    if let Some(server) = policy.node_server.as_deref() {
+        tags.push(server);
+        tags.extend(policy.node_fallback_servers.iter().map(String::as_str));
+    } else {
+        tags.push(dns.default_server.as_str());
+        tags.extend(policy.fallback_servers.iter().map(String::as_str));
+    }
+    let mut seen = HashSet::new();
+    let dns_budget = tags
+        .into_iter()
+        .filter(|tag| seen.insert(*tag))
+        .fold(0_u64, |total, tag| {
+            total.saturating_add(policy.timeout_ms_for(tag))
+        });
+    OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS
+        .saturating_add(dns_budget)
+        .clamp(
+            OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+            OUTBOUND_PROBE_MAX_TIMEOUT_MS,
+        )
 }
 
 fn global_probe_limiter() -> Arc<Semaphore> {

--- a/crates/proxy/src/runtime/outbound_probe/tests.rs
+++ b/crates/proxy/src/runtime/outbound_probe/tests.rs
@@ -1,4 +1,5 @@
 use super::ProbeKey;
+use super::{probe_timeout_ms_for_dns, OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS};
 use crate::runtime::tcp_dispatch::TcpDispatchIntent;
 
 #[test]
@@ -14,5 +15,57 @@ fn shared_probe_identity_separates_policy_and_diagnostic_intents() {
         key(TcpDispatchIntent::PolicyProbe),
         key(TcpDispatchIntent::DiagnosticProbe),
         "a diagnostic probe must never join a policy probe that can be rejected by traffic quarantine"
+    );
+}
+
+#[test]
+fn probe_deadline_covers_the_complete_node_dns_fallback_chain() {
+    let dns = serde_json::from_value::<zero_config::DnsConfig>(serde_json::json!({
+        "servers": {
+            "cloudflare-bootstrap": {
+                "type": "doh",
+                "host": "cloudflare-dns.com",
+                "bootstrap": ["1.1.1.1"]
+            },
+            "google-bootstrap": {
+                "type": "doh",
+                "host": "dns.google",
+                "bootstrap": ["8.8.8.8"]
+            },
+            "system": { "type": "system" }
+        },
+        "default_server": "cloudflare-bootstrap",
+        "policy": {
+            "timeout_ms": 5000,
+            "node_server": "cloudflare-bootstrap",
+            "node_fallback_servers": ["google-bootstrap", "system"]
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(probe_timeout_ms_for_dns(Some(&dns)), 20_000);
+}
+
+#[test]
+fn probe_deadline_uses_per_server_timeouts_and_deduplicates_fallbacks() {
+    let dns = serde_json::from_value::<zero_config::DnsConfig>(serde_json::json!({
+        "servers": {
+            "system": { "type": "system" },
+            "backup": { "type": "system" }
+        },
+        "default_server": "system",
+        "policy": {
+            "timeout_ms": 5000,
+            "server_timeout_ms": { "system": 1000, "backup": 2000 },
+            "node_server": "system",
+            "node_fallback_servers": ["system", "backup"]
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(probe_timeout_ms_for_dns(Some(&dns)), 8_000);
+    assert_eq!(
+        probe_timeout_ms_for_dns(None),
+        OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS
     );
 }

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -22,6 +22,9 @@ use super::protocol::{ipc_api_error, ipc_error, ipc_ok, serialize_frame, IpcRequ
 
 type CommandParseError = Box<ApiResponse<()>>;
 
+#[cfg(test)]
+mod tests;
+
 /// Parse a string method name + JSON params into a typed `CommandRequest`.
 ///
 /// Uses the same serde `#[serde(tag = "method", content = "params")]` path as
@@ -132,37 +135,25 @@ where
                         write_ipc_response(&mut *writer.lock().await, &resp).await?;
                     }
                     Ok(cmd) => {
-                        let command_handle = handle.clone();
-                        let acknowledged_apply = matches!(
-                            cmd,
-                            CommandRequest::ConfigApply(_) | CommandRequest::ConfigApplyRuntime(_)
-                        );
-                        let result = if acknowledged_apply {
-                            command_handle.execute_acknowledged(cmd).await
+                        if command_can_run_concurrently(&cmd) {
+                            let command_handle = handle.clone();
+                            let response_writer = writer.clone();
+                            tokio::spawn(async move {
+                                let result = execute_ipc_command(command_handle, cmd).await;
+                                if let Err(error) =
+                                    write_command_result(response_writer, id, result).await
+                                {
+                                    if !is_transient_disconnect(&error) {
+                                        tracing::warn!(
+                                            %error,
+                                            "failed to write concurrent IPC command response"
+                                        );
+                                    }
+                                }
+                            });
                         } else {
-                            // Some synchronous commands bridge to blocking runtime
-                            // services. Keep those off the reactor.
-                            match tokio::task::spawn_blocking(move || command_handle.execute(cmd))
-                                .await
-                            {
-                                Ok(result) => result,
-                                Err(error) => Err(zero_api::ApiError::new(
-                                    zero_api::ApiErrorCode::Internal,
-                                    format!("IPC command task failed: {error}"),
-                                )),
-                            }
-                        };
-                        match result {
-                            Ok(cmd_resp) => {
-                                let value =
-                                    serde_json::to_value(cmd_resp).map_err(io::Error::other)?;
-                                let resp = ipc_ok(id, value);
-                                write_ipc_response(&mut *writer.lock().await, &resp).await?;
-                            }
-                            Err(error) => {
-                                let resp = ipc_api_error(id, &error);
-                                write_ipc_response(&mut *writer.lock().await, &resp).await?;
-                            }
+                            let result = execute_ipc_command(handle.clone(), cmd).await;
+                            write_command_result(writer.clone(), id, result).await?;
                         }
                     }
                     Err(error) => {
@@ -288,6 +279,50 @@ where
     }
 
     Ok(())
+}
+
+fn command_can_run_concurrently(command: &CommandRequest) -> bool {
+    matches!(command, CommandRequest::DiagnosticsProbeOutbound(_))
+}
+
+async fn execute_ipc_command(
+    command_handle: ProxyHandle,
+    command: CommandRequest,
+) -> zero_api::ApiResult<zero_api::CommandResponse> {
+    if matches!(
+        command,
+        CommandRequest::ConfigApply(_) | CommandRequest::ConfigApplyRuntime(_)
+    ) {
+        return command_handle.execute_acknowledged(command).await;
+    }
+    match tokio::task::spawn_blocking(move || command_handle.execute(command)).await {
+        Ok(result) => result,
+        Err(error) => Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::Internal,
+            format!("IPC command task failed: {error}"),
+        )),
+    }
+}
+
+async fn write_command_result<W>(
+    writer: Arc<TokioMutex<BufWriter<W>>>,
+    id: Option<serde_json::Value>,
+    result: zero_api::ApiResult<zero_api::CommandResponse>,
+) -> io::Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    match result {
+        Ok(command_response) => {
+            let value = serde_json::to_value(command_response).map_err(io::Error::other)?;
+            let response = ipc_ok(id, value);
+            write_ipc_response(&mut *writer.lock().await, &response).await
+        }
+        Err(error) => {
+            let response = ipc_api_error(id, &error);
+            write_ipc_response(&mut *writer.lock().await, &response).await
+        }
+    }
 }
 
 /// Write a serialized IPC response frame to the transport.

--- a/src/ipc/connection/tests.rs
+++ b/src/ipc/connection/tests.rs
@@ -1,0 +1,12 @@
+use super::command_can_run_concurrently;
+use zero_api::{CommandRequest, DiagnosticsProbeOutboundCommand, ModeSetCommand};
+
+#[test]
+fn outbound_diagnostics_are_the_only_reordered_ipc_commands() {
+    assert!(command_can_run_concurrently(
+        &CommandRequest::DiagnosticsProbeOutbound(DiagnosticsProbeOutboundCommand::default())
+    ));
+    assert!(!command_can_run_concurrently(&CommandRequest::ModeSet(
+        ModeSetCommand::default()
+    )));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,22 @@ async fn main() {
     let args: Vec<String> = env::args().collect();
     let config_path = cli::config_path_from_args(&args);
     init_tracing_from_config(config_path.unwrap_or(""));
+    install_panic_hook();
 
     if let Err(error) = try_main().await {
+        tracing::error!(error = %error, "zero process terminating with fatal error");
         error_report::print_error(error.as_ref());
         process::exit(1);
     }
+}
+
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic| {
+        tracing::error!(panic = %panic, "zero process panicked");
+        eprintln!("fatal panic: {panic}");
+        previous(panic);
+    }));
 }
 
 async fn try_main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
## Summary

- size outbound diagnostic probe deadlines from the complete node-DNS fallback budget plus transport time
- allow only `diagnostics.probe_outbound` IPC commands to execute concurrently so an eight-node batch is not serialized behind one connection
- preserve ordered execution for configuration and control commands
- expose the selected physical DNS egress and prepared TUN DNS route exclusions in structured logs
- include DoH endpoint/deadline context in timeout errors
- emit structured fatal and panic diagnostics before process exit

## Validation

Per the project boundary, no local kernel build, TUN, DNS, browser, or network validation was run on this Windows workstation.

- `cargo fmt --all --check`
- `git diff --check`
- focused source-level regressions cover the complete DNS deadline and IPC concurrency classification
- GitHub-hosted CI is the compile/unit/static gate for this commit
- dedicated Windows test-machine TUN/Fake-IP acceptance remains user-owned

Refs #33