### PR TITLE
fix(tun): stabilize DNS bootstrap and node probes

### DIFF
--- a/crates/dns/src/backends.rs
+++ b/crates/dns/src/backends.rs
@@ -271,7 +271,20 @@ async fn connect_tcp(
         return connector.connect(outbound.to_owned(), addr).await;
     }
 
-    let interface = egress.try_current_for_peer(addr)?;
+    let selection = egress.select_for_peer(addr);
+    selection.ensure_connectable()?;
+    let interface = selection.interface().cloned();
+    tracing::debug!(
+        peer = %addr,
+        tun_active = selection.tun_active(),
+        egress_generation = selection.generation(),
+        binding_reason = selection.binding_reason().as_str(),
+        route_lookup = selection.route_lookup_status().as_str(),
+        route_source = ?selection.route_source(),
+        interface_name = interface.as_ref().map(|value| value.name()),
+        interface_index = interface.as_ref().map(|value| value.index()),
+        "selected DNS physical egress"
+    );
     zero_platform_tokio::TokioSocket::connect_addr_on(addr, interface.as_ref())
         .await
         .map(zero_platform_tokio::TcpRelayStream::from)

--- a/crates/dns/src/backends/doh.rs
+++ b/crates/dns/src/backends/doh.rs
@@ -110,7 +110,15 @@ impl DohDnsResolver {
             self.exchange_with_timeout(addr, query, detour, connector),
         )
         .await
-        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "DoH request timeout"))?
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "DoH request to {addr} timed out after {}ms",
+                    DNS_TIMEOUT.as_millis()
+                ),
+            )
+        })?
     }
 
     async fn exchange_with_timeout(

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -15,8 +15,18 @@ use zero_config::LogConfig;
 
 // ── public API ────────────────────────────────────────────────────────
 
+/// Keeps non-blocking file writers alive and flushes them when dropped.
+///
+/// Callers must retain this guard for the complete process lifetime. In
+/// particular, drop it explicitly before terminating through
+/// [`std::process::exit`], which does not run destructors itself.
+#[must_use = "dropping the tracing guard immediately stops file log writers"]
+pub struct TracingGuard {
+    _file_guards: Vec<tracing_appender::non_blocking::WorkerGuard>,
+}
+
 /// Initialise tracing.  Must be called exactly once, before any work.
-pub fn init_tracing(config: &LogConfig) {
+pub fn init_tracing(config: &LogConfig) -> TracingGuard {
     let default_level = config.level.as_str();
 
     let filter = EnvFilter::try_from_default_env()
@@ -71,11 +81,12 @@ pub fn init_tracing(config: &LogConfig) {
         layers.push(Box::new(file_layer));
     }
 
-    let _ = LOG_GUARDS.set(guards);
     let _ = tracing_subscriber::registry().with(layers).try_init();
+    TracingGuard {
+        _file_guards: guards,
+    }
 }
 
-static LOG_GUARDS: OnceLock<Vec<tracing_appender::non_blocking::WorkerGuard>> = OnceLock::new();
 type WarningSink = Box<dyn Fn(&str, &str) + Send + Sync>;
 
 /// Callback that receives every `warn` / `error` log line so it can be

--- a/crates/proxy/src/inbound/tun.rs
+++ b/crates/proxy/src/inbound/tun.rs
@@ -274,6 +274,12 @@ impl Proxy {
             }
         };
         let dns_hijack = prepared_network.dns_hijack;
+        tracing::info!(
+            dns_hijack,
+            route_exclusion_count = prepared_network.route_exclusions.len(),
+            route_exclusions = ?prepared_network.route_exclusions,
+            "prepared TUN DNS physical-route exclusions"
+        );
 
         let device = zero_tun::create(name).map_err(EngineError::Io)?;
         let address_pairs = interface_addresses

--- a/crates/proxy/src/runtime/handle/command/diagnostics.rs
+++ b/crates/proxy/src/runtime/handle/command/diagnostics.rs
@@ -1,6 +1,4 @@
-use crate::runtime::outbound_probe::{
-    OutboundProbeRequest, OutboundProbeRuntime, OUTBOUND_PROBE_TIMEOUT_MS,
-};
+use crate::runtime::outbound_probe::{OutboundProbeRequest, OutboundProbeRuntime};
 use crate::runtime::route_runtime::route_trace_for_session;
 use tracing::info;
 use zero_core::{Network, ProtocolType, Session};
@@ -270,6 +268,8 @@ pub(super) fn execute_diagnostics_probe_outbound(
         .latency_test_url_or(cmd.url.as_deref())
         .to_owned();
     let services = proxy.tcp_runtime_services_for_snapshot(snapshot);
+    let probe_runtime = OutboundProbeRuntime::new(services);
+    let timeout_ms = probe_runtime.probe_timeout_ms();
 
     with_current_runtime(
         "no tokio runtime available for probe_outbound command",
@@ -288,16 +288,12 @@ pub(super) fn execute_diagnostics_probe_outbound(
                     target_tag,
                     url,
                     started_at_unix_ms,
-                    timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                    timeout_ms,
                     "outbound diagnostic probe started"
                 );
                 let request = OutboundProbeRequest::parse(&url);
                 let result = match request {
-                    Ok(request) => {
-                        OutboundProbeRuntime::new(services)
-                            .probe_target_tag(&target_tag, &request)
-                            .await
-                    }
+                    Ok(request) => probe_runtime.probe_target_tag(&target_tag, &request).await,
                     Err(error) => Err(error),
                 };
                 let completed_at_unix_ms = unix_timestamp_ms();
@@ -317,7 +313,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                             started_at_unix_ms,
                             completed_at_unix_ms,
                             duration_ms,
-                            timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                            timeout_ms,
                             terminal_status = "succeeded",
                             reachable = true,
                             affects_policy_selection = false,
@@ -342,7 +338,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                                 "affects_outbound_health": false,
                                 "bypasses_outbound_health_quarantine": true,
                                 "latency_ms": latency_ms,
-                                "timeout_ms": OUTBOUND_PROBE_TIMEOUT_MS,
+                                "timeout_ms": timeout_ms,
                                 "started_at_unix_ms": started_at_unix_ms,
                                 "completed_at_unix_ms": completed_at_unix_ms,
                                 "duration_ms": duration_ms,
@@ -363,7 +359,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                             started_at_unix_ms,
                             completed_at_unix_ms,
                             duration_ms,
-                            timeout_ms = OUTBOUND_PROBE_TIMEOUT_MS,
+                            timeout_ms,
                             terminal_status = "failed",
                             reachable = false,
                             affects_policy_selection = false,
@@ -389,7 +385,7 @@ pub(super) fn execute_diagnostics_probe_outbound(
                                 "affects_outbound_health": false,
                                 "bypasses_outbound_health_quarantine": true,
                                 "latency_ms": null,
-                                "timeout_ms": OUTBOUND_PROBE_TIMEOUT_MS,
+                                "timeout_ms": timeout_ms,
                                 "error_code": error.code(),
                                 "error": error.message(),
                                 "started_at_unix_ms": started_at_unix_ms,

--- a/crates/proxy/src/runtime/handle/command/diagnostics.rs
+++ b/crates/proxy/src/runtime/handle/command/diagnostics.rs
@@ -253,151 +253,180 @@ pub(super) fn execute_diagnostics_probe_outbound(
     handle: &ProxyHandle,
     cmd: &zero_api::command::DiagnosticsProbeOutboundCommand,
 ) -> zero_api::ApiResult<zero_api::CommandResponse> {
-    let proxy = handle.proxy.clone();
-    let target_tag = cmd.target_tag.clone();
-    let snapshot = handle.proxy.engine().runtime_snapshot();
-    let core_instance_id = handle.proxy.engine().core_instance_id().to_owned();
-    let config_revision = snapshot.config_revision();
-    let operation_id = handle
-        .proxy
-        .engine()
-        .operation_id(cmd.operation_id.as_deref());
-    let url = snapshot
-        .config()
-        .runtime
-        .latency_test_url_or(cmd.url.as_deref())
-        .to_owned();
-    let services = proxy.tcp_runtime_services_for_snapshot(snapshot);
-    let probe_runtime = OutboundProbeRuntime::new(services);
-    let timeout_ms = probe_runtime.probe_timeout_ms();
-
+    let handle = handle.clone();
+    let cmd = cmd.clone();
     with_current_runtime(
         "no tokio runtime available for probe_outbound command",
-        |rt| {
-            rt.block_on(async move {
-                let started_at_unix_ms = unix_timestamp_ms();
-                let started = std::time::Instant::now();
+        |rt| rt.block_on(handle.execute_diagnostics_probe_outbound_command(cmd)),
+    )
+}
+
+impl ProxyHandle {
+    /// Run an outbound diagnostic without a blocking-task shell so async
+    /// control-plane transports can cancel it when their client disconnects.
+    pub async fn execute_diagnostics_probe_outbound_command(
+        &self,
+        cmd: zero_api::command::DiagnosticsProbeOutboundCommand,
+    ) -> zero_api::ApiResult<zero_api::CommandResponse> {
+        let handle = self;
+        let proxy = handle.proxy.clone();
+        let target_tag = cmd.target_tag.clone();
+        let snapshot = handle.proxy.engine().runtime_snapshot();
+        let core_instance_id = handle.proxy.engine().core_instance_id().to_owned();
+        let config_revision = snapshot.config_revision();
+        let operation_id = handle
+            .proxy
+            .engine()
+            .operation_id(cmd.operation_id.as_deref());
+        let url = snapshot
+            .config()
+            .runtime
+            .latency_test_url_or(cmd.url.as_deref())
+            .to_owned();
+        let services = proxy.tcp_runtime_services_for_snapshot(snapshot);
+        let probe_runtime = OutboundProbeRuntime::new(services);
+        let deadline = probe_runtime.probe_deadline();
+        let timeout_ms = deadline.timeout_ms;
+        let dns_budget_ms = deadline.dns_budget_ms;
+        let transport_budget_ms = deadline.transport_budget_ms;
+        let deadline_capped = deadline.capped;
+
+        let started_at_unix_ms = unix_timestamp_ms();
+        let started = std::time::Instant::now();
+        info!(
+            source = "core",
+            method = "diagnostics.probe_outbound",
+            operation_kind = "diagnostic_outbound",
+            phase = "started",
+            operation_id,
+            core_instance_id,
+            config_revision,
+            target_tag,
+            url,
+            started_at_unix_ms,
+            timeout_ms,
+            dns_budget_ms,
+            transport_budget_ms,
+            deadline_capped,
+            "outbound diagnostic probe started"
+        );
+        let request = OutboundProbeRequest::parse(&url);
+        let result = match request {
+            Ok(request) => probe_runtime.probe_target_tag(&target_tag, &request).await,
+            Err(error) => Err(error),
+        };
+        let completed_at_unix_ms = unix_timestamp_ms();
+        let duration_ms = started.elapsed().as_millis() as u64;
+        match result {
+            Ok(latency_ms) => {
                 info!(
                     source = "core",
                     method = "diagnostics.probe_outbound",
                     operation_kind = "diagnostic_outbound",
-                    phase = "started",
+                    phase = "completed",
                     operation_id,
                     core_instance_id,
                     config_revision,
                     target_tag,
                     url,
                     started_at_unix_ms,
+                    completed_at_unix_ms,
+                    duration_ms,
                     timeout_ms,
-                    "outbound diagnostic probe started"
+                    dns_budget_ms,
+                    transport_budget_ms,
+                    deadline_capped,
+                    terminal_status = "succeeded",
+                    reachable = true,
+                    affects_policy_selection = false,
+                    affects_outbound_health = false,
+                    bypasses_outbound_health_quarantine = true,
+                    latency_ms,
+                    "outbound diagnostic probe completed"
                 );
-                let request = OutboundProbeRequest::parse(&url);
-                let result = match request {
-                    Ok(request) => probe_runtime.probe_target_tag(&target_tag, &request).await,
-                    Err(error) => Err(error),
-                };
-                let completed_at_unix_ms = unix_timestamp_ms();
-                let duration_ms = started.elapsed().as_millis() as u64;
-                match result {
-                    Ok(latency_ms) => {
-                        info!(
-                            source = "core",
-                            method = "diagnostics.probe_outbound",
-                            operation_kind = "diagnostic_outbound",
-                            phase = "completed",
-                            operation_id,
-                            core_instance_id,
-                            config_revision,
-                            target_tag,
-                            url,
-                            started_at_unix_ms,
-                            completed_at_unix_ms,
-                            duration_ms,
-                            timeout_ms,
-                            terminal_status = "succeeded",
-                            reachable = true,
-                            affects_policy_selection = false,
-                            affects_outbound_health = false,
-                            bypasses_outbound_health_quarantine = true,
-                            latency_ms,
-                            "outbound diagnostic probe completed"
-                        );
-                        Ok(zero_api::CommandResponse {
-                            accepted: true,
-                            result: Some(serde_json::json!({
-                                "operation_id": operation_id,
-                                "core_instance_id": core_instance_id,
-                                "config_revision": config_revision,
-                                "operation_kind": "diagnostic_outbound",
-                                "target_tag": target_tag,
-                                "url": url,
-                                "via": "through_proxy",
-                                "reachable": true,
-                                "terminal_status": "succeeded",
-                                "affects_policy_selection": false,
-                                "affects_outbound_health": false,
-                                "bypasses_outbound_health_quarantine": true,
-                                "latency_ms": latency_ms,
-                                "timeout_ms": timeout_ms,
-                                "started_at_unix_ms": started_at_unix_ms,
-                                "completed_at_unix_ms": completed_at_unix_ms,
-                                "duration_ms": duration_ms,
-                            })),
-                        })
-                    }
-                    Err(error) => {
-                        info!(
-                            source = "core",
-                            method = "diagnostics.probe_outbound",
-                            operation_kind = "diagnostic_outbound",
-                            phase = "completed",
-                            operation_id,
-                            core_instance_id,
-                            config_revision,
-                            target_tag,
-                            url,
-                            started_at_unix_ms,
-                            completed_at_unix_ms,
-                            duration_ms,
-                            timeout_ms,
-                            terminal_status = "failed",
-                            reachable = false,
-                            affects_policy_selection = false,
-                            affects_outbound_health = false,
-                            bypasses_outbound_health_quarantine = true,
-                            error_code = error.code(),
-                            error = error.message(),
-                            "outbound diagnostic probe completed"
-                        );
-                        Ok(zero_api::CommandResponse {
-                            accepted: true,
-                            result: Some(serde_json::json!({
-                                "operation_id": operation_id,
-                                "core_instance_id": core_instance_id,
-                                "config_revision": config_revision,
-                                "operation_kind": "diagnostic_outbound",
-                                "target_tag": target_tag,
-                                "url": url,
-                                "via": "through_proxy",
-                                "reachable": false,
-                                "terminal_status": "failed",
-                                "affects_policy_selection": false,
-                                "affects_outbound_health": false,
-                                "bypasses_outbound_health_quarantine": true,
-                                "latency_ms": null,
-                                "timeout_ms": timeout_ms,
-                                "error_code": error.code(),
-                                "error": error.message(),
-                                "started_at_unix_ms": started_at_unix_ms,
-                                "completed_at_unix_ms": completed_at_unix_ms,
-                                "duration_ms": duration_ms,
-                            })),
-                        })
-                    }
-                }
-            })
-        },
-    )
+                Ok(zero_api::CommandResponse {
+                    accepted: true,
+                    result: Some(serde_json::json!({
+                        "operation_id": operation_id,
+                        "core_instance_id": core_instance_id,
+                        "config_revision": config_revision,
+                        "operation_kind": "diagnostic_outbound",
+                        "target_tag": target_tag,
+                        "url": url,
+                        "via": "through_proxy",
+                        "reachable": true,
+                        "terminal_status": "succeeded",
+                        "affects_policy_selection": false,
+                        "affects_outbound_health": false,
+                        "bypasses_outbound_health_quarantine": true,
+                        "latency_ms": latency_ms,
+                        "timeout_ms": timeout_ms,
+                        "dns_budget_ms": dns_budget_ms,
+                        "transport_budget_ms": transport_budget_ms,
+                        "deadline_capped": deadline_capped,
+                        "started_at_unix_ms": started_at_unix_ms,
+                        "completed_at_unix_ms": completed_at_unix_ms,
+                        "duration_ms": duration_ms,
+                    })),
+                })
+            }
+            Err(error) => {
+                info!(
+                    source = "core",
+                    method = "diagnostics.probe_outbound",
+                    operation_kind = "diagnostic_outbound",
+                    phase = "completed",
+                    operation_id,
+                    core_instance_id,
+                    config_revision,
+                    target_tag,
+                    url,
+                    started_at_unix_ms,
+                    completed_at_unix_ms,
+                    duration_ms,
+                    timeout_ms,
+                    dns_budget_ms,
+                    transport_budget_ms,
+                    deadline_capped,
+                    terminal_status = "failed",
+                    reachable = false,
+                    affects_policy_selection = false,
+                    affects_outbound_health = false,
+                    bypasses_outbound_health_quarantine = true,
+                    error_code = error.code(),
+                    error = error.message(),
+                    "outbound diagnostic probe completed"
+                );
+                Ok(zero_api::CommandResponse {
+                    accepted: true,
+                    result: Some(serde_json::json!({
+                        "operation_id": operation_id,
+                        "core_instance_id": core_instance_id,
+                        "config_revision": config_revision,
+                        "operation_kind": "diagnostic_outbound",
+                        "target_tag": target_tag,
+                        "url": url,
+                        "via": "through_proxy",
+                        "reachable": false,
+                        "terminal_status": "failed",
+                        "affects_policy_selection": false,
+                        "affects_outbound_health": false,
+                        "bypasses_outbound_health_quarantine": true,
+                        "latency_ms": null,
+                        "timeout_ms": timeout_ms,
+                        "dns_budget_ms": dns_budget_ms,
+                        "transport_budget_ms": transport_budget_ms,
+                        "deadline_capped": deadline_capped,
+                        "error_code": error.code(),
+                        "error": error.message(),
+                        "started_at_unix_ms": started_at_unix_ms,
+                        "completed_at_unix_ms": completed_at_unix_ms,
+                        "duration_ms": duration_ms,
+                    })),
+                })
+            }
+        }
+    }
 }
 
 fn unix_timestamp_ms() -> u64 {

--- a/crates/proxy/src/runtime/outbound_probe.rs
+++ b/crates/proxy/src/runtime/outbound_probe.rs
@@ -22,6 +22,42 @@ const OUTBOUND_PROBE_MAX_TIMEOUT_MS: u64 = 60_000;
 
 type SharedProbeFuture = Shared<BoxFuture<'static, Result<u64, OutboundProbeError>>>;
 
+struct SharedProbeEntry {
+    future: SharedProbeFuture,
+    waiters: usize,
+}
+
+struct SharedProbeWaiter {
+    probes: Arc<Mutex<HashMap<ProbeKey, SharedProbeEntry>>>,
+    key: ProbeKey,
+    future: SharedProbeFuture,
+}
+
+impl Drop for SharedProbeWaiter {
+    fn drop(&mut self) {
+        let mut probes = self
+            .probes
+            .lock()
+            .expect("shared outbound probe lock poisoned");
+        let Some(entry) = probes.get_mut(&self.key) else {
+            return;
+        };
+        if entry.waiters <= 1 {
+            probes.remove(&self.key);
+        } else {
+            entry.waiters -= 1;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct OutboundProbeDeadline {
+    pub(crate) dns_budget_ms: u64,
+    pub(crate) transport_budget_ms: u64,
+    pub(crate) timeout_ms: u64,
+    pub(crate) capped: bool,
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ProbeKey {
     config_identity: usize,
@@ -34,7 +70,7 @@ struct ProbeKey {
 pub(crate) struct OutboundProbeRuntime {
     services: TcpRuntimeServices,
     limiter: Arc<Semaphore>,
-    shared_probes: Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>,
+    shared_probes: Arc<Mutex<HashMap<ProbeKey, SharedProbeEntry>>>,
 }
 
 impl OutboundProbeRuntime {
@@ -53,9 +89,9 @@ impl OutboundProbeRuntime {
             .clear();
     }
 
-    /// Total probe deadline, including the complete node-DNS fallback chain.
-    pub(crate) fn probe_timeout_ms(&self) -> u64 {
-        probe_timeout_ms_for_dns(self.services.snapshot().config().runtime.dns.as_ref())
+    /// Probe deadline budget, including node-DNS fallbacks and its hard cap.
+    pub(crate) fn probe_deadline(&self) -> OutboundProbeDeadline {
+        probe_deadline_for_dns(self.services.snapshot().config().runtime.dns.as_ref())
     }
 
     pub(crate) async fn probe_target_tag(
@@ -113,13 +149,14 @@ impl OutboundProbeRuntime {
             url: request.url.clone(),
             intent,
         };
-        let shared = {
+        let waiter = {
             let mut probes = self
                 .shared_probes
                 .lock()
                 .expect("shared outbound probe lock poisoned");
-            if let Some(existing) = probes.get(&key) {
-                existing.clone()
+            let future = if let Some(existing) = probes.get_mut(&key) {
+                existing.waiters += 1;
+                existing.future.clone()
             } else {
                 let runtime = self.clone();
                 let request = request.clone();
@@ -142,16 +179,24 @@ impl OutboundProbeRuntime {
                 }
                 .boxed()
                 .shared();
-                probes.insert(key.clone(), future.clone());
+                probes.insert(
+                    key.clone(),
+                    SharedProbeEntry {
+                        future: future.clone(),
+                        waiters: 1,
+                    },
+                );
                 future
+            };
+            SharedProbeWaiter {
+                probes: self.shared_probes.clone(),
+                key,
+                future,
             }
         };
 
-        let result = shared.await;
-        self.shared_probes
-            .lock()
-            .expect("shared outbound probe lock poisoned")
-            .remove(&key);
+        let result = waiter.future.clone().await;
+        drop(waiter);
         result
     }
 
@@ -168,7 +213,7 @@ impl OutboundProbeRuntime {
             ));
         }
 
-        let timeout_ms = self.probe_timeout_ms();
+        let timeout_ms = self.probe_deadline().timeout_ms;
         match timeout(Duration::from_millis(timeout_ms), async {
             let started_at = Instant::now();
             let session = Session::new(
@@ -233,32 +278,35 @@ impl OutboundProbeRuntime {
     }
 }
 
-fn probe_timeout_ms_for_dns(dns: Option<&zero_config::DnsConfig>) -> u64 {
-    let Some(dns) = dns else {
-        return OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS;
-    };
-    let policy = &dns.policy;
-    let mut tags = Vec::new();
-    if let Some(server) = policy.node_server.as_deref() {
-        tags.push(server);
-        tags.extend(policy.node_fallback_servers.iter().map(String::as_str));
-    } else {
-        tags.push(dns.default_server.as_str());
-        tags.extend(policy.fallback_servers.iter().map(String::as_str));
+fn probe_deadline_for_dns(dns: Option<&zero_config::DnsConfig>) -> OutboundProbeDeadline {
+    let dns_budget_ms = dns.map_or(0, |dns| {
+        let policy = &dns.policy;
+        let mut tags = Vec::new();
+        if let Some(server) = policy.node_server.as_deref() {
+            tags.push(server);
+            tags.extend(policy.node_fallback_servers.iter().map(String::as_str));
+        } else {
+            tags.push(dns.default_server.as_str());
+            tags.extend(policy.fallback_servers.iter().map(String::as_str));
+        }
+        let mut seen = HashSet::new();
+        tags.into_iter()
+            .filter(|tag| seen.insert(*tag))
+            .fold(0_u64, |total, tag| {
+                total.saturating_add(policy.timeout_ms_for(tag))
+            })
+    });
+    let requested_timeout_ms = OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS.saturating_add(dns_budget_ms);
+    let timeout_ms = requested_timeout_ms.clamp(
+        OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+        OUTBOUND_PROBE_MAX_TIMEOUT_MS,
+    );
+    OutboundProbeDeadline {
+        dns_budget_ms,
+        transport_budget_ms: OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+        timeout_ms,
+        capped: timeout_ms < requested_timeout_ms,
     }
-    let mut seen = HashSet::new();
-    let dns_budget = tags
-        .into_iter()
-        .filter(|tag| seen.insert(*tag))
-        .fold(0_u64, |total, tag| {
-            total.saturating_add(policy.timeout_ms_for(tag))
-        });
-    OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS
-        .saturating_add(dns_budget)
-        .clamp(
-            OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
-            OUTBOUND_PROBE_MAX_TIMEOUT_MS,
-        )
 }
 
 fn global_probe_limiter() -> Arc<Semaphore> {
@@ -268,8 +316,8 @@ fn global_probe_limiter() -> Arc<Semaphore> {
         .clone()
 }
 
-fn global_shared_probes() -> Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>> {
-    static PROBES: OnceLock<Arc<Mutex<HashMap<ProbeKey, SharedProbeFuture>>>> = OnceLock::new();
+fn global_shared_probes() -> Arc<Mutex<HashMap<ProbeKey, SharedProbeEntry>>> {
+    static PROBES: OnceLock<Arc<Mutex<HashMap<ProbeKey, SharedProbeEntry>>>> = OnceLock::new();
     PROBES
         .get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
         .clone()

--- a/crates/proxy/src/runtime/outbound_probe.rs
+++ b/crates/proxy/src/runtime/outbound_probe.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -17,7 +17,8 @@ mod model;
 pub(crate) use model::{OutboundProbeError, OutboundProbeRequest};
 
 pub(crate) const MAX_CONCURRENT_OUTBOUND_PROBES: usize = 8;
-pub(crate) const OUTBOUND_PROBE_TIMEOUT_MS: u64 = 5_000;
+const OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS: u64 = 5_000;
+const OUTBOUND_PROBE_MAX_TIMEOUT_MS: u64 = 60_000;
 
 type SharedProbeFuture = Shared<BoxFuture<'static, Result<u64, OutboundProbeError>>>;
 
@@ -50,6 +51,11 @@ impl OutboundProbeRuntime {
             .lock()
             .expect("shared outbound probe lock poisoned")
             .clear();
+    }
+
+    /// Total probe deadline, including the complete node-DNS fallback chain.
+    pub(crate) fn probe_timeout_ms(&self) -> u64 {
+        probe_timeout_ms_for_dns(self.services.snapshot().config().runtime.dns.as_ref())
     }
 
     pub(crate) async fn probe_target_tag(
@@ -162,7 +168,8 @@ impl OutboundProbeRuntime {
             ));
         }
 
-        match timeout(Duration::from_millis(OUTBOUND_PROBE_TIMEOUT_MS), async {
+        let timeout_ms = self.probe_timeout_ms();
+        match timeout(Duration::from_millis(timeout_ms), async {
             let started_at = Instant::now();
             let session = Session::new(
                 0,
@@ -205,7 +212,7 @@ impl OutboundProbeRuntime {
             Ok(result) => result.map_err(OutboundProbeError::from_engine),
             Err(_) => Err(OutboundProbeError::new(
                 "probe_timeout",
-                format!("outbound latency probe timed out after {OUTBOUND_PROBE_TIMEOUT_MS} ms"),
+                format!("outbound latency probe timed out after {timeout_ms} ms"),
             )),
         }
     }
@@ -224,6 +231,34 @@ impl OutboundProbeRuntime {
             .engine()
             .target_tag_in_snapshot(self.services.snapshot(), target_id)
     }
+}
+
+fn probe_timeout_ms_for_dns(dns: Option<&zero_config::DnsConfig>) -> u64 {
+    let Some(dns) = dns else {
+        return OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS;
+    };
+    let policy = &dns.policy;
+    let mut tags = Vec::new();
+    if let Some(server) = policy.node_server.as_deref() {
+        tags.push(server);
+        tags.extend(policy.node_fallback_servers.iter().map(String::as_str));
+    } else {
+        tags.push(dns.default_server.as_str());
+        tags.extend(policy.fallback_servers.iter().map(String::as_str));
+    }
+    let mut seen = HashSet::new();
+    let dns_budget = tags
+        .into_iter()
+        .filter(|tag| seen.insert(*tag))
+        .fold(0_u64, |total, tag| {
+            total.saturating_add(policy.timeout_ms_for(tag))
+        });
+    OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS
+        .saturating_add(dns_budget)
+        .clamp(
+            OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+            OUTBOUND_PROBE_MAX_TIMEOUT_MS,
+        )
 }
 
 fn global_probe_limiter() -> Arc<Semaphore> {

--- a/crates/proxy/src/runtime/outbound_probe/tests.rs
+++ b/crates/proxy/src/runtime/outbound_probe/tests.rs
@@ -1,6 +1,11 @@
-use super::ProbeKey;
-use super::{probe_timeout_ms_for_dns, OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS};
+use super::{
+    probe_deadline_for_dns, OutboundProbeDeadline, OutboundProbeError, ProbeKey, SharedProbeEntry,
+    SharedProbeWaiter, OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+};
 use crate::runtime::tcp_dispatch::TcpDispatchIntent;
+use futures_util::FutureExt;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn shared_probe_identity_separates_policy_and_diagnostic_intents() {
@@ -16,6 +21,32 @@ fn shared_probe_identity_separates_policy_and_diagnostic_intents() {
         key(TcpDispatchIntent::DiagnosticProbe),
         "a diagnostic probe must never join a policy probe that can be rejected by traffic quarantine"
     );
+}
+
+#[test]
+fn dropping_the_last_shared_probe_waiter_removes_the_pending_entry() {
+    let key = ProbeKey {
+        config_identity: 7,
+        target_tag: "node-a".to_owned(),
+        url: "https://example.com/generate_204".to_owned(),
+        intent: TcpDispatchIntent::DiagnosticProbe,
+    };
+    let future = async { Ok::<u64, OutboundProbeError>(1) }.boxed().shared();
+    let probes = Arc::new(Mutex::new(HashMap::from([(
+        key.clone(),
+        SharedProbeEntry {
+            future: future.clone(),
+            waiters: 1,
+        },
+    )])));
+
+    drop(SharedProbeWaiter {
+        probes: probes.clone(),
+        key,
+        future,
+    });
+
+    assert!(probes.lock().unwrap().is_empty());
 }
 
 #[test]
@@ -43,7 +74,15 @@ fn probe_deadline_covers_the_complete_node_dns_fallback_chain() {
     }))
     .unwrap();
 
-    assert_eq!(probe_timeout_ms_for_dns(Some(&dns)), 20_000);
+    assert_eq!(
+        probe_deadline_for_dns(Some(&dns)),
+        OutboundProbeDeadline {
+            dns_budget_ms: 15_000,
+            transport_budget_ms: 5_000,
+            timeout_ms: 20_000,
+            capped: false,
+        }
+    );
 }
 
 #[test]
@@ -63,9 +102,47 @@ fn probe_deadline_uses_per_server_timeouts_and_deduplicates_fallbacks() {
     }))
     .unwrap();
 
-    assert_eq!(probe_timeout_ms_for_dns(Some(&dns)), 8_000);
     assert_eq!(
-        probe_timeout_ms_for_dns(None),
-        OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS
+        probe_deadline_for_dns(Some(&dns)),
+        OutboundProbeDeadline {
+            dns_budget_ms: 3_000,
+            transport_budget_ms: 5_000,
+            timeout_ms: 8_000,
+            capped: false,
+        }
+    );
+    assert_eq!(
+        probe_deadline_for_dns(None),
+        OutboundProbeDeadline {
+            dns_budget_ms: 0,
+            transport_budget_ms: OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+            timeout_ms: OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS,
+            capped: false,
+        }
+    );
+}
+
+#[test]
+fn probe_deadline_reports_when_the_dns_chain_exceeds_the_hard_cap() {
+    let dns = serde_json::from_value::<zero_config::DnsConfig>(serde_json::json!({
+        "servers": {
+            "system": { "type": "system" }
+        },
+        "default_server": "system",
+        "policy": {
+            "timeout_ms": 120000,
+            "node_server": "system"
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(
+        probe_deadline_for_dns(Some(&dns)),
+        OutboundProbeDeadline {
+            dns_budget_ms: 120_000,
+            transport_budget_ms: 5_000,
+            timeout_ms: 60_000,
+            capped: true,
+        }
     );
 }

--- a/crates/proxy/src/runtime/outbound_probe/tests.rs
+++ b/crates/proxy/src/runtime/outbound_probe/tests.rs
@@ -1,4 +1,5 @@
 use super::ProbeKey;
+use super::{probe_timeout_ms_for_dns, OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS};
 use crate::runtime::tcp_dispatch::TcpDispatchIntent;
 
 #[test]
@@ -14,5 +15,57 @@ fn shared_probe_identity_separates_policy_and_diagnostic_intents() {
         key(TcpDispatchIntent::PolicyProbe),
         key(TcpDispatchIntent::DiagnosticProbe),
         "a diagnostic probe must never join a policy probe that can be rejected by traffic quarantine"
+    );
+}
+
+#[test]
+fn probe_deadline_covers_the_complete_node_dns_fallback_chain() {
+    let dns = serde_json::from_value::<zero_config::DnsConfig>(serde_json::json!({
+        "servers": {
+            "cloudflare-bootstrap": {
+                "type": "doh",
+                "host": "cloudflare-dns.com",
+                "bootstrap": ["1.1.1.1"]
+            },
+            "google-bootstrap": {
+                "type": "doh",
+                "host": "dns.google",
+                "bootstrap": ["8.8.8.8"]
+            },
+            "system": { "type": "system" }
+        },
+        "default_server": "cloudflare-bootstrap",
+        "policy": {
+            "timeout_ms": 5000,
+            "node_server": "cloudflare-bootstrap",
+            "node_fallback_servers": ["google-bootstrap", "system"]
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(probe_timeout_ms_for_dns(Some(&dns)), 20_000);
+}
+
+#[test]
+fn probe_deadline_uses_per_server_timeouts_and_deduplicates_fallbacks() {
+    let dns = serde_json::from_value::<zero_config::DnsConfig>(serde_json::json!({
+        "servers": {
+            "system": { "type": "system" },
+            "backup": { "type": "system" }
+        },
+        "default_server": "system",
+        "policy": {
+            "timeout_ms": 5000,
+            "server_timeout_ms": { "system": 1000, "backup": 2000 },
+            "node_server": "system",
+            "node_fallback_servers": ["system", "backup"]
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(probe_timeout_ms_for_dns(Some(&dns)), 8_000);
+    assert_eq!(
+        probe_timeout_ms_for_dns(None),
+        OUTBOUND_PROBE_TRANSPORT_TIMEOUT_MS
     );
 }

--- a/crates/tun/src/route.rs
+++ b/crates/tun/src/route.rs
@@ -210,22 +210,19 @@ pub fn capture_route_prefixes_with_exclusions(
 }
 
 fn subtract_prefix(captured: IpNet, excluded: IpNet) -> Vec<IpNet> {
-    if captured.addr().is_ipv6() != excluded.addr().is_ipv6()
-        || !captured.contains(&excluded.network())
-    {
-        return if excluded.contains(&captured.network()) {
-            Vec::new()
-        } else {
-            vec![captured]
-        };
+    if captured.addr().is_ipv6() != excluded.addr().is_ipv6() {
+        return vec![captured];
     }
-    if excluded.contains(&captured.network()) {
+    if excluded.prefix_len() <= captured.prefix_len() && excluded.contains(&captured.network()) {
         return Vec::new();
     }
-    split_prefix(captured)
-        .into_iter()
-        .flat_map(|child| subtract_prefix(child, excluded))
-        .collect()
+    if captured.prefix_len() < excluded.prefix_len() && captured.contains(&excluded.network()) {
+        return split_prefix(captured)
+            .into_iter()
+            .flat_map(|child| subtract_prefix(child, excluded))
+            .collect();
+    }
+    vec![captured]
 }
 
 fn split_prefix(prefix: IpNet) -> [IpNet; 2] {

--- a/crates/tun/src/route/tests.rs
+++ b/crates/tun/src/route/tests.rs
@@ -47,6 +47,32 @@ fn capture_plan_subtracts_exclusions_for_both_address_families() {
 }
 
 #[test]
+fn default_capture_excludes_only_the_requested_ipv4_cidr() {
+    let routes = capture_route_prefixes_with_exclusions(
+        "10.66.0.1".parse().unwrap(),
+        &[],
+        &["16.0.0.0/8".parse().unwrap()],
+    );
+    assert_eq!(
+        routes,
+        vec![
+            "0.0.0.0/4".parse().unwrap(),
+            "17.0.0.0/8".parse().unwrap(),
+            "18.0.0.0/7".parse().unwrap(),
+            "20.0.0.0/6".parse().unwrap(),
+            "24.0.0.0/5".parse().unwrap(),
+            "32.0.0.0/3".parse().unwrap(),
+            "64.0.0.0/2".parse().unwrap(),
+            "128.0.0.0/1".parse().unwrap(),
+        ]
+    );
+    let excluded: IpAddr = "16.0.0.1".parse().unwrap();
+    let stun_server: IpAddr = "20.93.239.169".parse().unwrap();
+    assert!(!routes.iter().any(|route| route.contains(&excluded)));
+    assert!(routes.iter().any(|route| route.contains(&stun_server)));
+}
+
+#[test]
 fn broader_and_unrelated_exclusions_are_deterministic() {
     assert!(capture_route_prefixes_with_exclusions(
         "10.66.0.1".parse().unwrap(),

--- a/crates/tun/src/route/windows.rs
+++ b/crates/tun/src/route/windows.rs
@@ -465,25 +465,59 @@ fn default_interface(ipv6: bool, tun_index: u32) -> io::Result<WindowsInterface>
         })
         .collect::<Vec<_>>();
     let row_count = routes.len();
-    let route = routes
-        .into_iter()
-        .filter(|route| route.InterfaceIndex != tun_index)
-        .filter(|route| route.DestinationPrefix.PrefixLength == 0)
-        .min_by_key(|route| effective_metric(route, family))
+    let mut rejected = Vec::new();
+    let route = select_usable_default_route(
+        &routes,
+        tun_index,
+        |interface_index| match native_family_unavailable_reason(ipv6, interface_index) {
+            Ok(None) => true,
+            Ok(Some(reason)) => {
+                rejected.push((interface_index, reason.as_str().to_owned()));
+                false
+            }
+            Err(error) => {
+                rejected.push((interface_index, format!("route_lookup_failed: {error}")));
+                false
+            }
+        },
+        |route| effective_metric(route, family),
+    )
         .ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 format!(
-                    "default route not found for family {family}; TUN index {tun_index}; zero-prefix candidates {defaults:?}; rows={}; samples={samples:?}",
+                    "default route not found for family {family}; TUN index {tun_index}; zero-prefix candidates {defaults:?}; rejected unusable candidates {rejected:?}; rows={}; samples={samples:?}",
                     row_count
                 ),
             )
         })?;
+    if !rejected.is_empty() {
+        tracing::debug!(
+            family = if ipv6 { "ipv6" } else { "ipv4" },
+            selected_interface_index = route.InterfaceIndex,
+            rejected_candidates = ?rejected,
+            "skipped unusable Windows default route candidates"
+        );
+    }
     Ok(WindowsInterface {
         interface_alias: interface_alias(&route.InterfaceLuid)?,
         interface_index: route.InterfaceIndex,
         next_hop: socket_ip(&route.NextHop)?,
     })
+}
+
+fn select_usable_default_route<'a>(
+    routes: &'a [MIB_IPFORWARD_ROW2],
+    tun_index: u32,
+    mut is_usable: impl FnMut(u32) -> bool,
+    mut metric: impl FnMut(&MIB_IPFORWARD_ROW2) -> u64,
+) -> Option<&'a MIB_IPFORWARD_ROW2> {
+    routes
+        .iter()
+        .filter(|route| route.InterfaceIndex != tun_index)
+        .filter(|route| route.DestinationPrefix.PrefixLength == 0)
+        .filter(|route| is_usable(route.InterfaceIndex))
+        .min_by_key(|route| metric(route))
 }
 
 fn effective_metric(route: &MIB_IPFORWARD_ROW2, family: u16) -> u64 {
@@ -695,3 +729,6 @@ fn win32_result(context: &str, result: u32) -> io::Result<()> {
         )))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/tun/src/route/windows/tests.rs
+++ b/crates/tun/src/route/windows/tests.rs
@@ -1,0 +1,47 @@
+use super::{select_usable_default_route, MIB_IPFORWARD_ROW2};
+
+#[test]
+fn skips_a_disconnected_lower_metric_default_route() {
+    let routes = [default_route(18, 5), default_route(10, 45)];
+
+    let selected = select_usable_default_route(
+        &routes,
+        77,
+        |interface_index| interface_index != 18,
+        |route| u64::from(route.Metric),
+    )
+    .expect("connected higher-metric route should remain eligible");
+
+    assert_eq!(selected.InterfaceIndex, 10);
+}
+
+#[test]
+fn excludes_tun_and_non_default_routes_before_ranking() {
+    let mut non_default = default_route(5, 0);
+    non_default.DestinationPrefix.PrefixLength = 1;
+    let routes = [default_route(77, 0), non_default, default_route(18, 25)];
+
+    let selected =
+        select_usable_default_route(&routes, 77, |_| true, |route| u64::from(route.Metric))
+            .expect("physical default route should remain eligible");
+
+    assert_eq!(selected.InterfaceIndex, 18);
+}
+
+#[test]
+fn returns_none_when_every_physical_default_route_is_unusable() {
+    let routes = [default_route(18, 5), default_route(10, 45)];
+
+    assert!(
+        select_usable_default_route(&routes, 77, |_| false, |route| u64::from(route.Metric),)
+            .is_none()
+    );
+}
+
+fn default_route(interface_index: u32, metric: u32) -> MIB_IPFORWARD_ROW2 {
+    let mut route = MIB_IPFORWARD_ROW2::default();
+    route.InterfaceIndex = interface_index;
+    route.DestinationPrefix.PrefixLength = 0;
+    route.Metric = metric;
+    route
+}

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -4,6 +4,7 @@
 //! command parsing, and utility functions used by both the Unix domain
 //! socket and Windows named pipe IPC servers.
 
+use std::future::Future;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -12,6 +13,7 @@ use std::time::Duration;
 use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::sync::Mutex as TokioMutex;
+use tokio::task::JoinSet;
 use zero_api::{
     ApiResponse, AuthContext, CommandRequest, CommandService, EventFilter, EventSource, Permission,
     QueryService,
@@ -21,6 +23,37 @@ use zero_proxy::ProxyHandle;
 use super::protocol::{ipc_api_error, ipc_error, ipc_ok, serialize_frame, IpcRequest};
 
 type CommandParseError = Box<ApiResponse<()>>;
+const MAX_PENDING_CONCURRENT_IPC_COMMANDS: usize = 32;
+
+struct ConcurrentCommandTasks {
+    tasks: JoinSet<()>,
+}
+
+impl ConcurrentCommandTasks {
+    fn new() -> Self {
+        Self {
+            tasks: JoinSet::new(),
+        }
+    }
+
+    fn reap_finished(&mut self) {
+        while self.tasks.try_join_next().is_some() {}
+    }
+
+    fn try_spawn(&mut self, future: impl Future<Output = ()> + Send + 'static) -> bool {
+        self.reap_finished();
+        if self.tasks.len() >= MAX_PENDING_CONCURRENT_IPC_COMMANDS {
+            return false;
+        }
+        self.tasks.spawn(future);
+        true
+    }
+
+    async fn cancel_all(&mut self) {
+        self.tasks.abort_all();
+        while self.tasks.join_next().await.is_some() {}
+    }
+}
 
 #[cfg(test)]
 mod tests;
@@ -90,6 +123,7 @@ where
     // connection ends so the poller exits within ~100ms instead of looping
     // forever (which would keep the engine pushing events at a dead client).
     let mut bg_cancel: Option<Arc<AtomicBool>> = None;
+    let mut concurrent_commands = ConcurrentCommandTasks::new();
     loop {
         line.clear();
         let n = reader.read_line(&mut line).await?;
@@ -138,7 +172,8 @@ where
                         if command_can_run_concurrently(&cmd) {
                             let command_handle = handle.clone();
                             let response_writer = writer.clone();
-                            tokio::spawn(async move {
+                            let rejected_id = id.clone();
+                            let spawned = concurrent_commands.try_spawn(async move {
                                 let result = execute_ipc_command(command_handle, cmd).await;
                                 if let Err(error) =
                                     write_command_result(response_writer, id, result).await
@@ -151,6 +186,16 @@ where
                                     }
                                 }
                             });
+                            if !spawned {
+                                let error = zero_api::ApiError::new(
+                                    zero_api::ApiErrorCode::Conflict,
+                                    format!(
+                                        "this IPC connection already has {MAX_PENDING_CONCURRENT_IPC_COMMANDS} pending outbound probes"
+                                    ),
+                                );
+                                write_command_result(writer.clone(), rejected_id, Err(error))
+                                    .await?;
+                            }
                         } else {
                             let result = execute_ipc_command(handle.clone(), cmd).await;
                             write_command_result(writer.clone(), id, result).await?;
@@ -277,6 +322,7 @@ where
     if let Some(handle) = bg_blocking.take() {
         handle.abort();
     }
+    concurrent_commands.cancel_all().await;
 
     Ok(())
 }
@@ -289,6 +335,14 @@ async fn execute_ipc_command(
     command_handle: ProxyHandle,
     command: CommandRequest,
 ) -> zero_api::ApiResult<zero_api::CommandResponse> {
+    let command = match command {
+        CommandRequest::DiagnosticsProbeOutbound(command) => {
+            return command_handle
+                .execute_diagnostics_probe_outbound_command(command)
+                .await;
+        }
+        command => command,
+    };
     if matches!(
         command,
         CommandRequest::ConfigApply(_) | CommandRequest::ConfigApplyRuntime(_)

--- a/src/ipc/connection.rs
+++ b/src/ipc/connection.rs
@@ -22,6 +22,9 @@ use super::protocol::{ipc_api_error, ipc_error, ipc_ok, serialize_frame, IpcRequ
 
 type CommandParseError = Box<ApiResponse<()>>;
 
+#[cfg(test)]
+mod tests;
+
 /// Parse a string method name + JSON params into a typed `CommandRequest`.
 ///
 /// Uses the same serde `#[serde(tag = "method", content = "params")]` path as
@@ -132,37 +135,25 @@ where
                         write_ipc_response(&mut *writer.lock().await, &resp).await?;
                     }
                     Ok(cmd) => {
-                        let command_handle = handle.clone();
-                        let acknowledged_apply = matches!(
-                            cmd,
-                            CommandRequest::ConfigApply(_) | CommandRequest::ConfigApplyRuntime(_)
-                        );
-                        let result = if acknowledged_apply {
-                            command_handle.execute_acknowledged(cmd).await
+                        if command_can_run_concurrently(&cmd) {
+                            let command_handle = handle.clone();
+                            let response_writer = writer.clone();
+                            tokio::spawn(async move {
+                                let result = execute_ipc_command(command_handle, cmd).await;
+                                if let Err(error) =
+                                    write_command_result(response_writer, id, result).await
+                                {
+                                    if !is_transient_disconnect(&error) {
+                                        tracing::warn!(
+                                            %error,
+                                            "failed to write concurrent IPC command response"
+                                        );
+                                    }
+                                }
+                            });
                         } else {
-                            // Some synchronous commands bridge to blocking runtime
-                            // services. Keep those off the reactor.
-                            match tokio::task::spawn_blocking(move || command_handle.execute(cmd))
-                                .await
-                            {
-                                Ok(result) => result,
-                                Err(error) => Err(zero_api::ApiError::new(
-                                    zero_api::ApiErrorCode::Internal,
-                                    format!("IPC command task failed: {error}"),
-                                )),
-                            }
-                        };
-                        match result {
-                            Ok(cmd_resp) => {
-                                let value =
-                                    serde_json::to_value(cmd_resp).map_err(io::Error::other)?;
-                                let resp = ipc_ok(id, value);
-                                write_ipc_response(&mut *writer.lock().await, &resp).await?;
-                            }
-                            Err(error) => {
-                                let resp = ipc_api_error(id, &error);
-                                write_ipc_response(&mut *writer.lock().await, &resp).await?;
-                            }
+                            let result = execute_ipc_command(handle.clone(), cmd).await;
+                            write_command_result(writer.clone(), id, result).await?;
                         }
                     }
                     Err(error) => {
@@ -288,6 +279,50 @@ where
     }
 
     Ok(())
+}
+
+fn command_can_run_concurrently(command: &CommandRequest) -> bool {
+    matches!(command, CommandRequest::DiagnosticsProbeOutbound(_))
+}
+
+async fn execute_ipc_command(
+    command_handle: ProxyHandle,
+    command: CommandRequest,
+) -> zero_api::ApiResult<zero_api::CommandResponse> {
+    if matches!(
+        command,
+        CommandRequest::ConfigApply(_) | CommandRequest::ConfigApplyRuntime(_)
+    ) {
+        return command_handle.execute_acknowledged(command).await;
+    }
+    match tokio::task::spawn_blocking(move || command_handle.execute(command)).await {
+        Ok(result) => result,
+        Err(error) => Err(zero_api::ApiError::new(
+            zero_api::ApiErrorCode::Internal,
+            format!("IPC command task failed: {error}"),
+        )),
+    }
+}
+
+async fn write_command_result<W>(
+    writer: Arc<TokioMutex<BufWriter<W>>>,
+    id: Option<serde_json::Value>,
+    result: zero_api::ApiResult<zero_api::CommandResponse>,
+) -> io::Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    match result {
+        Ok(command_response) => {
+            let value = serde_json::to_value(command_response).map_err(io::Error::other)?;
+            let response = ipc_ok(id, value);
+            write_ipc_response(&mut *writer.lock().await, &response).await
+        }
+        Err(error) => {
+            let response = ipc_api_error(id, &error);
+            write_ipc_response(&mut *writer.lock().await, &response).await
+        }
+    }
 }
 
 /// Write a serialized IPC response frame to the transport.

--- a/src/ipc/connection/tests.rs
+++ b/src/ipc/connection/tests.rs
@@ -1,5 +1,15 @@
-use super::command_can_run_concurrently;
-use zero_api::{CommandRequest, DiagnosticsProbeOutboundCommand, ModeSetCommand};
+use super::{
+    command_can_run_concurrently, write_command_result, ConcurrentCommandTasks,
+    MAX_PENDING_CONCURRENT_IPC_COMMANDS,
+};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, BufReader, BufWriter};
+use tokio::sync::{oneshot, Mutex};
+use zero_api::{
+    CommandRequest, CommandResponse, ConfigApplyCommand, DiagnosticsProbeOutboundCommand,
+    ModeSetCommand, RawResponse,
+};
 
 #[test]
 fn outbound_diagnostics_are_the_only_reordered_ipc_commands() {
@@ -9,4 +19,98 @@ fn outbound_diagnostics_are_the_only_reordered_ipc_commands() {
     assert!(!command_can_run_concurrently(&CommandRequest::ModeSet(
         ModeSetCommand::default()
     )));
+    assert!(!command_can_run_concurrently(&CommandRequest::ConfigApply(
+        ConfigApplyCommand::default()
+    )));
+    assert!(!command_can_run_concurrently(
+        &CommandRequest::ConfigApplyRuntime(ConfigApplyCommand::default())
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_commands_overlap_and_keep_response_ids_paired() {
+    let (client, server) = tokio::io::duplex(4096);
+    let (_, server_writer) = tokio::io::split(server);
+    let writer = Arc::new(Mutex::new(BufWriter::new(server_writer)));
+    let mut reader = BufReader::new(client);
+    let mut tasks = ConcurrentCommandTasks::new();
+    let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (release_first_tx, release_first_rx) = oneshot::channel();
+    let (release_second_tx, release_second_rx) = oneshot::channel();
+
+    for (id, release) in [("first", release_first_rx), ("second", release_second_rx)] {
+        let writer = writer.clone();
+        let started_tx = started_tx.clone();
+        assert!(tasks.try_spawn(async move {
+            started_tx.send(id).unwrap();
+            release.await.unwrap();
+            write_command_result(
+                writer,
+                Some(serde_json::json!(id)),
+                Ok(CommandResponse {
+                    accepted: true,
+                    result: Some(serde_json::json!({"command": id})),
+                }),
+            )
+            .await
+            .unwrap();
+        }));
+    }
+
+    let mut started = vec![
+        started_rx.recv().await.unwrap(),
+        started_rx.recv().await.unwrap(),
+    ];
+    started.sort_unstable();
+    assert_eq!(started, vec!["first", "second"]);
+
+    release_second_tx.send(()).unwrap();
+    release_first_tx.send(()).unwrap();
+
+    let mut line = String::new();
+    reader.read_line(&mut line).await.unwrap();
+    let first: RawResponse = serde_json::from_str(line.trim()).unwrap();
+    line.clear();
+    reader.read_line(&mut line).await.unwrap();
+    let second: RawResponse = serde_json::from_str(line.trim()).unwrap();
+    let responses = [first, second];
+    for response in responses {
+        let id = response
+            .id
+            .as_ref()
+            .and_then(serde_json::Value::as_str)
+            .unwrap();
+        assert_eq!(response.result.as_ref().unwrap()["result"]["command"], id);
+    }
+
+    tasks.cancel_all().await;
+}
+
+#[tokio::test]
+async fn concurrent_command_queue_is_bounded_and_cancellable() {
+    struct CancellationGuard(Arc<AtomicBool>);
+    impl Drop for CancellationGuard {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let mut tasks = ConcurrentCommandTasks::new();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let (started_tx, started_rx) = oneshot::channel();
+    let cancellation = cancelled.clone();
+    assert!(tasks.try_spawn(async move {
+        let _guard = CancellationGuard(cancellation);
+        started_tx.send(()).unwrap();
+        std::future::pending::<()>().await;
+    }));
+    started_rx.await.unwrap();
+
+    for _ in 1..MAX_PENDING_CONCURRENT_IPC_COMMANDS {
+        assert!(tasks.try_spawn(std::future::pending()));
+    }
+    assert!(!tasks.try_spawn(async {}));
+
+    tasks.cancel_all().await;
+    assert!(cancelled.load(Ordering::SeqCst));
 }

--- a/src/ipc/connection/tests.rs
+++ b/src/ipc/connection/tests.rs
@@ -1,0 +1,12 @@
+use super::command_can_run_concurrently;
+use zero_api::{CommandRequest, DiagnosticsProbeOutboundCommand, ModeSetCommand};
+
+#[test]
+fn outbound_diagnostics_are_the_only_reordered_ipc_commands() {
+    assert!(command_can_run_concurrently(
+        &CommandRequest::DiagnosticsProbeOutbound(DiagnosticsProbeOutboundCommand::default())
+    ));
+    assert!(!command_can_run_concurrently(&CommandRequest::ModeSet(
+        ModeSetCommand::default()
+    )));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,22 @@ async fn main() {
     let args: Vec<String> = env::args().collect();
     let config_path = cli::config_path_from_args(&args);
     init_tracing_from_config(config_path.unwrap_or(""));
+    install_panic_hook();
 
     if let Err(error) = try_main().await {
+        tracing::error!(error = %error, "zero process terminating with fatal error");
         error_report::print_error(error.as_ref());
         process::exit(1);
     }
+}
+
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic| {
+        tracing::error!(panic = %panic, "zero process panicked");
+        eprintln!("fatal panic: {panic}");
+        previous(panic);
+    }));
 }
 
 async fn try_main() -> Result<(), Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,13 @@ async fn main() {
     // from `runtime.log` before any other work so all logs are captured.
     let args: Vec<String> = env::args().collect();
     let config_path = cli::config_path_from_args(&args);
-    init_tracing_from_config(config_path.unwrap_or(""));
+    let tracing_guard = init_tracing_from_config(config_path.unwrap_or(""));
     install_panic_hook();
 
     if let Err(error) = try_main().await {
         tracing::error!(error = %error, "zero process terminating with fatal error");
         error_report::print_error(error.as_ref());
+        drop(tracing_guard);
         process::exit(1);
     }
 }
@@ -53,7 +54,7 @@ async fn try_main() -> Result<(), Box<dyn Error>> {
 
 /// Early-parse the configuration file to extract `runtime.log` and
 /// initialise the tracing subscriber before any meaningful work.
-fn init_tracing_from_config(config_path: &str) {
+fn init_tracing_from_config(config_path: &str) -> zero_logging::TracingGuard {
     let log_config = std::fs::read_to_string(config_path)
         .ok()
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
@@ -64,7 +65,7 @@ fn init_tracing_from_config(config_path: &str) {
             zero_config::LogConfig::default()
         });
 
-    zero_logging::init_tracing(&log_config);
+    zero_logging::init_tracing(&log_config)
 }
 
 /// Collect compiled feature flags for the capabilities endpoint.

--- a/tests/workspace_architecture.rs
+++ b/tests/workspace_architecture.rs
@@ -103,7 +103,8 @@ fn dns_owned_udp_and_dot_sockets_follow_the_shared_egress_authority() {
     assert!(udp.contains("current_for_peer"));
     assert!(!udp.contains("tokio::net::UdpSocket"));
     assert!(backends.contains("TokioSocket::connect_addr_on"));
-    assert!(backends.contains("current_for_peer"));
+    assert!(backends.contains("select_for_peer"));
+    assert!(backends.contains("ensure_connectable"));
     assert!(!backends.contains("TcpStream::connect"));
 
     let direct = [


### PR DESCRIPTION
## Summary

- size outbound diagnostic probe deadlines from the complete node-DNS fallback budget plus transport time
- allow only `diagnostics.probe_outbound` IPC commands to execute concurrently so an eight-node batch is not serialized behind one connection
- preserve ordered execution for configuration and control commands
- expose the selected physical DNS egress and prepared TUN DNS route exclusions in structured logs
- include DoH endpoint/deadline context in timeout errors
- emit structured fatal and panic diagnostics before process exit

## Validation

Per the project boundary, no local kernel build, TUN, DNS, browser, or network validation was run on this Windows workstation.

- current head: `c4113e49`
- local non-compiling gates: `cargo fmt --all --check`, `git diff --check`
- GitHub CI #437: success, including Clippy, complete Linux workspace tests, feature matrices, musl, and Windows/Linux/macOS TUN compilation
- GitHub Privileged TUN E2E #95: success on hosted Windows, Linux, and macOS, including Fake-IP/DoH, multi-A fallback, egress publication, route reconciliation, and offline dual-stack
- dedicated Windows test-machine acceptance with the user's real subscription remains required before closing #104

Refs #104
Historical context: #33