### PR TITLE
fix(tun): preserve Windows DHCP acquisition under strict routing

### DIFF
--- a/crates/tun/src/route/leak/windows.rs
+++ b/crates/tun/src/route/leak/windows.rs
@@ -36,6 +36,8 @@ use super::{
 };
 use crate::route::journal::route_state_root;
 
+mod dhcp;
+
 const ALLOW_WEIGHT: u64 = u64::MAX;
 const BLOCK_WEIGHT: u64 = 1;
 const SUBLAYER_WEIGHT: u16 = 0x7fff;
@@ -184,6 +186,7 @@ fn install_policy(
         display_name,
         &mut tun_luid,
     )?;
+    dhcp::add_permits(engine.handle, sublayer_key, recovery_key, display_name)?;
     add_remote_filter(
         engine.handle,
         sublayer_key,
@@ -549,6 +552,8 @@ fn expected_filter_keys(recovery_key: &str, protected: &[IpNet], excluded: &[IpA
         "tun-v6",
         "loopback-v4",
         "loopback-v6",
+        "dhcp-v4",
+        "dhcp-v6",
     ]
     .into_iter()
     .map(|scope| stable_guid(recovery_key, scope))

--- a/crates/tun/src/route/leak/windows/dhcp.rs
+++ b/crates/tun/src/route/leak/windows/dhcp.rs
@@ -1,0 +1,68 @@
+//! Physical interfaces must be able to acquire and renew an address while
+//! strict routing is active. These permits are independent of the current
+//! gateway/DNS exclusions: a new interface has neither until DHCP completes.
+
+use super::*;
+use windows_sys::Win32::NetworkManagement::WindowsFilteringPlatform::{
+    FWPM_CONDITION_IP_LOCAL_PORT, FWPM_CONDITION_IP_PROTOCOL, FWPM_CONDITION_IP_REMOTE_PORT,
+    FWP_UINT16, FWP_UINT8,
+};
+
+const DHCP_PORTS: [(GUID, &str, u16, u16); 2] = [
+    (FWPM_LAYER_ALE_AUTH_CONNECT_V4, "dhcp-v4", 68, 67),
+    (FWPM_LAYER_ALE_AUTH_CONNECT_V6, "dhcp-v6", 546, 547),
+];
+
+pub(super) fn add_permits(
+    engine: HANDLE,
+    sublayer_key: GUID,
+    recovery_key: &str,
+    display_name: &str,
+) -> io::Result<()> {
+    for (layer, scope, local_port, remote_port) in DHCP_PORTS {
+        let mut conditions = conditions(local_port, remote_port);
+        add_filter(
+            engine,
+            FilterSpec {
+                key: stable_guid(recovery_key, scope),
+                layer,
+                sublayer_key,
+                display_name,
+                weight: ALLOW_WEIGHT,
+                action: FWP_ACTION_PERMIT,
+            },
+            &mut conditions,
+        )?;
+    }
+    Ok(())
+}
+
+fn conditions(local_port: u16, remote_port: u16) -> [FWPM_FILTER_CONDITION0; 3] {
+    [
+        FWPM_FILTER_CONDITION0 {
+            fieldKey: FWPM_CONDITION_IP_PROTOCOL,
+            matchType: FWP_MATCH_EQUAL,
+            conditionValue: FWP_CONDITION_VALUE0 {
+                r#type: FWP_UINT8,
+                Anonymous: FWP_CONDITION_VALUE0_0 { uint8: 17 },
+            },
+        },
+        port_condition(FWPM_CONDITION_IP_LOCAL_PORT, local_port),
+        port_condition(FWPM_CONDITION_IP_REMOTE_PORT, remote_port),
+    ]
+}
+
+fn port_condition(field: GUID, port: u16) -> FWPM_FILTER_CONDITION0 {
+    FWPM_FILTER_CONDITION0 {
+        fieldKey: field,
+        matchType: FWP_MATCH_EQUAL,
+        conditionValue: FWP_CONDITION_VALUE0 {
+            r#type: FWP_UINT16,
+            Anonymous: FWP_CONDITION_VALUE0_0 { uint16: port },
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/dhcp.rs"]
+mod tests;

--- a/crates/tun/src/route/leak/windows/tests/dhcp.rs
+++ b/crates/tun/src/route/leak/windows/tests/dhcp.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+// Evaluate the actual WFP condition array, including field keys and value
+// types, so reversed ports or an accidentally removed constraint fail tests.
+fn permits(conditions: &[FWPM_FILTER_CONDITION0], protocol: u8, local: u16, remote: u16) -> bool {
+    conditions.iter().all(|condition| {
+        assert_eq!(condition.matchType, FWP_MATCH_EQUAL);
+        if guid_eq(&condition.fieldKey, &FWPM_CONDITION_IP_PROTOCOL) {
+            assert_eq!(condition.conditionValue.r#type, FWP_UINT8);
+            unsafe { condition.conditionValue.Anonymous.uint8 == protocol }
+        } else {
+            assert_eq!(condition.conditionValue.r#type, FWP_UINT16);
+            let port = unsafe { condition.conditionValue.Anonymous.uint16 };
+            if guid_eq(&condition.fieldKey, &FWPM_CONDITION_IP_LOCAL_PORT) {
+                port == local
+            } else {
+                assert!(guid_eq(&condition.fieldKey, &FWPM_CONDITION_IP_REMOTE_PORT));
+                port == remote
+            }
+        }
+    })
+}
+
+#[test]
+fn dhcp_permits_only_client_udp_port_pairs() {
+    for (_, _, local, remote) in DHCP_PORTS {
+        let rules = conditions(local, remote);
+        assert!(permits(&rules, 17, local, remote));
+        assert!(!permits(&rules, 6, local, remote), "TCP must stay blocked");
+        assert!(!permits(&rules, 17, local + 1, remote));
+        assert!(!permits(&rules, 17, local, remote + 1));
+        assert!(
+            !permits(&rules, 17, remote, local),
+            "server traffic is not a client exception"
+        );
+        assert!(
+            !permits(&rules, 17, 8235, 8235),
+            "ordinary LAN broadcasts stay blocked"
+        );
+        assert!(
+            !permits(&rules, 17, local, 53),
+            "DNS is not a DHCP exception"
+        );
+    }
+}
+
+#[test]
+fn dhcp_permits_cover_both_families_before_an_egress_exists() {
+    assert!(guid_eq(&DHCP_PORTS[0].0, &FWPM_LAYER_ALE_AUTH_CONNECT_V4));
+    assert!(guid_eq(&DHCP_PORTS[1].0, &FWPM_LAYER_ALE_AUTH_CONNECT_V6));
+    let keys = expected_filter_keys("tun", &[], &[]);
+    for (_, scope, _, _) in DHCP_PORTS {
+        let key = stable_guid("tun", scope);
+        assert!(keys.iter().any(|candidate| guid_eq(candidate, &key)));
+    }
+    assert_eq!(
+        keys.len(),
+        8,
+        "reconciliation must detect old policies without DHCP permits"
+    );
+}

--- a/docs/project/windows-tun-dhcp-recovery.md
+++ b/docs/project/windows-tun-dhcp-recovery.md
@@ -1,0 +1,28 @@
+# Windows strict routing and DHCP recovery
+
+The Windows strict-route WFP policy permits outbound DHCPv4 UDP 68 -> 67
+and DHCPv6 UDP 546 -> 547. Both local and remote ports and the UDP protocol
+must match. The exception covers initial broadcast/multicast discovery and
+unicast lease renewal, including a newly connected physical adapter whose
+gateway and DNS servers are not known yet. It does not permit arbitrary LAN
+broadcasts, DNS, TCP, or DHCP server traffic.
+
+These two rules are installed in the existing Zero-owned WFP transaction and
+included in the expected filter inventory. Reconciliation repairs older
+policies missing them; normal cleanup removes them along with all other
+Zero-owned filters. No Windows Firewall profile or third-party filter changes
+are needed. The policy only filters outbound authorization, so it does not
+introduce an inbound exception.
+
+The triggering Windows report showed repeated Ethernet DHCP failures while
+TUN was active and Internet detection recovering seconds after TUN stopped.
+A WFP capture confirmed Zero blocked an ordinary LAN broadcast. It did not
+retain the original DHCP packet's filter ID: the capture is supporting
+evidence, not proof that every historical DHCP failure had the same cause.
+
+Regression coverage checks the generated WFP conditions, rejection of
+non-DHCP traffic, address-family binding, and inventory migration. Hosted
+Windows zero-tun tests and privileged TUN jobs validate the change without
+replacing the user's running binary. Final target-machine acceptance should
+capture DHCP acquisition/renewal with TUN active during Wi-Fi/Ethernet
+transitions, followed by normal proxy traffic and strict-route blocking checks.


### PR DESCRIPTION
Windows strict routing blocks physical-interface DHCP before a newly connected adapter can learn its gateway/DNS exclusions. This can leave Ethernet unidentified after Wi-Fi disconnects while TUN remains active.

This change adds outbound WFP permits for DHCPv4 UDP 68 → 67 and DHCPv6 UDP 546 → 547, matching both ports and the protocol. Discovery and unicast renewal work without broad LAN exceptions. The filters use the existing owned transaction/cleanup and expected inventory, so reconciliation repairs policies installed without DHCP permits.

Regression tests inspect the generated WFP conditions, reject TCP, reversed server ports, ordinary broadcasts and DNS, and cover both address families plus inventory migration.

Validation: `cargo fmt --all --check` and `git diff --check` passed locally. Rust tests run in the existing hosted Windows/privileged TUN CI; local compilation is avoided because this machine has a known memory/page-file limit. Live Wi-Fi/Ethernet DHCP acquisition and renewal with the candidate binary remain a target-machine acceptance gate.

The triggering logs showed repeated DHCP failures and recovery shortly after TUN stopped. WFP captured a Zero-blocked ordinary LAN broadcast, but did not retain the original DHCP packet/filter pair; historical causality is therefore not claimed as packet-level proof. Companion client PR https://github.com/zerodenet/znet-sink/pull/40 fixes unknown TUN state being displayed as OFF and unreported restoration failures. No running client/Core binaries or machine network settings were changed.