### PR TITLE
ci: scope heavy checks and fix macOS cache ownership

### DIFF
--- a/.github/actions/ci-scope/action.yml
+++ b/.github/actions/ci-scope/action.yml
@@ -1,0 +1,24 @@
+name: Select CI scope
+description: Select expensive checks from the complete Git diff, defaulting to full verification
+
+outputs:
+  code:
+    description: Run the ordinary Rust checks
+    value: ${{ steps.scope.outputs.code }}
+  compatibility:
+    description: Run the musl build and older-platform E2E harness compilation
+    value: ${{ steps.scope.outputs.compatibility }}
+  tun:
+    description: Run privileged TUN verification
+    value: ${{ steps.scope.outputs.tun }}
+
+runs:
+  using: composite
+  steps:
+    - name: Test CI scope policy
+      shell: bash
+      run: node --test .github/actions/ci-scope/scope.test.mjs
+    - name: Select checks
+      id: scope
+      shell: bash
+      run: node .github/actions/ci-scope/scope.mjs

--- a/.github/actions/ci-scope/scope.mjs
+++ b/.github/actions/ci-scope/scope.mjs
@@ -1,0 +1,82 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const fullScope = () => ({ code: true, compatibility: true, tun: true });
+const startsWithAny = (path, prefixes) => prefixes.some(prefix => path.startsWith(prefix));
+
+export function selectScope(paths) {
+  // Only known documentation is cheap. Examples and proto files can be compiled
+  // or consumed by tests, so they must not bypass the ordinary Rust checks.
+  const relevant = paths.filter(path => !(
+    path.endsWith('.md') || path === 'LICENSE' || path.startsWith('docs/')
+  ));
+  if (relevant.length === 0) {
+    return { code: false, compatibility: false, tun: false };
+  }
+
+  const buildChanged = relevant.some(path =>
+    /(^|\/)(Cargo\.(toml|lock)|build\.rs|Cross\.toml|rust-toolchain(\.toml)?)$/.test(path)
+    || startsWithAny(path, ['.cargo/', '.github/', 'scripts/'])
+  );
+  // Keep native/crypto/transport changes on the compatibility gate. Ordinary
+  // domain logic is tested on Linux; main and manual runs always check all OSes.
+  const compatibility = buildChanged || relevant.some(path => startsWithAny(path, [
+    'src/', 'protocols/', 'crates/platform/', 'crates/tun/',
+    'crates/transport/', 'crates/ztls/',
+  ]));
+  // Deliberately include all production crates: changes to config, routing,
+  // shared traits or protocol dispatch can affect TUN without editing tun/.
+  const tun = buildChanged || relevant.some(path =>
+    startsWithAny(path, ['src/', 'crates/', 'protocols/', 'proto/', 'tests/tun'])
+  );
+  return { code: true, compatibility, tun };
+}
+
+export function scopeForEvent(eventName, event, git) {
+  // RC/main candidates and explicit manual qualification must never be filtered.
+  if (eventName === 'workflow_dispatch' || event.ref === 'refs/heads/main'
+      || event.pull_request?.base?.ref === 'main') {
+    return fullScope();
+  }
+
+  try {
+    let base;
+    let head;
+    if (eventName === 'pull_request') {
+      base = event.pull_request?.base?.sha;
+      head = event.pull_request?.head?.sha;
+    } else if (eventName === 'push') {
+      base = event.before;
+      head = event.after;
+    }
+    const validSha = value => typeof value === 'string'
+      && /^[a-f0-9]{40}$/.test(value) && !/^0+$/.test(value);
+    if (!validSha(base) || !validSha(head)) return fullScope();
+    if (eventName === 'pull_request') {
+      base = git(['merge-base', base, head]).trim();
+      if (!validSha(base)) return fullScope();
+    }
+    // --no-renames includes both sides of moves; -z preserves unusual filenames.
+    // Local Git avoids the API's changed-file pagination/truncation limits.
+    const paths = git(['diff', '--name-only', '--no-renames', '-z', base, head, '--'])
+      .split('\0').filter(Boolean);
+    return selectScope(paths);
+  } catch {
+    // Force pushes and missing history must run more checks, never skip them.
+    console.warn('Changed-file detection failed; running the full CI scope.');
+    return fullScope();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+  const scope = scopeForEvent(process.env.GITHUB_EVENT_NAME, event, args =>
+    execFileSync('git', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 })
+  );
+  for (const [name, enabled] of Object.entries(scope)) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${enabled}\n`);
+  }
+  console.log(JSON.stringify(scope));
+}

--- a/.github/actions/ci-scope/scope.test.mjs
+++ b/.github/actions/ci-scope/scope.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { scopeForEvent, selectScope } from './scope.mjs';
+
+const full = { code: true, compatibility: true, tun: true };
+const cheap = { code: false, compatibility: false, tun: false };
+const base = 'a'.repeat(40);
+const head = 'b'.repeat(40);
+
+test('documentation-only changes skip Rust jobs', () => {
+  assert.deepEqual(selectScope(['README.md', 'docs/project/tooling.md', 'LICENSE']), cheap);
+});
+
+test('every production crate and protocol retains TUN coverage', () => {
+  for (const path of [
+    'crates/tun/src/route.rs', 'crates/config/src/lib.rs',
+    'crates/proxy/src/runtime/tcp_dispatch.rs', 'crates/platform/tokio/src/egress.rs',
+    'crates/engine/src/runtime.rs', 'crates/traits/src/lib.rs',
+    'protocols/vless/src/lib.rs', 'src/application/tun.rs',
+  ]) assert.equal(selectScope([path]).tun, true, path);
+});
+
+test('domain changes retain ordinary tests without an unrelated compatibility build', () => {
+  assert.deepEqual(selectScope(['crates/router/src/lib.rs']), {
+    code: true, compatibility: false, tun: true,
+  });
+});
+
+test('build, dependency, workflow and native changes require full coverage', () => {
+  for (const path of [
+    'Cargo.toml', 'Cargo.lock', 'crates/dns/Cargo.toml', 'protocols/http/build.rs',
+    'Cross.toml', 'rust-toolchain.toml', '.cargo/config.toml',
+    '.github/workflows/ci.yml', '.github/actions/ci-scope/scope.mjs',
+    'scripts/prepare-wintun.ps1', 'crates/platform/tokio/src/lib.rs',
+    'crates/transport/src/tls.rs', 'crates/ztls/src/lib.rs',
+  ]) assert.deepEqual(selectScope([path]), full, path);
+});
+
+test('TUN test edits keep the privileged gate', () => {
+  for (const path of ['tests/tun_privileged_e2e.rs', 'tests/tun_route_reconcile_macos_e2e.rs']) {
+    assert.deepEqual(selectScope([path]), { code: true, compatibility: false, tun: true });
+  }
+});
+
+test('examples and proto edits cannot bypass ordinary Rust tests', () => {
+  assert.equal(selectScope(['examples/client.json']).code, true);
+  assert.equal(selectScope(['proto/zero.proto']).code, true);
+  assert.equal(selectScope(['proto/zero.proto']).tun, true);
+});
+
+test('ordinary test-only changes do not start privileged or compatibility jobs', () => {
+  assert.deepEqual(selectScope(['tests/status.rs']), {
+    code: true, compatibility: false, tun: false,
+  });
+});
+
+test('manual and main qualification always run everything', () => {
+  const noGit = () => assert.fail('full qualification must not depend on a diff');
+  assert.deepEqual(scopeForEvent('workflow_dispatch', {}, noGit), full);
+  assert.deepEqual(scopeForEvent('push', { ref: 'refs/heads/main' }, noGit), full);
+  assert.deepEqual(scopeForEvent('pull_request', { pull_request: { base: { ref: 'main' } } }, noGit), full);
+});
+
+test('push uses the entire before/after diff including old paths of renamed files', () => {
+  const calls = [];
+  const scope = scopeForEvent('push', { before: base, after: head }, args => {
+    calls.push(args);
+    return 'crates/tun/src/old.rs\0docs/old.md\0';
+  });
+  assert.deepEqual(calls, [['diff', '--name-only', '--no-renames', '-z', base, head, '--']]);
+  assert.deepEqual(scope, full);
+});
+
+test('PRs compare from the merge base, not unrelated base branch changes', () => {
+  let calls = 0;
+  const scope = scopeForEvent('pull_request', {
+    pull_request: { base: { sha: base, ref: 'develop' }, head: { sha: head } },
+  }, args => {
+    calls += 1;
+    if (calls === 1) {
+      assert.deepEqual(args, ['merge-base', base, head]);
+      return `${'c'.repeat(40)}\n`;
+    }
+    assert.equal(args[4], 'c'.repeat(40));
+    return 'README.md\0';
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(scope, cheap);
+});
+
+test('missing history, new branches and unknown events fail open to full verification', () => {
+  const missing = () => { throw new Error('missing revision'); };
+  assert.deepEqual(scopeForEvent('push', { before: base, after: head }, missing), full);
+  assert.deepEqual(scopeForEvent('push', { before: '0'.repeat(40), after: head }, missing), full);
+  assert.deepEqual(scopeForEvent('unknown', {}, missing), full);
+});
+
+test('large diffs and unusual filenames do not lose relevant paths', () => {
+  const files = Array.from({ length: 3500 }, (_, i) => `docs/${i}.md`);
+  files.push('crates/tun/src/file with spaces.rs');
+  assert.deepEqual(scopeForEvent('push', { before: base, after: head }, () => files.join('\0')), full);
+});
+
+test('workflow contracts preserve coverage and avoid root-owned build artifacts', () => {
+  const ci = readFileSync('.github/workflows/ci.yml', 'utf8');
+  const tun = readFileSync('.github/workflows/tun-e2e.yml', 'utf8');
+  for (const workflow of [ci, tun]) {
+    assert.doesNotMatch(workflow, /^\s+paths(-ignore)?:/m);
+    assert.match(workflow, /fetch-depth: 0/);
+    assert.match(workflow, /if: always\(\)/);
+  }
+  assert.match(ci, /cargo test --workspace --all-features/);
+  assert.match(ci, /cargo clippy --workspace --all-targets --all-features/);
+  assert.doesNotMatch(ci, /cargo check --workspace --all-features/);
+  assert.doesNotMatch(ci, /cargo test -p zero-proxy --test runtime_boundary/);
+  assert.match(ci, /if: needs.scope.outputs.compatibility == 'true'\s+run: cargo test --test tun_privileged_e2e --no-run/);
+  assert.doesNotMatch(tun, /sudo[^\n]*cargo test/);
+  assert.match(tun, /CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo/);
+  assert.equal(tun.match(/cache-on-failure: true/g)?.length, 3);
+  assert.match(tun, /cargo test --target x86_64-apple-darwin/);
+  assert.match(tun, /privileged_windows_ipv4_only_tun_falls_back_trusted_ipv6_domains/);
+  assert.doesNotMatch(tun, /if: github\.event_name != 'pull_request'\r?\n/);
+  assert.doesNotMatch(tun, /continue-on-error:/);
+});
+
+test('both result gates propagate failures and cancellations but accept intentional skips', () => {
+  for (const file of ['ci.yml', 'tun-e2e.yml']) {
+    const workflow = readFileSync(`.github/workflows/${file}`, 'utf8');
+    const script = workflow.match(/node -e '([^']+)'/)[1];
+    for (const [result, exitCode] of [
+      ['success', 0], ['skipped', 0], ['failure', 1], ['cancelled', 1],
+    ]) {
+      const child = spawnSync(process.execPath, ['-e', script], {
+        env: {
+          ...process.env,
+          CHECK_RESULTS: JSON.stringify({ scope: { result: 'success' }, selected: { result } }),
+        },
+        encoding: 'utf8',
+      });
+      assert.equal(child.status, exitCode, `${file}: ${result}: ${child.stderr}`);
+    }
+  }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,28 +3,37 @@ name: CI
 on:
   push:
     branches: [develop, main]
-    paths-ignore:
-      - "**.md"
-      - "LICENSE"
-      - "docs/**"
-      - "examples/**"
-      - "proto/**"
   pull_request:
     branches: [develop, main, "fix/**", "feat/**"]
-    paths-ignore:
-      - "**.md"
-      - "LICENSE"
-      - "docs/**"
-      - "examples/**"
-      - "proto/**"
+  # Run explicitly on the candidate ref for complete RC qualification.
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  scope:
+    name: Select CI checks
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.scope.outputs.code }}
+      compatibility: ${{ steps.scope.outputs.compatibility }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - id: scope
+        uses: ./.github/actions/ci-scope
+
   static:
     name: Static checks (fmt + clippy)
+    needs: scope
+    if: needs.scope.outputs.code == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -54,7 +63,8 @@ jobs:
     name: Check & Test (Linux)
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    needs: static
+    needs: [scope, static]
+    if: needs.scope.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v5
 
@@ -70,22 +80,19 @@ jobs:
       - name: Verify protoc
         run: protoc --version
 
-      - name: Check (all features)
-        run: cargo check --workspace --all-features
-
+      # Clippy already type-checks every target. The workspace suite also runs
+      # zero-proxy's runtime_boundary integration test; do not compile it twice.
       - name: Test (workspace, including connector webhook delivery)
         env:
           RUST_MIN_STACK: "16777216"
         run: cargo test --workspace --all-features
 
-      - name: Architecture boundary tests
-        run: cargo test -p zero-proxy --test runtime_boundary --all-features
-
   tun-platform-check:
     name: TUN platform check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    needs: static
+    needs: [scope, static]
+    if: needs.scope.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -101,13 +108,17 @@ jobs:
         run: cargo check -p zero-tun -p zero-platform-tokio
 
       - name: Compile privileged TUN E2E harness
+        # Daily platform checks cover the native backends. The privileged jobs
+        # compile/run this harness; keep older-OS compilation for compatibility.
+        if: needs.scope.outputs.compatibility == 'true'
         run: cargo test --test tun_privileged_e2e --no-run
 
   linux-musl-compat:
     name: Build Linux musl compatibility artifact
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    needs: static
+    needs: [scope, static]
+    if: needs.scope.outputs.compatibility == 'true'
     steps:
       - uses: actions/checkout@v5
 
@@ -150,7 +161,8 @@ jobs:
     name: Proxy feature compatibility
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    needs: static
+    needs: [scope, static]
+    if: needs.scope.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v5
 
@@ -194,7 +206,8 @@ jobs:
     name: Optional surface compatibility
     runs-on: ubuntu-22.04
     timeout-minutes: 45
-    needs: static
+    needs: [scope, static]
+    if: needs.scope.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v5
 
@@ -221,3 +234,16 @@ jobs:
 
       - name: Check optional surface (grpc-api)
         run: cargo check --no-default-features --features grpc-api
+
+  result:
+    name: CI result
+    if: always()
+    needs: [scope, static, check-and-test, tun-platform-check, linux-musl-compat, proxy-feature-compat, optional-surface-compat]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Require successful selected checks
+        env:
+          CHECK_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          node -e 'const checks = JSON.parse(process.env.CHECK_RESULTS); for (const [name, check] of Object.entries(checks)) { console.log(`${name}: ${check.result}`); if (!["success", "skipped"].includes(check.result)) process.exitCode = 1; }'

--- a/.github/workflows/tun-e2e.yml
+++ b/.github/workflows/tun-e2e.yml
@@ -4,20 +4,11 @@ on:
   push:
     branches:
       - develop
+      - main
   pull_request:
     branches:
       - develop
-    paths:
-      - ".github/workflows/tun-e2e.yml"
-      - "tests/tun_privileged_e2e.rs"
-      - "tests/tun_route_reconcile*_e2e.rs"
-      - "crates/tun/**"
-      - "crates/stack/**"
-      - "crates/dns/**"
-      - "crates/proxy/src/inbound/tun/**"
-      - "crates/proxy/src/runtime/udp_socket.rs"
-      - "crates/proxy/src/runtime/udp_socket/**"
-      - "crates/platform/tokio/src/egress.rs"
+      - main
   workflow_dispatch:
     inputs:
       target:
@@ -31,6 +22,9 @@ on:
           - hosted-macos
           - hosted-windows
 
+permissions:
+  contents: read
+
 concurrency:
   group: tun-e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -39,14 +33,30 @@ concurrency:
 # The matrix uses deterministic local peers for dual-stack and fallback behavior
 # so it does not depend on a runner having public native IPv6 connectivity.
 jobs:
+  scope:
+    name: Select TUN checks
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      tun: ${{ steps.scope.outputs.tun }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - id: scope
+        uses: ./.github/actions/ci-scope
+
   hosted-linux:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || inputs.target == 'hosted-all' || inputs.target == 'hosted-linux'
+    needs: scope
+    if: needs.scope.outputs.tun == 'true' && (github.event_name != 'workflow_dispatch' || inputs.target == 'hosted-all' || inputs.target == 'hosted-linux')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install build prerequisites
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler iproute2 nftables
       - name: Run zero-tun tests
@@ -56,7 +66,7 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
         run: cargo test --target x86_64-unknown-linux-gnu --test tun_route_reconcile_linux_e2e linux_reconciles_runtime_egress_and_dns_exclusion_inside_network_namespace -- --ignored --exact --nocapture
       - name: Run privileged TUN smoke test
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || github.base_ref == 'main'
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: sudo
         run: cargo test --target x86_64-unknown-linux-gnu --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
@@ -78,13 +88,16 @@ jobs:
         run: cargo test --target x86_64-unknown-linux-gnu --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
 
   hosted-macos:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || inputs.target == 'hosted-all' || inputs.target == 'hosted-macos'
+    needs: scope
+    if: needs.scope.outputs.tun == 'true' && (github.event_name != 'workflow_dispatch' || inputs.target == 'hosted-all' || inputs.target == 'hosted-macos')
     runs-on: macos-15-intel
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Record native network topology
         run: |
           sw_vers
@@ -92,32 +105,49 @@ jobs:
           ifconfig
           route -n get -inet default
       - name: Run zero-tun tests
-        run: cargo test -p zero-tun
+        run: cargo test --target x86_64-apple-darwin -p zero-tun
       - name: Run native PF_ROUTE lifecycle E2E
-        run: sudo env "PATH=$PATH" cargo test -p zero-tun --test route_monitor_macos_e2e macos_route_monitor_observes_repeated_route_changes_and_releases_cleanly -- --ignored --exact --nocapture
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin -p zero-tun --test route_monitor_macos_e2e macos_route_monitor_observes_repeated_route_changes_and_releases_cleanly -- --ignored --exact --nocapture
       - name: Run privileged TUN smoke test
-        if: github.event_name != 'pull_request'
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
+        if: github.event_name != 'pull_request' || github.base_ref == 'main'
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
       - name: Run macOS loopback capture and crash-recovery E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_macos_tun_loopback_remains_reachable_across_crash_recovery -- --ignored --exact --nocapture
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin --test tun_privileged_e2e privileged_macos_tun_loopback_remains_reachable_across_crash_recovery -- --ignored --exact --nocapture
       - name: Run direct UDP self-capture E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run Fake-IP DoH underlay E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin --test tun_privileged_e2e privileged_tun_ipv4_fake_ip_doh_direct_domain_does_not_self_capture -- --ignored --exact --nocapture
       - name: Run command-managed egress publication E2E
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_command_managed_tun_publishes_egress_before_capture -- --ignored --exact --nocapture
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin --test tun_privileged_e2e privileged_command_managed_tun_publishes_egress_before_capture -- --ignored --exact --nocapture
       - name: Run offline dual-stack privileged TUN E2E
-        if: github.event_name != 'pull_request'
-        run: sudo env "PATH=$PATH" cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
+        if: github.event_name != 'pull_request' || github.base_ref == 'main'
+        env:
+          CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER: sudo
+        run: cargo test --target x86_64-apple-darwin --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
 
   hosted-windows:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || inputs.target == 'hosted-all' || inputs.target == 'hosted-windows'
+    needs: scope
+    if: needs.scope.outputs.tun == 'true' && (github.event_name != 'workflow_dispatch' || inputs.target == 'hosted-all' || inputs.target == 'hosted-windows')
     runs-on: windows-2025
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install protoc
         uses: ./.github/actions/setup-protoc
         with:
@@ -132,7 +162,7 @@ jobs:
       - name: Run privileged Wintun address configuration E2E
         run: cargo test -p zero-tun --test privileged_configuration windows_configures_ipv4_and_ipv6_addresses_on_one_adapter -- --ignored --exact --nocapture
       - name: Run privileged TUN smoke test
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' || github.base_ref == 'main'
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_smoke_tcp_dns_and_crash_recovery -- --ignored --exact --nocapture
       - name: Run direct UDP self-capture E2E
         run: cargo test --test tun_privileged_e2e privileged_tun_ipv4_direct_udp_dns_does_not_self_capture -- --ignored --exact --nocapture
@@ -148,3 +178,16 @@ jobs:
         run: cargo test --test tun_privileged_e2e privileged_windows_ipv4_only_tun_falls_back_trusted_ipv6_domains -- --ignored --exact --nocapture
       - name: Run offline dual-stack privileged TUN E2E
         run: cargo test --test tun_privileged_e2e privileged_tun_dual_stack_configuration_traffic_and_crash_recovery -- --ignored --exact --nocapture
+
+  result:
+    name: TUN E2E result
+    if: always()
+    needs: [scope, hosted-linux, hosted-macos, hosted-windows]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Require successful selected checks
+        env:
+          CHECK_RESULTS: ${{ toJSON(needs) }}
+        run: |
+          node -e 'const checks = JSON.parse(process.env.CHECK_RESULTS); for (const [name, check] of Object.entries(checks)) { console.log(`${name}: ${check.result}`); if (!["success", "skipped"].includes(check.result)) process.exitCode = 1; }'

--- a/docs/project/tooling.md
+++ b/docs/project/tooling.md
@@ -40,6 +40,44 @@ cargo test <test_name>
 
 公开文档站由 `zerodenet/docs` 仓库独立构建和部署。本仓库只维护工程资料；公开文档变更应提交到该仓库并运行其 `pnpm check:build`。
 
+## CI 分层
+
+`CI` 与 `Privileged TUN E2E` 使用 `.github/actions/ci-scope` 读取完整 Git 差异，
+在 job 层决定执行范围，而不是用 workflow 路径过滤留下 Pending 检查。
+PR 比较 merge base 到 head，push 比较 before 到 after；历史缺失、首次推送或未知事件
+保守执行全量检查。范围规则可通过 `node --test .github/actions/ci-scope/scope.test.mjs` 验证。
+
+| 场景 | 验证范围 |
+|---|---|
+| 仅 Markdown、`docs/` 或 LICENSE 变化 | 运行轻量范围自测与汇总，不启动 Rust 构建 |
+| 普通代码或测试变化 | fmt、全目标全 feature Clippy、全 workspace 测试、三平台原生后端 check、独立 feature 组合检查 |
+| 构建依赖、原生平台、协议或 transport 变化 | 额外构建 musl 静态制品、编译较旧平台上的 TUN E2E harness |
+| `src/`、`crates/`、`protocols/`、`proto/`、TUN 测试或构建设施变化 | 运行 Linux、macOS、Windows 特权 TUN 回归；不限于直接修改 `tun/` 的变更 |
+| 目标为 `main` 的 PR、`main` push、手动运行 | 不按文件过滤，执行完整候选验证 |
+
+`examples/` 和 `proto/` 可能被编译或测试消费，不属于纯文档豁免。构建设施包括任意
+`Cargo.toml` / `Cargo.lock` / `build.rs`、工具链配置、`.cargo/`、`.github/` 和 `scripts/`。
+兼容性检查另外覆盖 `src/`、`protocols/`、`crates/{platform,tun,transport,ztls}/`。
+日常三平台原生后端检查使用 Ubuntu 22.04、macOS 14、Windows 2022；完整 TUN 运行使用
+Ubuntu 24.04、macOS 15 Intel、Windows 2025。两组系统版本的兼容性覆盖不视为完全重复。
+
+全 workspace 测试已经包含 `zero-proxy` 的 `runtime_boundary`，不单独重复编译运行；
+Clippy 已执行全目标类型检查，不再叠加同范围的 `cargo check --workspace --all-features`。
+最小 feature 组合检查仍保留，以发现 all-features 下被掩盖的条件编译错误。
+
+macOS 特权测试由普通用户运行 Cargo 编译，通过
+`CARGO_TARGET_X86_64_APPLE_DARWIN_RUNNER=sudo` 仅提升测试可执行程序的权限。
+不得恢复 `sudo cargo test`，以免产生 root 所有的构建缓存，导致缓存上传失败。
+三平台 TUN 任务在测试失败时也保存依赖缓存，但任务本身仍返回失败，不将缓存策略当作重试或豁免。
+
+汇总检查名为 `CI result` 和 `TUN E2E result`，选中的任务失败或取消时汇总失败；
+无关改动正常返回跳过结果。配置分支保护时可要求这两个汇总检查，不要要求可能不触发的
+路径过滤工作流。工作流修改本身不会自动修改仓库分支保护设置。
+
+封板时在候选 ref 上手动运行 `CI`，并运行 `Privileged TUN E2E` 的 `hosted-all`。
+单平台手动入口只用于定向验证，不代表完整候选通过。本轮分层不新增夜间定时任务，
+也不削弱 TUN 断言、增加失败重试或修改发布流程。
+
 ## 版本与发布
 
 完整的版本格式、状态转换、分支来源、Release PR、标签创建和失败处理规则见[版本演化与发布流程](./release-process.md)。该流程属于 Core 仓库内部工程规范，不需要同步到外部文档仓库。


### PR DESCRIPTION
## Summary

- Remove the redundant workspace `cargo check` after all-target/all-feature Clippy and the duplicate `runtime_boundary` run already included in workspace tests.
- Select expensive compatibility and privileged TUN jobs from complete Git diffs. Documentation-only changes skip Rust builds; ordinary test-only changes skip unrelated heavy jobs. Production crates retain three-platform TUN coverage. Build/native/transport changes retain musl and older-platform harness compilation.
- Keep full verification for main candidates and manual runs. Add always-running result gates; missing history falls back to full verification, and selected job failures/cancellations still fail the gate.
- Compile macOS tests as the runner user and use Cargo's target runner to elevate only test execution. The previous `sudo cargo test` produced root-owned incremental artifacts and cache-upload permission failures. Preserve dependency caches on failed TUN runs without masking failures.
- Document the CI tiers and add 14 policy/workflow-contract tests.

## Validation

- [x] `node --test .github/actions/ci-scope/scope.test.mjs` — 14 tests passed
- [x] actionlint 1.7.12 for both changed workflows (`-shellcheck= -pyflakes=`)
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [ ] Hosted CI / three-platform privileged TUN verification
- [ ] Confirm successful macOS cache upload and measure actual runtime improvement

No Rust runtime or TUN assertions are changed. The suspected Windows fallback-response race from [run 33624927487](https://github.com/zerodenet/core/actions/runs/33624927487/job/100230321465) remains a separate investigation; this PR neither fixes nor suppresses it. No nightly schedules or repository branch-protection settings are changed.